### PR TITLE
Add Gemini provider, custom URLs, local providers, and extra headers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ OBJS = src/pgedge_vectorizer.o \
        src/hybrid_chunking.o \
        src/tokenizer.o \
        src/provider.o \
+       src/provider_common.o \
        src/provider_openai.o \
        src/provider_voyage.o \
        src/provider_ollama.o \

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ OBJS = src/pgedge_vectorizer.o \
        src/provider_openai.o \
        src/provider_voyage.o \
        src/provider_ollama.o \
+       src/provider_gemini.o \
        src/worker.o \
        src/queue.o \
        src/embed.o

--- a/TODO.md
+++ b/TODO.md
@@ -4,14 +4,3 @@
 to be assessed as part of the initial work, and inclusion here does not 
 represent a roadmap or any guarantee that any features will actually be
 implemented.
-
-## LLM Support
-
-- Add support for custom base URLs for LLM providers.
-- Add support for use of Google Gemini as the LLM provider.
-- Add support for use of OpenAI API-compatible local LLM providers, such as
-    LM Studio, Docker Model Runner, and EXO. These should just work if 
-    configured as OpenAI, but without a requirement for an API key.
-- Add support for arbitrary request headers to be added to LLM request calls
-    to support servers such as Portkey which requires addition of headers such
-    as `x-portkey-provider: openai`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -8,10 +8,11 @@ These settings configure the connection to your embedding provider, including th
 
 | Parameter | Default | Description | Reload | Restart | Superuser |
 |-----------|---------|-------------|--------|---------|-----------|
-| `pgedge_vectorizer.provider` | `openai` | Embedding provider (openai, voyage, ollama) | No | No | No |
-| `pgedge_vectorizer.api_key_file` | `~/.pgedge-vectorizer-llm-api-key` | API key file path (not needed for Ollama) | No | No | No |
-| `pgedge_vectorizer.api_url` | `https://api.openai.com/v1` | API endpoint | No | No | No |
+| `pgedge_vectorizer.provider` | `openai` | Embedding provider (openai, voyage, ollama, gemini) | No | No | No |
+| `pgedge_vectorizer.api_key_file` | `~/.pgedge-vectorizer-llm-api-key` | API key file path (not needed for Ollama; optional for OpenAI with custom URL) | No | No | No |
+| `pgedge_vectorizer.api_url` | (empty) | API endpoint URL. Leave empty for provider defaults. Set for custom/local endpoints. | No | No | No |
 | `pgedge_vectorizer.model` | `text-embedding-3-small` | Model name | No | No | No |
+| `pgedge_vectorizer.extra_headers` | (empty) | Semicolon-separated `key: value` HTTP headers added to all API requests | No | No | No |
 
 ## Worker Settings
 

--- a/docs/embedding_providers.md
+++ b/docs/embedding_providers.md
@@ -9,7 +9,6 @@ OpenAI provides industry-leading embedding models; these models offer excellent 
 **Configuration:**
 ```ini
 pgedge_vectorizer.provider = 'openai'
-pgedge_vectorizer.api_url = 'https://api.openai.com/v1'
 pgedge_vectorizer.api_key_file = '/path/to/api-key-file'
 pgedge_vectorizer.model = 'text-embedding-3-small'
 ```
@@ -19,6 +18,21 @@ pgedge_vectorizer.model = 'text-embedding-3-small'
 - `text-embedding-3-large` - 3072 dimensions, higher quality
 - `text-embedding-ada-002` - 1536 dimensions, legacy model
 
+## Google Gemini
+
+Google Gemini provides embedding models through the Generative Language API.  Save your Gemini API key from https://aistudio.google.com/apikey; specify the path in the `pgedge_vectorizer.api_key_file` configuration parameter.
+
+**Configuration:**
+```ini
+pgedge_vectorizer.provider = 'gemini'
+pgedge_vectorizer.api_key_file = '/path/to/api-key-file'
+pgedge_vectorizer.model = 'text-embedding-004'
+```
+
+**Available Models:**
+- `text-embedding-004` - 768 dimensions, latest model
+- `embedding-001` - 768 dimensions, earlier model
+
 ## Voyage AI
 
 Voyage AI provides high-quality embeddings optimized for retrieval tasks. The API is OpenAI-compatible, making it easy to switch between providers.  Save your Voyage AI API key from https://www.voyageai.com/; specify the path in the `pgedge_vectorizer.api_key_file` configuration parameter.
@@ -26,7 +40,6 @@ Voyage AI provides high-quality embeddings optimized for retrieval tasks. The AP
 **Configuration:**
 ```ini
 pgedge_vectorizer.provider = 'voyage'
-pgedge_vectorizer.api_url = 'https://api.voyageai.com/v1'
 pgedge_vectorizer.api_key_file = '/path/to/api-key-file'
 pgedge_vectorizer.model = 'voyage-2'
 ```
@@ -43,7 +56,6 @@ Ollama allows you to run embedding models locally without API keys or internet c
 **Configuration:**
 ```ini
 pgedge_vectorizer.provider = 'ollama'
-pgedge_vectorizer.api_url = 'http://localhost:11434'
 pgedge_vectorizer.model = 'nomic-embed-text'
 # No API key needed for Ollama
 ```
@@ -59,3 +71,40 @@ ollama pull nomic-embed-text
 ```
 
 Note that Ollama doesn't support batch processing, so each text is embedded individually.
+
+## OpenAI-Compatible Local Providers
+
+The OpenAI provider also works with OpenAI-compatible local inference servers. Set `pgedge_vectorizer.api_url` to point at a local server. The API key is optional when using a custom base URL.
+
+**Configuration:**
+```ini
+pgedge_vectorizer.provider = 'openai'
+pgedge_vectorizer.api_url = 'http://localhost:1234/v1'
+pgedge_vectorizer.model = 'your-local-model'
+# No API key needed for local providers
+```
+
+**Compatible Servers and Default URLs:**
+
+| Server | Default URL |
+|--------|------------|
+| Docker Model Runner | `http://localhost:12434/engines/llama.cpp/v1` |
+| llama.cpp | `http://localhost:8080/v1` |
+| LM Studio | `http://localhost:1234/v1` |
+| EXO | `http://localhost:52415/v1` |
+
+## Custom Base URLs
+
+All providers support custom base URLs via the `pgedge_vectorizer.api_url` parameter. When left empty (the default), each provider uses its own default URL. Set a custom URL to use a proxy, gateway, or alternative endpoint.
+
+## Extra Headers
+
+For proxy servers and gateways that require additional HTTP headers (e.g., Portkey), use the `pgedge_vectorizer.extra_headers` parameter:
+
+```ini
+pgedge_vectorizer.provider = 'openai'
+pgedge_vectorizer.api_url = 'https://api.portkey.ai/v1'
+pgedge_vectorizer.extra_headers = 'x-portkey-api-key: pk-xxx; x-portkey-provider: openai'
+```
+
+Headers are semicolon-separated `key: value` pairs.

--- a/src/guc.c
+++ b/src/guc.c
@@ -60,7 +60,7 @@ pgedge_vectorizer_init_guc(void)
 {
 	/* Provider configuration */
 	DefineCustomStringVariable("pgedge_vectorizer.provider",
-								"Embedding provider to use (openai, voyage, ollama)",
+								"Embedding provider to use (openai, voyage, ollama, gemini)",
 								"Determines which API provider is used for generating embeddings.",
 								&pgedge_vectorizer_provider,
 								"openai",
@@ -79,11 +79,16 @@ pgedge_vectorizer_init_guc(void)
 								NULL, NULL, NULL);
 
 	DefineCustomStringVariable("pgedge_vectorizer.api_url",
-								"API endpoint URL",
-								"API endpoint URL. Defaults: OpenAI=https://api.openai.com/v1, "
-								"Voyage=https://api.voyageai.com/v1, Ollama=http://localhost:11434",
+								"API endpoint URL (empty = provider default)",
+								"API endpoint URL. Leave empty to use provider defaults: "
+								"OpenAI=https://api.openai.com/v1, "
+								"Voyage=https://api.voyageai.com/v1, "
+								"Gemini=https://generativelanguage.googleapis.com/v1beta, "
+								"Ollama=http://localhost:11434. "
+								"Set a custom URL for OpenAI-compatible local providers "
+								"(LM Studio, Docker Model Runner, EXO) or proxies (Portkey).",
 								&pgedge_vectorizer_api_url,
-								"https://api.openai.com/v1",
+								"",
 								PGC_USERSET,
 								0,
 								NULL, NULL, NULL);
@@ -96,6 +101,17 @@ pgedge_vectorizer_init_guc(void)
 								"Ollama: nomic-embed-text, mxbai-embed-large",
 								&pgedge_vectorizer_model,
 								"text-embedding-3-small",
+								PGC_USERSET,
+								0,
+								NULL, NULL, NULL);
+
+	DefineCustomStringVariable("pgedge_vectorizer.extra_headers",
+								"Extra HTTP headers for API requests",
+								"Semicolon-separated key: value pairs added to all "
+								"provider HTTP requests. Example: "
+								"'x-portkey-provider: openai; x-custom: value'",
+								&pgedge_vectorizer_extra_headers,
+								"",
 								PGC_USERSET,
 								0,
 								NULL, NULL, NULL);

--- a/src/guc.c
+++ b/src/guc.c
@@ -20,6 +20,7 @@ char *pgedge_vectorizer_provider = NULL;
 char *pgedge_vectorizer_api_key_file = NULL;
 char *pgedge_vectorizer_api_url = NULL;
 char *pgedge_vectorizer_model = NULL;
+char *pgedge_vectorizer_extra_headers = NULL;
 
 /*
  * GUC Variables - Worker Configuration

--- a/src/pgedge_vectorizer.h
+++ b/src/pgedge_vectorizer.h
@@ -164,6 +164,9 @@ extern EmbeddingProvider VoyageProvider;
 /* provider_ollama.c */
 extern EmbeddingProvider OllamaProvider;
 
+/* provider_gemini.c */
+extern EmbeddingProvider GeminiProvider;
+
 /* tokenizer.c */
 int count_tokens(const char *text, const char *model);
 int *tokenize_text(const char *text, const char *model, int *token_count);

--- a/src/pgedge_vectorizer.h
+++ b/src/pgedge_vectorizer.h
@@ -50,6 +50,7 @@ extern char *pgedge_vectorizer_provider;
 extern char *pgedge_vectorizer_api_key_file;
 extern char *pgedge_vectorizer_api_url;
 extern char *pgedge_vectorizer_model;
+extern char *pgedge_vectorizer_extra_headers;
 extern char *pgedge_vectorizer_databases;
 extern int pgedge_vectorizer_num_workers;
 extern int pgedge_vectorizer_batch_size;

--- a/src/pgedge_vectorizer.h
+++ b/src/pgedge_vectorizer.h
@@ -53,6 +53,7 @@ extern char *pgedge_vectorizer_provider;
 extern char *pgedge_vectorizer_api_key_file;
 extern char *pgedge_vectorizer_api_url;
 extern char *pgedge_vectorizer_model;
+extern char *pgedge_vectorizer_extra_headers;
 extern char *pgedge_vectorizer_databases;
 extern int pgedge_vectorizer_num_workers;
 extern int pgedge_vectorizer_batch_size;

--- a/src/pgedge_vectorizer.h
+++ b/src/pgedge_vectorizer.h
@@ -167,6 +167,9 @@ extern EmbeddingProvider VoyageProvider;
 /* provider_ollama.c */
 extern EmbeddingProvider OllamaProvider;
 
+/* provider_gemini.c */
+extern EmbeddingProvider GeminiProvider;
+
 /* tokenizer.c */
 int count_tokens(const char *text, const char *model);
 int *tokenize_text(const char *text, const char *model, int *token_count);

--- a/src/provider.c
+++ b/src/provider.c
@@ -18,6 +18,7 @@ static EmbeddingProvider *providers[] = {
 	&OpenAIProvider,
 	&VoyageProvider,
 	&OllamaProvider,
+	&GeminiProvider,
 	NULL  /* Sentinel */
 };
 

--- a/src/provider_common.c
+++ b/src/provider_common.c
@@ -1,0 +1,460 @@
+/*-------------------------------------------------------------------------
+ *
+ * provider_common.c
+ *		Shared utilities for embedding provider implementations
+ *
+ * Extracted from provider_openai.c and provider_voyage.c to eliminate
+ * code duplication across providers.
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ *
+ *-------------------------------------------------------------------------
+ */
+#include "provider_common.h"
+
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include "utils/memutils.h"
+
+/*
+ * Curl write callback - accumulates response data into a ResponseBuffer.
+ */
+size_t
+provider_write_callback(void *contents, size_t size, size_t nmemb, void *userp)
+{
+	size_t realsize = size * nmemb;
+	ResponseBuffer *mem = (ResponseBuffer *) userp;
+
+	char *ptr = repalloc(mem->data, mem->size + realsize + 1);
+	if (!ptr)
+		return 0;  /* Out of memory */
+
+	mem->data = ptr;
+	/* flawfinder: ignore - buffer was realloced to mem->size + realsize + 1 */
+	memcpy(&(mem->data[mem->size]), contents, realsize);  /* nosemgrep */
+	mem->size += realsize;
+	mem->data[mem->size] = 0;
+
+	return realsize;
+}
+
+/*
+ * Expand tilde in path
+ */
+char *
+provider_expand_tilde(const char *path)
+{
+	if (path[0] == '~' && (path[1] == '/' || path[1] == '\0'))
+	{
+		const char *home = getenv("HOME");
+		if (home)
+			return psprintf("%s%s", home, path + 1);
+	}
+	return pstrdup(path);
+}
+
+/*
+ * Load API key from file
+ *
+ * Handles tilde expansion, file permission checks, and persists the key
+ * in TopMemoryContext so it survives across transactions.
+ */
+char *
+provider_load_api_key(const char *filepath, char **error_msg)
+{
+	FILE *fp;
+	char *expanded_path;
+	StringInfoData key_buf;
+	int c;
+	struct stat st;
+
+	if (filepath == NULL || filepath[0] == '\0')
+	{
+		*error_msg = pstrdup("API key file path is not configured");
+		return NULL;
+	}
+
+	/* Expand tilde */
+	expanded_path = provider_expand_tilde(filepath);
+
+	/* Check file exists and has proper permissions */
+	if (stat(expanded_path, &st) != 0)
+	{
+		*error_msg = psprintf("API key file not found: %s", expanded_path);
+		pfree(expanded_path);
+		return NULL;
+	}
+
+	/* Warn if file is world-readable */
+	if (st.st_mode & (S_IRWXG | S_IRWXO))
+	{
+		elog(WARNING, "API key file %s has permissive permissions (should be 0600)",
+			 expanded_path);
+	}
+
+	/* Open and read file */
+	fp = fopen(expanded_path, "r");
+	if (fp == NULL)
+	{
+		*error_msg = psprintf("Failed to open API key file: %s", expanded_path);
+		pfree(expanded_path);
+		return NULL;
+	}
+
+	initStringInfo(&key_buf);
+
+	/* Read the file, trimming whitespace */
+	while ((c = fgetc(fp)) != EOF)
+	{
+		if (c != '\n' && c != '\r' && c != ' ' && c != '\t')
+			appendStringInfoChar(&key_buf, c);
+	}
+
+	fclose(fp);
+	pfree(expanded_path);
+
+	if (key_buf.len == 0)
+	{
+		*error_msg = pstrdup("API key file is empty");
+		pfree(key_buf.data);
+		return NULL;
+	}
+
+	/* Copy to TopMemoryContext so it persists across transactions */
+	{
+		char *persistent_key;
+		MemoryContext oldcontext;
+
+		oldcontext = MemoryContextSwitchTo(TopMemoryContext);
+		persistent_key = pstrdup(key_buf.data);
+		MemoryContextSwitchTo(oldcontext);
+
+		pfree(key_buf.data);
+		return persistent_key;
+	}
+}
+
+/*
+ * Escape a string for JSON
+ */
+char *
+provider_escape_json_string(const char *str)
+{
+	StringInfoData buf;
+	const char *p;
+
+	initStringInfo(&buf);
+
+	for (p = str; *p; p++)
+	{
+		switch (*p)
+		{
+			case '"':
+				appendStringInfoString(&buf, "\\\"");
+				break;
+			case '\\':
+				appendStringInfoString(&buf, "\\\\");
+				break;
+			case '\b':
+				appendStringInfoString(&buf, "\\b");
+				break;
+			case '\f':
+				appendStringInfoString(&buf, "\\f");
+				break;
+			case '\n':
+				appendStringInfoString(&buf, "\\n");
+				break;
+			case '\r':
+				appendStringInfoString(&buf, "\\r");
+				break;
+			case '\t':
+				appendStringInfoString(&buf, "\\t");
+				break;
+			default:
+				if ((unsigned char) *p < 32)
+					appendStringInfo(&buf, "\\u%04x", (unsigned char) *p);
+				else
+					appendStringInfoChar(&buf, *p);
+				break;
+		}
+	}
+
+	return buf.data;
+}
+
+/*
+ * Build an OpenAI-format embedding request body.
+ *
+ * Returns a palloc'd JSON string: {"input":["text1","text2"],"model":"model-name"}
+ * Caller must pfree the result.
+ */
+char *
+provider_build_openai_request(const char **texts, int count, const char *model)
+{
+	StringInfoData request_buf;
+
+	initStringInfo(&request_buf);
+	appendStringInfo(&request_buf, "{\"input\":[");
+	for (int i = 0; i < count; i++)
+	{
+		char *escaped = provider_escape_json_string(texts[i]);
+		if (i > 0)
+			appendStringInfoChar(&request_buf, ',');
+		appendStringInfo(&request_buf, "\"%s\"", escaped);
+		pfree(escaped);
+	}
+	appendStringInfo(&request_buf, "],\"model\":\"%s\"}", model);
+
+	return request_buf.data;
+}
+
+/*
+ * Perform an HTTP POST request via curl.
+ *
+ * Handles:
+ * - Setting Content-Type header
+ * - Adding provider-specific auth header (if non-NULL)
+ * - Parsing and appending extra_headers from GUC
+ * - Curl lifecycle (init, perform, cleanup)
+ * - HTTP response code checking
+ *
+ * Returns true on HTTP 200, false otherwise.
+ */
+bool
+provider_do_curl_request(const char *url, const char *auth_header,
+						 const char *json_request,
+						 const char *provider_name,
+						 ResponseBuffer *response_out,
+						 char **error_msg)
+{
+	CURL *curl;
+	CURLcode res;
+	struct curl_slist *headers = NULL;
+	long response_code;
+
+	/* Initialize response buffer */
+	response_out->data = palloc(1);
+	response_out->data[0] = '\0';
+	response_out->size = 0;
+
+	/* Initialize curl */
+	curl = curl_easy_init();
+	if (!curl)
+	{
+		*error_msg = pstrdup("Failed to initialize libcurl");
+		pfree(response_out->data);
+		response_out->data = NULL;
+		return false;
+	}
+
+	/* Set up headers */
+	headers = curl_slist_append(headers, "Content-Type: application/json; charset=utf-8");
+
+	if (auth_header != NULL)
+		headers = curl_slist_append(headers, auth_header);
+
+	/* Parse and append extra headers from GUC */
+	if (pgedge_vectorizer_extra_headers != NULL &&
+		pgedge_vectorizer_extra_headers[0] != '\0')
+	{
+		char *headers_copy = pstrdup(pgedge_vectorizer_extra_headers);
+		char *saveptr = NULL;
+		char *token;
+
+		for (token = strtok_r(headers_copy, ";", &saveptr);
+			 token != NULL;
+			 token = strtok_r(NULL, ";", &saveptr))
+		{
+			/* Trim leading whitespace */
+			while (*token == ' ' || *token == '\t')
+				token++;
+
+			/* Trim trailing whitespace */
+			{
+				char *end = token + strlen(token) - 1;
+				while (end > token && (*end == ' ' || *end == '\t'))
+					*end-- = '\0';
+			}
+
+			/* Skip empty tokens */
+			if (*token == '\0')
+				continue;
+
+			/* Validate: must contain a colon */
+			if (strchr(token, ':') == NULL)
+			{
+				elog(WARNING, "Ignoring invalid extra header (no colon): %s", token);
+				continue;
+			}
+
+			headers = curl_slist_append(headers, token);
+		}
+
+		pfree(headers_copy);
+	}
+
+	/* Configure curl */
+	curl_easy_setopt(curl, CURLOPT_URL, url);
+	curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
+	curl_easy_setopt(curl, CURLOPT_POSTFIELDS, json_request);
+	/* flawfinder: ignore - json_request is null-terminated */
+	curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, (long)strlen(json_request));
+	curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, provider_write_callback);
+	curl_easy_setopt(curl, CURLOPT_WRITEDATA, response_out);
+	curl_easy_setopt(curl, CURLOPT_TIMEOUT, 300L);  /* 5 minute timeout */
+
+	/* Perform the request */
+	res = curl_easy_perform(curl);
+
+	if (res != CURLE_OK)
+	{
+		*error_msg = psprintf("curl_easy_perform() failed: %s",
+							  curl_easy_strerror(res));
+		curl_slist_free_all(headers);
+		curl_easy_cleanup(curl);
+		return false;
+	}
+
+	/* Check HTTP response code */
+	curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &response_code);
+	if (response_code != 200)
+	{
+		*error_msg = psprintf("%s API returned HTTP %ld: %s",
+							  provider_name, response_code, response_out->data);
+		curl_slist_free_all(headers);
+		curl_easy_cleanup(curl);
+		return false;
+	}
+
+	curl_slist_free_all(headers);
+	curl_easy_cleanup(curl);
+	return true;
+}
+
+/*
+ * Parse OpenAI-format batch embedding response.
+ *
+ * Expected format:
+ * {"data":[{"embedding":[0.1,0.2,...]},{"embedding":[...]}],...}
+ *
+ * Used by OpenAI, Voyage, and OpenAI-compatible local providers.
+ */
+float **
+provider_parse_openai_embedding_response(const char *json_response, int count,
+										 int *dim, char **error_msg)
+{
+	const char *p;
+	float **embeddings = NULL;
+	int embedding_idx = 0;
+	int value_idx;
+	char value_buf[32];
+	int value_pos;
+
+	/* Allocate array for embeddings */
+	embeddings = (float **) palloc0(sizeof(float *) * count);
+
+	/* Find "data" array */
+	p = strstr(json_response, "\"data\"");
+	if (p == NULL)
+	{
+		*error_msg = pstrdup("Invalid response: 'data' field not found");
+		goto error;
+	}
+
+	/* Find first embedding array */
+	p = strstr(p, "\"embedding\"");
+	if (p == NULL)
+	{
+		*error_msg = pstrdup("Invalid response: 'embedding' field not found");
+		goto error;
+	}
+
+	/* Process each embedding */
+	while (embedding_idx < count && p != NULL)
+	{
+		/* Find opening bracket */
+		p = strchr(p, '[');
+		if (p == NULL)
+			break;
+		p++;
+
+		/* Count dimensions if first embedding */
+		if (*dim == 0)
+		{
+			const char *temp = p;
+			int comma_count = 0;
+			while (*temp && *temp != ']')
+			{
+				if (*temp == ',')
+					comma_count++;
+				temp++;
+			}
+			*dim = comma_count + 1;
+		}
+
+		/* Allocate array for this embedding */
+		embeddings[embedding_idx] = (float *) palloc(sizeof(float) * (*dim));
+		value_idx = 0;
+
+		/* Parse values */
+		while (value_idx < *dim && *p && *p != ']')
+		{
+			/* Skip whitespace and commas */
+			while (*p && (*p == ' ' || *p == ',' || *p == '\t' || *p == '\n'))
+				p++;
+
+			if (*p == ']')
+				break;
+
+			/* Read numeric value */
+			value_pos = 0;
+			while (*p && (isdigit(*p) || *p == '.' || *p == '-' || *p == '+' || *p == 'e' || *p == 'E'))
+			{
+				if (value_pos < sizeof(value_buf) - 1)
+					value_buf[value_pos++] = *p;
+				p++;
+			}
+			value_buf[value_pos] = '\0';
+
+			if (value_pos > 0)
+			{
+				embeddings[embedding_idx][value_idx] = atof(value_buf);
+				value_idx++;
+			}
+		}
+
+		if (value_idx != *dim)
+		{
+			*error_msg = psprintf("Dimension mismatch: expected %d, got %d",
+								  *dim, value_idx);
+			goto error;
+		}
+
+		embedding_idx++;
+
+		/* Find next embedding */
+		p = strstr(p, "\"embedding\"");
+	}
+
+	if (embedding_idx != count)
+	{
+		*error_msg = psprintf("Expected %d embeddings, got %d",
+							  count, embedding_idx);
+		goto error;
+	}
+
+	return embeddings;
+
+error:
+	if (embeddings != NULL)
+	{
+		for (int i = 0; i < embedding_idx; i++)
+		{
+			if (embeddings[i] != NULL)
+				pfree(embeddings[i]);
+		}
+		pfree(embeddings);
+	}
+	return NULL;
+}

--- a/src/provider_common.c
+++ b/src/provider_common.c
@@ -47,7 +47,7 @@ provider_expand_tilde(const char *path)
 {
 	if (path[0] == '~' && (path[1] == '/' || path[1] == '\0'))
 	{
-		const char *home = getenv("HOME");
+		const char *home = getenv("HOME");  /* nosemgrep */
 		if (home)
 			return psprintf("%s%s", home, path + 1);
 	}
@@ -55,10 +55,9 @@ provider_expand_tilde(const char *path)
 }
 
 /*
- * Load API key from file
+ * Read API key from file into a persistent (TopMemoryContext) string.
  *
- * Handles tilde expansion, file permission checks, and persists the key
- * in TopMemoryContext so it survives across transactions.
+ * Handles tilde expansion, file permission checks, and whitespace trimming.
  */
 char *
 provider_load_api_key(const char *filepath, char **error_msg)
@@ -68,6 +67,8 @@ provider_load_api_key(const char *filepath, char **error_msg)
 	StringInfoData key_buf;
 	int c;
 	struct stat st;
+	MemoryContext oldcontext;
+	char *persistent_key;
 
 	if (filepath == NULL || filepath[0] == '\0')
 	{
@@ -75,10 +76,8 @@ provider_load_api_key(const char *filepath, char **error_msg)
 		return NULL;
 	}
 
-	/* Expand tilde */
 	expanded_path = provider_expand_tilde(filepath);
 
-	/* Check file exists and has proper permissions */
 	if (stat(expanded_path, &st) != 0)
 	{
 		*error_msg = psprintf("API key file not found: %s", expanded_path);
@@ -86,14 +85,10 @@ provider_load_api_key(const char *filepath, char **error_msg)
 		return NULL;
 	}
 
-	/* Warn if file is world-readable */
 	if (st.st_mode & (S_IRWXG | S_IRWXO))
-	{
 		elog(WARNING, "API key file %s has permissive permissions (should be 0600)",
 			 expanded_path);
-	}
 
-	/* Open and read file */
 	fp = fopen(expanded_path, "r");
 	if (fp == NULL)
 	{
@@ -102,17 +97,16 @@ provider_load_api_key(const char *filepath, char **error_msg)
 		return NULL;
 	}
 
+	pfree(expanded_path);
 	initStringInfo(&key_buf);
 
-	/* Read the file, trimming whitespace */
+	/* flawfinder: ignore - fgetc reads into auto-resizing StringInfo */
 	while ((c = fgetc(fp)) != EOF)
 	{
 		if (c != '\n' && c != '\r' && c != ' ' && c != '\t')
 			appendStringInfoChar(&key_buf, c);
 	}
-
 	fclose(fp);
-	pfree(expanded_path);
 
 	if (key_buf.len == 0)
 	{
@@ -121,18 +115,12 @@ provider_load_api_key(const char *filepath, char **error_msg)
 		return NULL;
 	}
 
-	/* Copy to TopMemoryContext so it persists across transactions */
-	{
-		char *persistent_key;
-		MemoryContext oldcontext;
+	oldcontext = MemoryContextSwitchTo(TopMemoryContext);
+	persistent_key = pstrdup(key_buf.data);
+	MemoryContextSwitchTo(oldcontext);
 
-		oldcontext = MemoryContextSwitchTo(TopMemoryContext);
-		persistent_key = pstrdup(key_buf.data);
-		MemoryContextSwitchTo(oldcontext);
-
-		pfree(key_buf.data);
-		return persistent_key;
-	}
+	pfree(key_buf.data);
+	return persistent_key;
 }
 
 /*
@@ -187,7 +175,6 @@ provider_escape_json_string(const char *str)
  * Build an OpenAI-format embedding request body.
  *
  * Returns a palloc'd JSON string: {"input":["text1","text2"],"model":"model-name"}
- * Caller must pfree the result.
  */
 char *
 provider_build_openai_request(const char **texts, int count, const char *model)
@@ -210,15 +197,139 @@ provider_build_openai_request(const char **texts, int count, const char *model)
 }
 
 /*
+ * Count dimensions in a JSON float array by counting commas.
+ * Pointer should be positioned just after the opening '['.
+ */
+int
+provider_count_array_dimensions(const char *p)
+{
+	int comma_count = 0;
+
+	while (*p && *p != ']')
+	{
+		if (*p == ',')
+			comma_count++;
+		p++;
+	}
+	return comma_count + 1;
+}
+
+/*
+ * Parse a JSON float array into a pre-allocated output buffer.
+ *
+ * Reads up to `dim` float values from the current position (after '[').
+ * Advances *pos past the parsed values (to ']' or end of parsed data).
+ * Returns the number of values successfully parsed.
+ */
+int
+provider_parse_float_array(const char **pos, float *output, int dim)
+{
+	const char *p = *pos;
+	int idx = 0;
+	char value_buf[32];
+	int value_pos;
+
+	while (idx < dim && *p && *p != ']')
+	{
+		/* Skip whitespace and commas */
+		while (*p && (*p == ' ' || *p == ',' || *p == '\t' || *p == '\n'))
+			p++;
+
+		if (*p == ']')
+			break;
+
+		/* Read numeric value */
+		value_pos = 0;
+		while (*p && (isdigit(*p) || *p == '.' || *p == '-' ||
+					  *p == '+' || *p == 'e' || *p == 'E'))
+		{
+			if (value_pos < (int) sizeof(value_buf) - 1)
+				value_buf[value_pos++] = *p;
+			p++;
+		}
+		value_buf[value_pos] = '\0';
+
+		if (value_pos > 0)
+		{
+			output[idx] = atof(value_buf);
+			idx++;
+		}
+	}
+
+	*pos = p;
+	return idx;
+}
+
+/*
+ * Append extra headers from the pgedge_vectorizer.extra_headers GUC
+ * to a curl header list. Parses semicolon-separated "key: value" pairs.
+ */
+void
+provider_append_extra_headers(struct curl_slist **headers)
+{
+	char *headers_copy;
+	char *saveptr = NULL;
+	char *token;
+
+	if (pgedge_vectorizer_extra_headers == NULL ||
+		pgedge_vectorizer_extra_headers[0] == '\0')
+		return;
+
+	headers_copy = pstrdup(pgedge_vectorizer_extra_headers);
+
+	for (token = strtok_r(headers_copy, ";", &saveptr);
+		 token != NULL;
+		 token = strtok_r(NULL, ";", &saveptr))
+	{
+		char *end;
+
+		/* Trim leading whitespace */
+		while (*token == ' ' || *token == '\t')
+			token++;
+
+		/* Trim trailing whitespace */
+		/* flawfinder: ignore - token is NUL-terminated by strtok_r */
+		end = token + strlen(token) - 1;  /* nosemgrep */
+		while (end > token && (*end == ' ' || *end == '\t'))
+			*end-- = '\0';
+
+		if (*token == '\0')
+			continue;
+
+		if (strchr(token, ':') == NULL)
+		{
+			elog(WARNING, "Ignoring invalid extra header (no colon): %s", token);
+			continue;
+		}
+
+		*headers = curl_slist_append(*headers, token);
+	}
+
+	pfree(headers_copy);
+}
+
+/*
+ * Free a partially-allocated embeddings array (for error cleanup).
+ */
+void
+provider_free_embeddings(float **embeddings, int count)
+{
+	if (embeddings == NULL)
+		return;
+
+	for (int i = 0; i < count; i++)
+	{
+		if (embeddings[i] != NULL)
+			pfree(embeddings[i]);
+	}
+	pfree(embeddings);
+}
+
+/*
  * Perform an HTTP POST request via curl.
  *
- * Handles:
- * - Setting Content-Type header
- * - Adding provider-specific auth header (if non-NULL)
- * - Parsing and appending extra_headers from GUC
- * - Curl lifecycle (init, perform, cleanup)
- * - HTTP response code checking
- *
+ * Handles Content-Type, auth header, extra headers from GUC,
+ * curl lifecycle, and HTTP response code checking.
  * Returns true on HTTP 200, false otherwise.
  */
 bool
@@ -238,7 +349,6 @@ provider_do_curl_request(const char *url, const char *auth_header,
 	response_out->data[0] = '\0';
 	response_out->size = 0;
 
-	/* Initialize curl */
 	curl = curl_easy_init();
 	if (!curl)
 	{
@@ -250,61 +360,20 @@ provider_do_curl_request(const char *url, const char *auth_header,
 
 	/* Set up headers */
 	headers = curl_slist_append(headers, "Content-Type: application/json; charset=utf-8");
-
 	if (auth_header != NULL)
 		headers = curl_slist_append(headers, auth_header);
+	provider_append_extra_headers(&headers);
 
-	/* Parse and append extra headers from GUC */
-	if (pgedge_vectorizer_extra_headers != NULL &&
-		pgedge_vectorizer_extra_headers[0] != '\0')
-	{
-		char *headers_copy = pstrdup(pgedge_vectorizer_extra_headers);
-		char *saveptr = NULL;
-		char *token;
-
-		for (token = strtok_r(headers_copy, ";", &saveptr);
-			 token != NULL;
-			 token = strtok_r(NULL, ";", &saveptr))
-		{
-			/* Trim leading whitespace */
-			while (*token == ' ' || *token == '\t')
-				token++;
-
-			/* Trim trailing whitespace */
-			{
-				char *end = token + strlen(token) - 1;
-				while (end > token && (*end == ' ' || *end == '\t'))
-					*end-- = '\0';
-			}
-
-			/* Skip empty tokens */
-			if (*token == '\0')
-				continue;
-
-			/* Validate: must contain a colon */
-			if (strchr(token, ':') == NULL)
-			{
-				elog(WARNING, "Ignoring invalid extra header (no colon): %s", token);
-				continue;
-			}
-
-			headers = curl_slist_append(headers, token);
-		}
-
-		pfree(headers_copy);
-	}
-
-	/* Configure curl */
+	/* Configure and perform request */
 	curl_easy_setopt(curl, CURLOPT_URL, url);
 	curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
 	curl_easy_setopt(curl, CURLOPT_POSTFIELDS, json_request);
 	/* flawfinder: ignore - json_request is null-terminated */
-	curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, (long)strlen(json_request));
+	curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, (long)strlen(json_request));  /* nosemgrep */
 	curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, provider_write_callback);
 	curl_easy_setopt(curl, CURLOPT_WRITEDATA, response_out);
-	curl_easy_setopt(curl, CURLOPT_TIMEOUT, 300L);  /* 5 minute timeout */
+	curl_easy_setopt(curl, CURLOPT_TIMEOUT, 300L);
 
-	/* Perform the request */
 	res = curl_easy_perform(curl);
 
 	if (res != CURLE_OK)
@@ -316,19 +385,17 @@ provider_do_curl_request(const char *url, const char *auth_header,
 		return false;
 	}
 
-	/* Check HTTP response code */
 	curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &response_code);
+	curl_slist_free_all(headers);
+	curl_easy_cleanup(curl);
+
 	if (response_code != 200)
 	{
 		*error_msg = psprintf("%s API returned HTTP %ld: %s",
 							  provider_name, response_code, response_out->data);
-		curl_slist_free_all(headers);
-		curl_easy_cleanup(curl);
 		return false;
 	}
 
-	curl_slist_free_all(headers);
-	curl_easy_cleanup(curl);
 	return true;
 }
 
@@ -345,95 +412,51 @@ provider_parse_openai_embedding_response(const char *json_response, int count,
 										 int *dim, char **error_msg)
 {
 	const char *p;
-	float **embeddings = NULL;
+	float **embeddings;
 	int embedding_idx = 0;
-	int value_idx;
-	char value_buf[32];
-	int value_pos;
 
-	/* Allocate array for embeddings */
 	embeddings = (float **) palloc0(sizeof(float *) * count);
 
-	/* Find "data" array */
 	p = strstr(json_response, "\"data\"");
 	if (p == NULL)
 	{
 		*error_msg = pstrdup("Invalid response: 'data' field not found");
-		goto error;
+		pfree(embeddings);
+		return NULL;
 	}
 
-	/* Find first embedding array */
 	p = strstr(p, "\"embedding\"");
 	if (p == NULL)
 	{
 		*error_msg = pstrdup("Invalid response: 'embedding' field not found");
-		goto error;
+		pfree(embeddings);
+		return NULL;
 	}
 
-	/* Process each embedding */
 	while (embedding_idx < count && p != NULL)
 	{
-		/* Find opening bracket */
+		int parsed;
+
 		p = strchr(p, '[');
 		if (p == NULL)
 			break;
 		p++;
 
-		/* Count dimensions if first embedding */
 		if (*dim == 0)
-		{
-			const char *temp = p;
-			int comma_count = 0;
-			while (*temp && *temp != ']')
-			{
-				if (*temp == ',')
-					comma_count++;
-				temp++;
-			}
-			*dim = comma_count + 1;
-		}
+			*dim = provider_count_array_dimensions(p);
 
-		/* Allocate array for this embedding */
 		embeddings[embedding_idx] = (float *) palloc(sizeof(float) * (*dim));
-		value_idx = 0;
+		parsed = provider_parse_float_array(&p, embeddings[embedding_idx], *dim);
 
-		/* Parse values */
-		while (value_idx < *dim && *p && *p != ']')
-		{
-			/* Skip whitespace and commas */
-			while (*p && (*p == ' ' || *p == ',' || *p == '\t' || *p == '\n'))
-				p++;
-
-			if (*p == ']')
-				break;
-
-			/* Read numeric value */
-			value_pos = 0;
-			while (*p && (isdigit(*p) || *p == '.' || *p == '-' || *p == '+' || *p == 'e' || *p == 'E'))
-			{
-				if (value_pos < sizeof(value_buf) - 1)
-					value_buf[value_pos++] = *p;
-				p++;
-			}
-			value_buf[value_pos] = '\0';
-
-			if (value_pos > 0)
-			{
-				embeddings[embedding_idx][value_idx] = atof(value_buf);
-				value_idx++;
-			}
-		}
-
-		if (value_idx != *dim)
+		if (parsed != *dim)
 		{
 			*error_msg = psprintf("Dimension mismatch: expected %d, got %d",
-								  *dim, value_idx);
-			goto error;
+								  *dim, parsed);
+			provider_free_embeddings(embeddings, embedding_idx + 1);
+			return NULL;
 		}
 
 		embedding_idx++;
-
-		/* Find next embedding */
 		p = strstr(p, "\"embedding\"");
 	}
 
@@ -441,20 +464,9 @@ provider_parse_openai_embedding_response(const char *json_response, int count,
 	{
 		*error_msg = psprintf("Expected %d embeddings, got %d",
 							  count, embedding_idx);
-		goto error;
+		provider_free_embeddings(embeddings, embedding_idx);
+		return NULL;
 	}
 
 	return embeddings;
-
-error:
-	if (embeddings != NULL)
-	{
-		for (int i = 0; i < embedding_idx; i++)
-		{
-			if (embeddings[i] != NULL)
-				pfree(embeddings[i]);
-		}
-		pfree(embeddings);
-	}
-	return NULL;
 }

--- a/src/provider_common.c
+++ b/src/provider_common.c
@@ -82,6 +82,16 @@ provider_load_api_key(const char *filepath, char **error_msg)
 		return NULL;
 	}
 
+	/* Bound the read to guard against a misconfigured path (CWE-20) */
+	if (st.st_size > MAX_API_KEY_FILE_SIZE)
+	{
+		*error_msg = psprintf("API key file %s is too large (%lld bytes; limit %d)",
+							  expanded_path, (long long) st.st_size,
+							  MAX_API_KEY_FILE_SIZE);
+		pfree(expanded_path);
+		return NULL;
+	}
+
 	if (st.st_mode & (S_IRWXG | S_IRWXO))
 		elog(WARNING, "API key file %s has permissive permissions (should be 0600)",
 			 expanded_path);

--- a/src/provider_common.c
+++ b/src/provider_common.c
@@ -26,11 +26,8 @@ provider_write_callback(void *contents, size_t size, size_t nmemb, void *userp)
 	size_t realsize = size * nmemb;
 	ResponseBuffer *mem = (ResponseBuffer *) userp;
 
-	char *ptr = repalloc(mem->data, mem->size + realsize + 1);
-	if (!ptr)
-		return 0;  /* Out of memory */
-
-	mem->data = ptr;
+	/* repalloc never returns NULL - it throws on allocation failure */
+	mem->data = repalloc(mem->data, mem->size + realsize + 1);
 	/* flawfinder: ignore - buffer was realloced to mem->size + realsize + 1 */
 	memcpy(&(mem->data[mem->size]), contents, realsize);  /* nosemgrep */
 	mem->size += realsize;
@@ -240,7 +237,7 @@ provider_parse_float_array(const char **pos, float *output, int dim)
 
 		/* Read numeric value */
 		value_pos = 0;
-		while (*p && (isdigit(*p) || *p == '.' || *p == '-' ||
+		while (*p && (isdigit((unsigned char) *p) || *p == '.' || *p == '-' ||
 					  *p == '+' || *p == 'e' || *p == 'E'))
 		{
 			if (value_pos < (int) sizeof(value_buf) - 1)

--- a/src/provider_common.h
+++ b/src/provider_common.h
@@ -1,0 +1,75 @@
+/*-------------------------------------------------------------------------
+ *
+ * provider_common.h
+ *		Shared utilities for embedding provider implementations
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ *
+ *-------------------------------------------------------------------------
+ */
+#ifndef PROVIDER_COMMON_H
+#define PROVIDER_COMMON_H
+
+#include "pgedge_vectorizer.h"
+#include <curl/curl.h>
+
+/*
+ * Response buffer for libcurl callbacks
+ */
+typedef struct
+{
+	char   *data;
+	size_t  size;
+} ResponseBuffer;
+
+/*
+ * Shared provider utility functions
+ */
+
+/* curl write callback for all providers */
+size_t provider_write_callback(void *contents, size_t size, size_t nmemb,
+							   void *userp);
+
+/* Load API key from file with tilde expansion and permission checks */
+char *provider_load_api_key(const char *filepath, char **error_msg);
+
+/* Expand tilde (~) to home directory in file paths */
+char *provider_expand_tilde(const char *path);
+
+/* Escape a string for safe inclusion in JSON */
+char *provider_escape_json_string(const char *str);
+
+/* Build OpenAI-format request body: {"input":[...], "model":"..."} */
+char *provider_build_openai_request(const char **texts, int count,
+									const char *model);
+
+/*
+ * Perform an HTTP POST request via curl.
+ *
+ * url: full endpoint URL
+ * auth_header: e.g. "Authorization: Bearer xxx" or "x-goog-api-key: xxx",
+ *              NULL for no auth
+ * json_request: POST body
+ * provider_name: for error messages (e.g. "OpenAI", "Gemini")
+ * response_out: receives the response body (caller must pfree response_out->data)
+ * error_msg: receives error message on failure
+ *
+ * Returns true on success (HTTP 200), false on failure.
+ */
+bool provider_do_curl_request(const char *url, const char *auth_header,
+							  const char *json_request,
+							  const char *provider_name,
+							  ResponseBuffer *response_out,
+							  char **error_msg);
+
+/*
+ * Parse OpenAI-format embedding response:
+ * {"data":[{"embedding":[0.1,0.2,...]},{"embedding":[...]}],...}
+ *
+ * Used by OpenAI, Voyage, and OpenAI-compatible local providers.
+ */
+float **provider_parse_openai_embedding_response(const char *json_response,
+												 int count, int *dim,
+												 char **error_msg);
+
+#endif /* PROVIDER_COMMON_H */

--- a/src/provider_common.h
+++ b/src/provider_common.h
@@ -72,4 +72,16 @@ float **provider_parse_openai_embedding_response(const char *json_response,
 												 int count, int *dim,
 												 char **error_msg);
 
+/* Count dimensions by counting commas in a JSON float array (after '[') */
+int provider_count_array_dimensions(const char *p);
+
+/* Parse a JSON float array into pre-allocated output; returns count parsed */
+int provider_parse_float_array(const char **pos, float *output, int dim);
+
+/* Append extra headers from GUC to a curl header list */
+void provider_append_extra_headers(struct curl_slist **headers);
+
+/* Free a partially-allocated embeddings array */
+void provider_free_embeddings(float **embeddings, int count);
+
 #endif /* PROVIDER_COMMON_H */

--- a/src/provider_gemini.c
+++ b/src/provider_gemini.c
@@ -198,93 +198,51 @@ parse_gemini_batch_embedding_response(const char *json_response, int count,
 									  int *dim, char **error_msg)
 {
 	const char *p;
-	float **embeddings = NULL;
+	float **embeddings;
 	int embedding_idx = 0;
-	int value_idx;
-	char value_buf[32];
-	int value_pos;
 
-	/* Allocate array for embeddings */
 	embeddings = (float **) palloc0(sizeof(float *) * count);
 
-	/* Find "embeddings" array */
 	p = strstr(json_response, "\"embeddings\"");
 	if (p == NULL)
 	{
 		*error_msg = pstrdup("Invalid response: 'embeddings' field not found");
-		goto error;
+		pfree(embeddings);
+		return NULL;
 	}
 
-	/* Find first "values" array */
 	p = strstr(p, "\"values\"");
 	if (p == NULL)
 	{
 		*error_msg = pstrdup("Invalid response: 'values' field not found");
-		goto error;
+		pfree(embeddings);
+		return NULL;
 	}
 
-	/* Process each embedding */
 	while (embedding_idx < count && p != NULL)
 	{
-		/* Find opening bracket */
+		int parsed;
+
 		p = strchr(p, '[');
 		if (p == NULL)
 			break;
 		p++;
 
-		/* Count dimensions if first embedding */
 		if (*dim == 0)
-		{
-			const char *temp = p;
-			int comma_count = 0;
-			while (*temp && *temp != ']')
-			{
-				if (*temp == ',')
-					comma_count++;
-				temp++;
-			}
-			*dim = comma_count + 1;
-		}
+			*dim = provider_count_array_dimensions(p);
 
-		/* Allocate array for this embedding */
 		embeddings[embedding_idx] = (float *) palloc(sizeof(float) * (*dim));
-		value_idx = 0;
+		parsed = provider_parse_float_array(&p, embeddings[embedding_idx], *dim);
 
-		/* Parse values */
-		while (value_idx < *dim && *p && *p != ']')
-		{
-			while (*p && (*p == ' ' || *p == ',' || *p == '\t' || *p == '\n'))
-				p++;
-
-			if (*p == ']')
-				break;
-
-			value_pos = 0;
-			while (*p && (isdigit(*p) || *p == '.' || *p == '-' || *p == '+' || *p == 'e' || *p == 'E'))
-			{
-				if (value_pos < sizeof(value_buf) - 1)
-					value_buf[value_pos++] = *p;
-				p++;
-			}
-			value_buf[value_pos] = '\0';
-
-			if (value_pos > 0)
-			{
-				embeddings[embedding_idx][value_idx] = atof(value_buf);
-				value_idx++;
-			}
-		}
-
-		if (value_idx != *dim)
+		if (parsed != *dim)
 		{
 			*error_msg = psprintf("Dimension mismatch: expected %d, got %d",
-								  *dim, value_idx);
-			goto error;
+								  *dim, parsed);
+			provider_free_embeddings(embeddings, embedding_idx + 1);
+			return NULL;
 		}
 
 		embedding_idx++;
-
-		/* Find next values array */
 		p = strstr(p, "\"values\"");
 	}
 
@@ -292,20 +250,9 @@ parse_gemini_batch_embedding_response(const char *json_response, int count,
 	{
 		*error_msg = psprintf("Expected %d embeddings, got %d",
 							  count, embedding_idx);
-		goto error;
+		provider_free_embeddings(embeddings, embedding_idx);
+		return NULL;
 	}
 
 	return embeddings;
-
-error:
-	if (embeddings != NULL)
-	{
-		for (int i = 0; i < embedding_idx; i++)
-		{
-			if (embeddings[i] != NULL)
-				pfree(embeddings[i]);
-		}
-		pfree(embeddings);
-	}
-	return NULL;
 }

--- a/src/provider_gemini.c
+++ b/src/provider_gemini.c
@@ -32,9 +32,7 @@ static float *gemini_generate(const char *text, int *dim, char **error_msg);
 static float **gemini_generate_batch(const char **texts, int count, int *dim,
 									 char **error_msg);
 
-/* Gemini-specific response parsers */
-static float *parse_gemini_embedding_response(const char *json_response,
-											  int *dim, char **error_msg);
+/* Gemini-specific response parser */
 static float **parse_gemini_batch_embedding_response(const char *json_response,
 													 int count, int *dim,
 													 char **error_msg);
@@ -98,70 +96,21 @@ gemini_cleanup(void)
 
 /*
  * Generate a single embedding
- *
- * Gemini single embedding endpoint:
- * POST {base_url}/models/{model}:embedContent
- * Body: {"model":"models/{model}","content":{"parts":[{"text":"..."}]}}
- * Response: {"embedding":{"values":[0.1,0.2,...]}}
  */
 static float *
 gemini_generate(const char *text, int *dim, char **error_msg)
 {
-	char *json_request;
-	char *url;
-	const char *base_url;
-	char *escaped;
-	char auth_header[512];
-	StringInfoData request_buf;
-	ResponseBuffer response;
-	float *embedding;
+	const char *texts[1] = {text};
+	float **embeddings;
+	float *result;
 
-	if (!provider_initialized)
-	{
-		if (!gemini_init(error_msg))
-			return NULL;
-	}
-
-	/* Build JSON request - Gemini format */
-	initStringInfo(&request_buf);
-	escaped = provider_escape_json_string(text);
-	appendStringInfo(&request_buf,
-					 "{\"model\":\"models/%s\","
-					 "\"content\":{\"parts\":[{\"text\":\"%s\"}]}}",
-					 pgedge_vectorizer_model, escaped);
-	pfree(escaped);
-	json_request = request_buf.data;
-
-	/* Build URL - model name is in the path */
-	base_url = (pgedge_vectorizer_api_url != NULL &&
-				pgedge_vectorizer_api_url[0] != '\0')
-		? pgedge_vectorizer_api_url
-		: GEMINI_DEFAULT_BASE_URL;
-	url = psprintf("%s/models/%s:embedContent", base_url,
-				   pgedge_vectorizer_model);
-
-	/* Build auth header - Gemini uses x-goog-api-key */
-	snprintf(auth_header, sizeof(auth_header),
-			 "x-goog-api-key: %s", api_key);
-
-	/* Perform request */
-	if (!provider_do_curl_request(url, auth_header, json_request,
-								  "Gemini", &response, error_msg))
-	{
-		pfree(json_request);
-		pfree(url);
-		if (response.data)
-			pfree(response.data);
+	embeddings = gemini_generate_batch(texts, 1, dim, error_msg);
+	if (embeddings == NULL)
 		return NULL;
-	}
 
-	/* Parse Gemini-specific response */
-	embedding = parse_gemini_embedding_response(response.data, dim, error_msg);
-
-	pfree(json_request);
-	pfree(url);
-	pfree(response.data);
-	return embedding;
+	result = embeddings[0];
+	pfree(embeddings);
+	return result;
 }
 
 /*
@@ -237,98 +186,6 @@ gemini_generate_batch(const char **texts, int count, int *dim, char **error_msg)
 	pfree(url);
 	pfree(response.data);
 	return embeddings;
-}
-
-/*
- * Parse Gemini single embedding response
- *
- * Expected format: {"embedding":{"values":[0.1,0.2,...]}}
- */
-static float *
-parse_gemini_embedding_response(const char *json_response, int *dim,
-								char **error_msg)
-{
-	const char *p;
-	float *embedding = NULL;
-	int value_idx = 0;
-	char value_buf[32];
-	int value_pos;
-
-	/* Find "values" array inside "embedding" object */
-	p = strstr(json_response, "\"embedding\"");
-	if (p == NULL)
-	{
-		*error_msg = pstrdup("Invalid response: 'embedding' field not found");
-		return NULL;
-	}
-
-	p = strstr(p, "\"values\"");
-	if (p == NULL)
-	{
-		*error_msg = pstrdup("Invalid response: 'values' field not found");
-		return NULL;
-	}
-
-	/* Find opening bracket */
-	p = strchr(p, '[');
-	if (p == NULL)
-	{
-		*error_msg = pstrdup("Invalid response: values array not found");
-		return NULL;
-	}
-	p++;
-
-	/* Count dimensions if not known */
-	if (*dim == 0)
-	{
-		const char *temp = p;
-		int comma_count = 0;
-		while (*temp && *temp != ']')
-		{
-			if (*temp == ',')
-				comma_count++;
-			temp++;
-		}
-		*dim = comma_count + 1;
-	}
-
-	/* Allocate array */
-	embedding = (float *) palloc(sizeof(float) * (*dim));
-
-	/* Parse values */
-	while (value_idx < *dim && *p && *p != ']')
-	{
-		while (*p && (*p == ' ' || *p == ',' || *p == '\t' || *p == '\n'))
-			p++;
-
-		if (*p == ']')
-			break;
-
-		value_pos = 0;
-		while (*p && (isdigit(*p) || *p == '.' || *p == '-' || *p == '+' || *p == 'e' || *p == 'E'))
-		{
-			if (value_pos < sizeof(value_buf) - 1)
-				value_buf[value_pos++] = *p;
-			p++;
-		}
-		value_buf[value_pos] = '\0';
-
-		if (value_pos > 0)
-		{
-			embedding[value_idx] = atof(value_buf);
-			value_idx++;
-		}
-	}
-
-	if (value_idx != *dim)
-	{
-		*error_msg = psprintf("Dimension mismatch: expected %d, got %d",
-							  *dim, value_idx);
-		pfree(embedding);
-		return NULL;
-	}
-
-	return embedding;
 }
 
 /*

--- a/src/provider_gemini.c
+++ b/src/provider_gemini.c
@@ -1,0 +1,454 @@
+/*-------------------------------------------------------------------------
+ *
+ * provider_gemini.c
+ *		Google Gemini embedding provider implementation
+ *
+ * Gemini uses a different API format from OpenAI:
+ * - Auth via x-goog-api-key header (not Bearer token)
+ * - Model name is part of the URL path
+ * - Different request/response JSON structure
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ *
+ *-------------------------------------------------------------------------
+ */
+#include "provider_common.h"
+
+/* Default base URL for Gemini API */
+#define GEMINI_DEFAULT_BASE_URL "https://generativelanguage.googleapis.com/v1beta"
+
+/*
+ * Static variables
+ */
+static char *api_key = NULL;
+static bool provider_initialized = false;
+
+/*
+ * Forward declarations
+ */
+static bool gemini_init(char **error_msg);
+static void gemini_cleanup(void);
+static float *gemini_generate(const char *text, int *dim, char **error_msg);
+static float **gemini_generate_batch(const char **texts, int count, int *dim,
+									 char **error_msg);
+
+/* Gemini-specific response parsers */
+static float *parse_gemini_embedding_response(const char *json_response,
+											  int *dim, char **error_msg);
+static float **parse_gemini_batch_embedding_response(const char *json_response,
+													 int count, int *dim,
+													 char **error_msg);
+
+/*
+ * Gemini Provider struct
+ */
+EmbeddingProvider GeminiProvider = {
+	.name = "gemini",
+	.init = gemini_init,
+	.cleanup = gemini_cleanup,
+	.generate = gemini_generate,
+	.generate_batch = gemini_generate_batch
+};
+
+/*
+ * Initialize Gemini provider
+ */
+static bool
+gemini_init(char **error_msg)
+{
+	if (provider_initialized)
+		return true;
+
+	curl_global_init(CURL_GLOBAL_DEFAULT);
+
+	/* Gemini always requires an API key */
+	api_key = provider_load_api_key(pgedge_vectorizer_api_key_file, error_msg);
+	if (api_key == NULL)
+	{
+		curl_global_cleanup();
+		return false;
+	}
+
+	provider_initialized = true;
+	elog(DEBUG1, "Gemini provider initialized successfully");
+	return true;
+}
+
+/*
+ * Cleanup Gemini provider
+ */
+static void
+gemini_cleanup(void)
+{
+	if (!provider_initialized)
+		return;
+
+	if (api_key != NULL)
+	{
+		/* flawfinder: ignore - api_key is palloc'd, always null-terminated */
+		memset(api_key, 0, strlen(api_key));
+		pfree(api_key);
+		api_key = NULL;
+	}
+
+	curl_global_cleanup();
+	provider_initialized = false;
+	elog(DEBUG1, "Gemini provider cleaned up");
+}
+
+/*
+ * Generate a single embedding
+ *
+ * Gemini single embedding endpoint:
+ * POST {base_url}/models/{model}:embedContent
+ * Body: {"model":"models/{model}","content":{"parts":[{"text":"..."}]}}
+ * Response: {"embedding":{"values":[0.1,0.2,...]}}
+ */
+static float *
+gemini_generate(const char *text, int *dim, char **error_msg)
+{
+	char *json_request;
+	char *url;
+	const char *base_url;
+	char *escaped;
+	char auth_header[512];
+	StringInfoData request_buf;
+	ResponseBuffer response;
+	float *embedding;
+
+	if (!provider_initialized)
+	{
+		if (!gemini_init(error_msg))
+			return NULL;
+	}
+
+	/* Build JSON request - Gemini format */
+	initStringInfo(&request_buf);
+	escaped = provider_escape_json_string(text);
+	appendStringInfo(&request_buf,
+					 "{\"model\":\"models/%s\","
+					 "\"content\":{\"parts\":[{\"text\":\"%s\"}]}}",
+					 pgedge_vectorizer_model, escaped);
+	pfree(escaped);
+	json_request = request_buf.data;
+
+	/* Build URL - model name is in the path */
+	base_url = (pgedge_vectorizer_api_url != NULL &&
+				pgedge_vectorizer_api_url[0] != '\0')
+		? pgedge_vectorizer_api_url
+		: GEMINI_DEFAULT_BASE_URL;
+	url = psprintf("%s/models/%s:embedContent", base_url,
+				   pgedge_vectorizer_model);
+
+	/* Build auth header - Gemini uses x-goog-api-key */
+	snprintf(auth_header, sizeof(auth_header),
+			 "x-goog-api-key: %s", api_key);
+
+	/* Perform request */
+	if (!provider_do_curl_request(url, auth_header, json_request,
+								  "Gemini", &response, error_msg))
+	{
+		pfree(json_request);
+		pfree(url);
+		if (response.data)
+			pfree(response.data);
+		return NULL;
+	}
+
+	/* Parse Gemini-specific response */
+	embedding = parse_gemini_embedding_response(response.data, dim, error_msg);
+
+	pfree(json_request);
+	pfree(url);
+	pfree(response.data);
+	return embedding;
+}
+
+/*
+ * Generate embeddings in batch
+ *
+ * Gemini batch endpoint:
+ * POST {base_url}/models/{model}:batchEmbedContents
+ * Body: {"requests":[{"model":"models/{model}","content":{"parts":[{"text":"..."}]}}, ...]}
+ * Response: {"embeddings":[{"values":[0.1,0.2,...]}, ...]}
+ */
+static float **
+gemini_generate_batch(const char **texts, int count, int *dim, char **error_msg)
+{
+	char *json_request;
+	char *url;
+	const char *base_url;
+	char auth_header[512];
+	StringInfoData request_buf;
+	ResponseBuffer response;
+	float **embeddings;
+
+	if (!provider_initialized)
+	{
+		if (!gemini_init(error_msg))
+			return NULL;
+	}
+
+	/* Build JSON request - Gemini batch format */
+	initStringInfo(&request_buf);
+	appendStringInfo(&request_buf, "{\"requests\":[");
+	for (int i = 0; i < count; i++)
+	{
+		char *escaped = provider_escape_json_string(texts[i]);
+		if (i > 0)
+			appendStringInfoChar(&request_buf, ',');
+		appendStringInfo(&request_buf,
+						 "{\"model\":\"models/%s\","
+						 "\"content\":{\"parts\":[{\"text\":\"%s\"}]}}",
+						 pgedge_vectorizer_model, escaped);
+		pfree(escaped);
+	}
+	appendStringInfo(&request_buf, "]}");
+	json_request = request_buf.data;
+
+	/* Build URL */
+	base_url = (pgedge_vectorizer_api_url != NULL &&
+				pgedge_vectorizer_api_url[0] != '\0')
+		? pgedge_vectorizer_api_url
+		: GEMINI_DEFAULT_BASE_URL;
+	url = psprintf("%s/models/%s:batchEmbedContents", base_url,
+				   pgedge_vectorizer_model);
+
+	/* Build auth header */
+	snprintf(auth_header, sizeof(auth_header),
+			 "x-goog-api-key: %s", api_key);
+
+	/* Perform request */
+	if (!provider_do_curl_request(url, auth_header, json_request,
+								  "Gemini", &response, error_msg))
+	{
+		pfree(json_request);
+		pfree(url);
+		if (response.data)
+			pfree(response.data);
+		return NULL;
+	}
+
+	/* Parse Gemini batch response */
+	embeddings = parse_gemini_batch_embedding_response(response.data, count,
+													   dim, error_msg);
+
+	pfree(json_request);
+	pfree(url);
+	pfree(response.data);
+	return embeddings;
+}
+
+/*
+ * Parse Gemini single embedding response
+ *
+ * Expected format: {"embedding":{"values":[0.1,0.2,...]}}
+ */
+static float *
+parse_gemini_embedding_response(const char *json_response, int *dim,
+								char **error_msg)
+{
+	const char *p;
+	float *embedding = NULL;
+	int value_idx = 0;
+	char value_buf[32];
+	int value_pos;
+
+	/* Find "values" array inside "embedding" object */
+	p = strstr(json_response, "\"embedding\"");
+	if (p == NULL)
+	{
+		*error_msg = pstrdup("Invalid response: 'embedding' field not found");
+		return NULL;
+	}
+
+	p = strstr(p, "\"values\"");
+	if (p == NULL)
+	{
+		*error_msg = pstrdup("Invalid response: 'values' field not found");
+		return NULL;
+	}
+
+	/* Find opening bracket */
+	p = strchr(p, '[');
+	if (p == NULL)
+	{
+		*error_msg = pstrdup("Invalid response: values array not found");
+		return NULL;
+	}
+	p++;
+
+	/* Count dimensions if not known */
+	if (*dim == 0)
+	{
+		const char *temp = p;
+		int comma_count = 0;
+		while (*temp && *temp != ']')
+		{
+			if (*temp == ',')
+				comma_count++;
+			temp++;
+		}
+		*dim = comma_count + 1;
+	}
+
+	/* Allocate array */
+	embedding = (float *) palloc(sizeof(float) * (*dim));
+
+	/* Parse values */
+	while (value_idx < *dim && *p && *p != ']')
+	{
+		while (*p && (*p == ' ' || *p == ',' || *p == '\t' || *p == '\n'))
+			p++;
+
+		if (*p == ']')
+			break;
+
+		value_pos = 0;
+		while (*p && (isdigit(*p) || *p == '.' || *p == '-' || *p == '+' || *p == 'e' || *p == 'E'))
+		{
+			if (value_pos < sizeof(value_buf) - 1)
+				value_buf[value_pos++] = *p;
+			p++;
+		}
+		value_buf[value_pos] = '\0';
+
+		if (value_pos > 0)
+		{
+			embedding[value_idx] = atof(value_buf);
+			value_idx++;
+		}
+	}
+
+	if (value_idx != *dim)
+	{
+		*error_msg = psprintf("Dimension mismatch: expected %d, got %d",
+							  *dim, value_idx);
+		pfree(embedding);
+		return NULL;
+	}
+
+	return embedding;
+}
+
+/*
+ * Parse Gemini batch embedding response
+ *
+ * Expected format: {"embeddings":[{"values":[0.1,0.2,...]},{"values":[...]}]}
+ */
+static float **
+parse_gemini_batch_embedding_response(const char *json_response, int count,
+									  int *dim, char **error_msg)
+{
+	const char *p;
+	float **embeddings = NULL;
+	int embedding_idx = 0;
+	int value_idx;
+	char value_buf[32];
+	int value_pos;
+
+	/* Allocate array for embeddings */
+	embeddings = (float **) palloc0(sizeof(float *) * count);
+
+	/* Find "embeddings" array */
+	p = strstr(json_response, "\"embeddings\"");
+	if (p == NULL)
+	{
+		*error_msg = pstrdup("Invalid response: 'embeddings' field not found");
+		goto error;
+	}
+
+	/* Find first "values" array */
+	p = strstr(p, "\"values\"");
+	if (p == NULL)
+	{
+		*error_msg = pstrdup("Invalid response: 'values' field not found");
+		goto error;
+	}
+
+	/* Process each embedding */
+	while (embedding_idx < count && p != NULL)
+	{
+		/* Find opening bracket */
+		p = strchr(p, '[');
+		if (p == NULL)
+			break;
+		p++;
+
+		/* Count dimensions if first embedding */
+		if (*dim == 0)
+		{
+			const char *temp = p;
+			int comma_count = 0;
+			while (*temp && *temp != ']')
+			{
+				if (*temp == ',')
+					comma_count++;
+				temp++;
+			}
+			*dim = comma_count + 1;
+		}
+
+		/* Allocate array for this embedding */
+		embeddings[embedding_idx] = (float *) palloc(sizeof(float) * (*dim));
+		value_idx = 0;
+
+		/* Parse values */
+		while (value_idx < *dim && *p && *p != ']')
+		{
+			while (*p && (*p == ' ' || *p == ',' || *p == '\t' || *p == '\n'))
+				p++;
+
+			if (*p == ']')
+				break;
+
+			value_pos = 0;
+			while (*p && (isdigit(*p) || *p == '.' || *p == '-' || *p == '+' || *p == 'e' || *p == 'E'))
+			{
+				if (value_pos < sizeof(value_buf) - 1)
+					value_buf[value_pos++] = *p;
+				p++;
+			}
+			value_buf[value_pos] = '\0';
+
+			if (value_pos > 0)
+			{
+				embeddings[embedding_idx][value_idx] = atof(value_buf);
+				value_idx++;
+			}
+		}
+
+		if (value_idx != *dim)
+		{
+			*error_msg = psprintf("Dimension mismatch: expected %d, got %d",
+								  *dim, value_idx);
+			goto error;
+		}
+
+		embedding_idx++;
+
+		/* Find next values array */
+		p = strstr(p, "\"values\"");
+	}
+
+	if (embedding_idx != count)
+	{
+		*error_msg = psprintf("Expected %d embeddings, got %d",
+							  count, embedding_idx);
+		goto error;
+	}
+
+	return embeddings;
+
+error:
+	if (embeddings != NULL)
+	{
+		for (int i = 0; i < embedding_idx; i++)
+		{
+			if (embeddings[i] != NULL)
+				pfree(embeddings[i]);
+		}
+		pfree(embeddings);
+	}
+	return NULL;
+}

--- a/src/provider_ollama.c
+++ b/src/provider_ollama.c
@@ -4,26 +4,17 @@
  *		Ollama local embedding provider implementation
  *
  * Ollama allows running local embedding models. This provider connects to
- * a local Ollama instance (default: http://localhost:11434).
+ * a local Ollama instance. Uses shared infrastructure from provider_common.c
+ * but keeps its own request format and response parser.
  *
  * Copyright (c) 2025 - 2026, pgEdge, Inc.
  *
  *-------------------------------------------------------------------------
  */
-#include "pgedge_vectorizer.h"
+#include "provider_common.h"
 
-#include <curl/curl.h>
-
-#include "utils/memutils.h"
-
-/*
- * Response buffer for libcurl
- */
-typedef struct
-{
-	char *data;
-	size_t size;
-} ResponseBuffer;
+/* Default base URL for Ollama */
+#define OLLAMA_DEFAULT_BASE_URL "http://localhost:11434"
 
 /*
  * Static variables
@@ -36,12 +27,12 @@ static bool provider_initialized = false;
 static bool ollama_init(char **error_msg);
 static void ollama_cleanup(void);
 static float *ollama_generate(const char *text, int *dim, char **error_msg);
-static float **ollama_generate_batch(const char **texts, int count, int *dim, char **error_msg);
+static float **ollama_generate_batch(const char **texts, int count, int *dim,
+									 char **error_msg);
 
-/* Helper functions */
-static char *escape_json_string(const char *str);
-static size_t write_callback(void *contents, size_t size, size_t nmemb, void *userp);
-static float *parse_ollama_embedding_response(const char *json_response, int *dim, char **error_msg);
+/* Ollama-specific response parser */
+static float *parse_ollama_embedding_response(const char *json_response,
+											  int *dim, char **error_msg);
 
 /*
  * Ollama Provider struct
@@ -63,10 +54,9 @@ ollama_init(char **error_msg)
 	if (provider_initialized)
 		return true;
 
-	/* Initialize curl globally */
 	curl_global_init(CURL_GLOBAL_DEFAULT);
 
-	/* Ollama doesn't require API key, but we verify the endpoint is reachable */
+	/* Ollama doesn't require API key */
 	provider_initialized = true;
 	elog(DEBUG1, "Ollama provider initialized successfully");
 	return true;
@@ -92,16 +82,13 @@ ollama_cleanup(void)
 static float *
 ollama_generate(const char *text, int *dim, char **error_msg)
 {
-	CURL *curl;
-	CURLcode res;
-	struct curl_slist *headers = NULL;
 	char *json_request;
 	char *url;
+	const char *base_url;
+	char *escaped;
 	StringInfoData request_buf;
 	ResponseBuffer response;
-	float *embedding = NULL;
-	long response_code;
-	char *escaped;
+	float *embedding;
 
 	if (!provider_initialized)
 	{
@@ -109,71 +96,38 @@ ollama_generate(const char *text, int *dim, char **error_msg)
 			return NULL;
 	}
 
-	/* Initialize response buffer */
-	response.data = palloc(1);
-	response.data[0] = '\0';
-	response.size = 0;
-
 	/* Build JSON request - Ollama API format */
 	initStringInfo(&request_buf);
-	escaped = escape_json_string(text);
+	escaped = provider_escape_json_string(text);
 	appendStringInfo(&request_buf, "{\"model\":\"%s\",\"prompt\":\"%s\"}",
 					 pgedge_vectorizer_model, escaped);
 	pfree(escaped);
 	json_request = request_buf.data;
 
 	/* Build URL */
-	url = psprintf("%s/api/embeddings", pgedge_vectorizer_api_url);
+	base_url = (pgedge_vectorizer_api_url != NULL &&
+				pgedge_vectorizer_api_url[0] != '\0')
+		? pgedge_vectorizer_api_url
+		: OLLAMA_DEFAULT_BASE_URL;
+	url = psprintf("%s/api/embeddings", base_url);
 
-	/* Initialize curl */
-	curl = curl_easy_init();
-	if (!curl)
+	/* Perform request - no auth header for Ollama */
+	if (!provider_do_curl_request(url, NULL, json_request,
+								  "Ollama", &response, error_msg))
 	{
-		*error_msg = pstrdup("Failed to initialize libcurl");
-		pfree(response.data);
+		pfree(json_request);
+		pfree(url);
+		if (response.data)
+			pfree(response.data);
 		return NULL;
 	}
 
-	/* Set up headers - Ollama doesn't require authentication */
-	headers = curl_slist_append(headers, "Content-Type: application/json; charset=utf-8");
-
-	/* Configure curl */
-	curl_easy_setopt(curl, CURLOPT_URL, url);
-	curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
-	curl_easy_setopt(curl, CURLOPT_POSTFIELDS, json_request);
-	/* flawfinder: ignore - json_request from cJSON is null-terminated */
-	curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, (long)strlen(json_request));
-	curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_callback);
-	curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response);
-	curl_easy_setopt(curl, CURLOPT_TIMEOUT, 300L);  /* 5 minute timeout */
-
-	/* Perform the request */
-	res = curl_easy_perform(curl);
-
-	if (res != CURLE_OK)
-	{
-		*error_msg = psprintf("curl_easy_perform() failed: %s", curl_easy_strerror(res));
-		goto cleanup;
-	}
-
-	/* Check HTTP response code */
-	curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &response_code);
-	if (response_code != 200)
-	{
-		*error_msg = psprintf("Ollama API returned HTTP %ld: %s",
-							  response_code, response.data);
-		goto cleanup;
-	}
-
-	/* Parse the response */
+	/* Parse Ollama-specific response */
 	embedding = parse_ollama_embedding_response(response.data, dim, error_msg);
 
-cleanup:
-	curl_slist_free_all(headers);
-	curl_easy_cleanup(curl);
 	pfree(json_request);
+	pfree(url);
 	pfree(response.data);
-
 	return embedding;
 }
 
@@ -181,7 +135,7 @@ cleanup:
  * Generate embeddings in batch
  *
  * Ollama API doesn't support batch requests, so we call the single
- * endpoint multiple times. This is less efficient but simpler.
+ * endpoint multiple times.
  */
 static float **
 ollama_generate_batch(const char **texts, int count, int *dim, char **error_msg)
@@ -195,16 +149,13 @@ ollama_generate_batch(const char **texts, int count, int *dim, char **error_msg)
 			return NULL;
 	}
 
-	/* Allocate array for embeddings */
 	embeddings = (float **) palloc0(sizeof(float *) * count);
 
-	/* Generate each embedding individually */
 	for (i = 0; i < count; i++)
 	{
 		embeddings[i] = ollama_generate(texts[i], dim, error_msg);
 		if (embeddings[i] == NULL)
 		{
-			/* Clean up on error */
 			for (int j = 0; j < i; j++)
 			{
 				if (embeddings[j] != NULL)
@@ -219,83 +170,13 @@ ollama_generate_batch(const char **texts, int count, int *dim, char **error_msg)
 }
 
 /*
- * Curl write callback
- */
-static size_t
-write_callback(void *contents, size_t size, size_t nmemb, void *userp)
-{
-	size_t realsize = size * nmemb;
-	ResponseBuffer *mem = (ResponseBuffer *) userp;
-
-	char *ptr = repalloc(mem->data, mem->size + realsize + 1);
-	if (!ptr)
-		return 0;  /* Out of memory */
-
-	mem->data = ptr;
-	/* flawfinder: ignore - buffer was realloced to mem->size + realsize + 1 */
-	memcpy(&(mem->data[mem->size]), contents, realsize);  /* nosemgrep */
-	mem->size += realsize;
-	mem->data[mem->size] = 0;
-
-	return realsize;
-}
-
-/*
- * Escape a string for JSON
- */
-static char *
-escape_json_string(const char *str)
-{
-	StringInfoData buf;
-	const char *p;
-
-	initStringInfo(&buf);
-
-	for (p = str; *p; p++)
-	{
-		switch (*p)
-		{
-			case '"':
-				appendStringInfoString(&buf, "\\\"");
-				break;
-			case '\\':
-				appendStringInfoString(&buf, "\\\\");
-				break;
-			case '\b':
-				appendStringInfoString(&buf, "\\b");
-				break;
-			case '\f':
-				appendStringInfoString(&buf, "\\f");
-				break;
-			case '\n':
-				appendStringInfoString(&buf, "\\n");
-				break;
-			case '\r':
-				appendStringInfoString(&buf, "\\r");
-				break;
-			case '\t':
-				appendStringInfoString(&buf, "\\t");
-				break;
-			default:
-				if ((unsigned char) *p < 32)
-					appendStringInfo(&buf, "\\u%04x", (unsigned char) *p);
-				else
-					appendStringInfoChar(&buf, *p);
-				break;
-		}
-	}
-
-	return buf.data;
-}
-
-/*
  * Parse Ollama embedding response
  *
- * Expected format:
- * {"embedding":[0.1,0.2,0.3,...]}
+ * Expected format: {"embedding":[0.1,0.2,0.3,...]}
  */
 static float *
-parse_ollama_embedding_response(const char *json_response, int *dim, char **error_msg)
+parse_ollama_embedding_response(const char *json_response, int *dim,
+								char **error_msg)
 {
 	const char *p;
 	float *embedding = NULL;
@@ -340,14 +221,12 @@ parse_ollama_embedding_response(const char *json_response, int *dim, char **erro
 	/* Parse values */
 	while (value_idx < *dim && *p && *p != ']')
 	{
-		/* Skip whitespace and commas */
 		while (*p && (*p == ' ' || *p == ',' || *p == '\t' || *p == '\n'))
 			p++;
 
 		if (*p == ']')
 			break;
 
-		/* Read numeric value */
 		value_pos = 0;
 		while (*p && (isdigit(*p) || *p == '.' || *p == '-' || *p == '+' || *p == 'e' || *p == 'E'))
 		{
@@ -366,7 +245,8 @@ parse_ollama_embedding_response(const char *json_response, int *dim, char **erro
 
 	if (value_idx != *dim)
 	{
-		*error_msg = psprintf("Dimension mismatch: expected %d, got %d", *dim, value_idx);
+		*error_msg = psprintf("Dimension mismatch: expected %d, got %d",
+							  *dim, value_idx);
 		pfree(embedding);
 		return NULL;
 	}

--- a/src/provider_ollama.c
+++ b/src/provider_ollama.c
@@ -179,12 +179,9 @@ parse_ollama_embedding_response(const char *json_response, int *dim,
 								char **error_msg)
 {
 	const char *p;
-	float *embedding = NULL;
-	int value_idx = 0;
-	char value_buf[32];
-	int value_pos;
+	float *embedding;
+	int parsed;
 
-	/* Find "embedding" array */
 	p = strstr(json_response, "\"embedding\"");
 	if (p == NULL)
 	{
@@ -192,7 +189,6 @@ parse_ollama_embedding_response(const char *json_response, int *dim,
 		return NULL;
 	}
 
-	/* Find opening bracket */
 	p = strchr(p, '[');
 	if (p == NULL)
 	{
@@ -201,52 +197,16 @@ parse_ollama_embedding_response(const char *json_response, int *dim,
 	}
 	p++;
 
-	/* Count dimensions if not known */
 	if (*dim == 0)
-	{
-		const char *temp = p;
-		int comma_count = 0;
-		while (*temp && *temp != ']')
-		{
-			if (*temp == ',')
-				comma_count++;
-			temp++;
-		}
-		*dim = comma_count + 1;
-	}
+		*dim = provider_count_array_dimensions(p);
 
-	/* Allocate array for embedding */
 	embedding = (float *) palloc(sizeof(float) * (*dim));
+	parsed = provider_parse_float_array(&p, embedding, *dim);
 
-	/* Parse values */
-	while (value_idx < *dim && *p && *p != ']')
-	{
-		while (*p && (*p == ' ' || *p == ',' || *p == '\t' || *p == '\n'))
-			p++;
-
-		if (*p == ']')
-			break;
-
-		value_pos = 0;
-		while (*p && (isdigit(*p) || *p == '.' || *p == '-' || *p == '+' || *p == 'e' || *p == 'E'))
-		{
-			if (value_pos < sizeof(value_buf) - 1)
-				value_buf[value_pos++] = *p;
-			p++;
-		}
-		value_buf[value_pos] = '\0';
-
-		if (value_pos > 0)
-		{
-			embedding[value_idx] = atof(value_buf);
-			value_idx++;
-		}
-	}
-
-	if (value_idx != *dim)
+	if (parsed != *dim)
 	{
 		*error_msg = psprintf("Dimension mismatch: expected %d, got %d",
-							  *dim, value_idx);
+							  *dim, parsed);
 		pfree(embedding);
 		return NULL;
 	}

--- a/src/provider_openai.c
+++ b/src/provider_openai.c
@@ -3,30 +3,18 @@
  * provider_openai.c
  *		OpenAI embedding provider implementation
  *
- * This file implements the OpenAI embedding API integration using libcurl.
+ * Uses shared infrastructure from provider_common.c. Supports custom
+ * base URLs for OpenAI-compatible local providers (LM Studio, Docker
+ * Model Runner, EXO) where API key is optional.
  *
  * Copyright (c) 2025 - 2026, pgEdge, Inc.
  *
  *-------------------------------------------------------------------------
  */
-#include "pgedge_vectorizer.h"
+#include "provider_common.h"
 
-#include <curl/curl.h>
-#include <sys/stat.h>
-#include <unistd.h>
-
-#include "utils/memutils.h"
-
-/* For JSON parsing - we'll use a simple manual parser */
-
-/*
- * Response buffer for libcurl
- */
-typedef struct
-{
-	char *data;
-	size_t size;
-} ResponseBuffer;
+/* Default base URL for OpenAI API */
+#define OPENAI_DEFAULT_BASE_URL "https://api.openai.com/v1"
 
 /*
  * Static variables
@@ -40,14 +28,8 @@ static bool provider_initialized = false;
 static bool openai_init(char **error_msg);
 static void openai_cleanup(void);
 static float *openai_generate(const char *text, int *dim, char **error_msg);
-static float **openai_generate_batch(const char **texts, int count, int *dim, char **error_msg);
-
-/* Helper functions */
-static char *load_api_key(const char *filepath, char **error_msg);
-static char *expand_tilde(const char *path);
-static char *escape_json_string(const char *str);
-static size_t write_callback(void *contents, size_t size, size_t nmemb, void *userp);
-static float **parse_batch_embedding_response(const char *json_response, int count, int *dim, char **error_msg);
+static float **openai_generate_batch(const char **texts, int count, int *dim,
+									 char **error_msg);
 
 /*
  * OpenAI Provider struct
@@ -62,22 +44,40 @@ EmbeddingProvider OpenAIProvider = {
 
 /*
  * Initialize OpenAI provider
+ *
+ * API key is required when using the default OpenAI URL. When a custom
+ * URL is set (for local OpenAI-compatible providers), key loading is
+ * attempted but failure is not fatal.
  */
 static bool
 openai_init(char **error_msg)
 {
+	bool using_custom_url;
+
 	if (provider_initialized)
 		return true;
 
 	/* Initialize curl globally */
 	curl_global_init(CURL_GLOBAL_DEFAULT);
 
+	/* Determine if using a custom URL */
+	using_custom_url = (pgedge_vectorizer_api_url != NULL &&
+						pgedge_vectorizer_api_url[0] != '\0');
+
 	/* Load API key */
-	api_key = load_api_key(pgedge_vectorizer_api_key_file, error_msg);
+	api_key = provider_load_api_key(pgedge_vectorizer_api_key_file, error_msg);
 	if (api_key == NULL)
 	{
-		curl_global_cleanup();
-		return false;
+		if (!using_custom_url)
+		{
+			/* Default OpenAI URL requires an API key */
+			curl_global_cleanup();
+			return false;
+		}
+
+		/* Custom URL: key is optional (local provider) */
+		elog(DEBUG1, "OpenAI provider: no API key loaded (custom URL, key optional)");
+		*error_msg = NULL;  /* Clear the error */
 	}
 
 	provider_initialized = true;
@@ -117,15 +117,12 @@ openai_generate(const char *text, int *dim, char **error_msg)
 	float **embeddings;
 	float *result;
 
-	/* Use batch function with count=1 */
 	embeddings = openai_generate_batch(texts, 1, dim, error_msg);
 	if (embeddings == NULL)
 		return NULL;
 
-	/* Extract the single embedding */
 	result = embeddings[0];
 	pfree(embeddings);
-
 	return result;
 }
 
@@ -135,16 +132,13 @@ openai_generate(const char *text, int *dim, char **error_msg)
 static float **
 openai_generate_batch(const char **texts, int count, int *dim, char **error_msg)
 {
-	CURL *curl;
-	CURLcode res;
-	struct curl_slist *headers = NULL;
 	char *json_request;
 	char *url;
-	StringInfoData request_buf;
-	ResponseBuffer response;
+	const char *base_url;
 	char auth_header[512];
-	float **embeddings = NULL;
-	long response_code;
+	const char *auth_header_ptr = NULL;
+	ResponseBuffer response;
+	float **embeddings;
 
 	if (!provider_initialized)
 	{
@@ -152,365 +146,42 @@ openai_generate_batch(const char **texts, int count, int *dim, char **error_msg)
 			return NULL;
 	}
 
-	/* Initialize response buffer */
-	response.data = palloc(1);
-	response.data[0] = '\0';
-	response.size = 0;
-
-	/* Build JSON request */
-	initStringInfo(&request_buf);
-	appendStringInfo(&request_buf, "{\"input\":[");
-	for (int i = 0; i < count; i++)
-	{
-		char *escaped = escape_json_string(texts[i]);
-		if (i > 0)
-			appendStringInfoChar(&request_buf, ',');
-		appendStringInfo(&request_buf, "\"%s\"", escaped);
-		pfree(escaped);
-	}
-	appendStringInfo(&request_buf, "],\"model\":\"%s\"}", pgedge_vectorizer_model);
-	json_request = request_buf.data;
+	/* Build request body */
+	json_request = provider_build_openai_request(texts, count,
+												 pgedge_vectorizer_model);
 
 	/* Build URL */
-	url = psprintf("%s/embeddings", pgedge_vectorizer_api_url);
+	base_url = (pgedge_vectorizer_api_url != NULL &&
+				pgedge_vectorizer_api_url[0] != '\0')
+		? pgedge_vectorizer_api_url
+		: OPENAI_DEFAULT_BASE_URL;
+	url = psprintf("%s/embeddings", base_url);
 
-	/* Initialize curl */
-	curl = curl_easy_init();
-	if (!curl)
+	/* Build auth header if we have a key */
+	if (api_key != NULL)
 	{
-		*error_msg = pstrdup("Failed to initialize libcurl");
-		pfree(response.data);
+		snprintf(auth_header, sizeof(auth_header),
+				 "Authorization: Bearer %s", api_key);
+		auth_header_ptr = auth_header;
+	}
+
+	/* Perform request */
+	if (!provider_do_curl_request(url, auth_header_ptr, json_request,
+								  "OpenAI", &response, error_msg))
+	{
+		pfree(json_request);
+		pfree(url);
+		if (response.data)
+			pfree(response.data);
 		return NULL;
 	}
 
-	/* Set up headers */
-	headers = curl_slist_append(headers, "Content-Type: application/json; charset=utf-8");
-	snprintf(auth_header, sizeof(auth_header), "Authorization: Bearer %s", api_key);
-	headers = curl_slist_append(headers, auth_header);
+	/* Parse response */
+	embeddings = provider_parse_openai_embedding_response(response.data, count,
+														  dim, error_msg);
 
-	/* Configure curl */
-	curl_easy_setopt(curl, CURLOPT_URL, url);
-	curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
-	curl_easy_setopt(curl, CURLOPT_POSTFIELDS, json_request);
-	/* flawfinder: ignore - json_request from cJSON is null-terminated */
-	curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, (long)strlen(json_request));
-	curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_callback);
-	curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response);
-	curl_easy_setopt(curl, CURLOPT_TIMEOUT, 300L);  /* 5 minute timeout */
-
-	/* Perform the request */
-	res = curl_easy_perform(curl);
-
-	if (res != CURLE_OK)
-	{
-		*error_msg = psprintf("curl_easy_perform() failed: %s", curl_easy_strerror(res));
-		goto cleanup;
-	}
-
-	/* Check HTTP response code */
-	curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &response_code);
-	if (response_code != 200)
-	{
-		*error_msg = psprintf("OpenAI API returned HTTP %ld: %s",
-							  response_code, response.data);
-		goto cleanup;
-	}
-
-	/* Parse the response */
-	embeddings = parse_batch_embedding_response(response.data, count, dim, error_msg);
-
-cleanup:
-	curl_slist_free_all(headers);
-	curl_easy_cleanup(curl);
 	pfree(json_request);
+	pfree(url);
 	pfree(response.data);
-
 	return embeddings;
-}
-
-/*
- * Curl write callback
- */
-static size_t
-write_callback(void *contents, size_t size, size_t nmemb, void *userp)
-{
-	size_t realsize = size * nmemb;
-	ResponseBuffer *mem = (ResponseBuffer *) userp;
-
-	char *ptr = repalloc(mem->data, mem->size + realsize + 1);
-	if (!ptr)
-		return 0;  /* Out of memory */
-
-	mem->data = ptr;
-	/* flawfinder: ignore - buffer was realloced to mem->size + realsize + 1 */
-	memcpy(&(mem->data[mem->size]), contents, realsize);  /* nosemgrep */
-	mem->size += realsize;
-	mem->data[mem->size] = 0;
-
-	return realsize;
-}
-
-/*
- * Load API key from file
- */
-static char *
-load_api_key(const char *filepath, char **error_msg)
-{
-	FILE *fp;
-	char *expanded_path;
-	StringInfoData key_buf;
-	int c;
-	struct stat st;
-
-	if (filepath == NULL || filepath[0] == '\0')
-	{
-		*error_msg = pstrdup("API key file path is not configured");
-		return NULL;
-	}
-
-	/* Expand tilde */
-	expanded_path = expand_tilde(filepath);
-
-	/* Check file exists and has proper permissions */
-	if (stat(expanded_path, &st) != 0)
-	{
-		*error_msg = psprintf("API key file not found: %s", expanded_path);
-		pfree(expanded_path);
-		return NULL;
-	}
-
-	/* Warn if file is world-readable */
-	if (st.st_mode & (S_IRWXG | S_IRWXO))
-	{
-		elog(WARNING, "API key file %s has permissive permissions (should be 0600)",
-			 expanded_path);
-	}
-
-	/* Open and read file */
-	fp = fopen(expanded_path, "r");
-	if (fp == NULL)
-	{
-		*error_msg = psprintf("Failed to open API key file: %s", expanded_path);
-		pfree(expanded_path);
-		return NULL;
-	}
-
-	initStringInfo(&key_buf);
-
-	/* Read the file, trimming whitespace */
-	while ((c = fgetc(fp)) != EOF)
-	{
-		if (c != '\n' && c != '\r' && c != ' ' && c != '\t')
-			appendStringInfoChar(&key_buf, c);
-	}
-
-	fclose(fp);
-	pfree(expanded_path);
-
-	if (key_buf.len == 0)
-	{
-		*error_msg = pstrdup("API key file is empty");
-		pfree(key_buf.data);
-		return NULL;
-	}
-
-	/* Copy to TopMemoryContext so it persists across transactions */
-	{
-		char *persistent_key;
-		MemoryContext oldcontext;
-
-		oldcontext = MemoryContextSwitchTo(TopMemoryContext);
-		persistent_key = pstrdup(key_buf.data);
-		MemoryContextSwitchTo(oldcontext);
-
-		pfree(key_buf.data);
-		return persistent_key;
-	}
-}
-
-/*
- * Expand tilde in path
- */
-static char *
-expand_tilde(const char *path)
-{
-	if (path[0] == '~' && (path[1] == '/' || path[1] == '\0'))
-	{
-		const char *home = getenv("HOME");
-		if (home)
-			return psprintf("%s%s", home, path + 1);
-	}
-	return pstrdup(path);
-}
-
-/*
- * Escape a string for JSON
- */
-static char *
-escape_json_string(const char *str)
-{
-	StringInfoData buf;
-	const char *p;
-
-	initStringInfo(&buf);
-
-	for (p = str; *p; p++)
-	{
-		switch (*p)
-		{
-			case '"':
-				appendStringInfoString(&buf, "\\\"");
-				break;
-			case '\\':
-				appendStringInfoString(&buf, "\\\\");
-				break;
-			case '\b':
-				appendStringInfoString(&buf, "\\b");
-				break;
-			case '\f':
-				appendStringInfoString(&buf, "\\f");
-				break;
-			case '\n':
-				appendStringInfoString(&buf, "\\n");
-				break;
-			case '\r':
-				appendStringInfoString(&buf, "\\r");
-				break;
-			case '\t':
-				appendStringInfoString(&buf, "\\t");
-				break;
-			default:
-				if ((unsigned char) *p < 32)
-					appendStringInfo(&buf, "\\u%04x", (unsigned char) *p);
-				else
-					appendStringInfoChar(&buf, *p);
-				break;
-		}
-	}
-
-	return buf.data;
-}
-
-/*
- * Parse batch embedding response
- *
- * Expected format:
- * {"data":[{"embedding":[0.1,0.2,...]},{"embedding":[...]}],...}
- *
- * This is a simplified parser. For production, consider using a robust JSON library.
- */
-static float **
-parse_batch_embedding_response(const char *json_response, int count, int *dim, char **error_msg)
-{
-	const char *p;
-	float **embeddings = NULL;
-	int embedding_idx = 0;
-	int value_idx;
-	char value_buf[32];
-	int value_pos;
-
-	/* Allocate array for embeddings */
-	embeddings = (float **) palloc0(sizeof(float *) * count);
-
-	/* Find "data" array */
-	p = strstr(json_response, "\"data\"");
-	if (p == NULL)
-	{
-		*error_msg = pstrdup("Invalid response: 'data' field not found");
-		goto error;
-	}
-
-	/* Find first embedding array */
-	p = strstr(p, "\"embedding\"");
-	if (p == NULL)
-	{
-		*error_msg = pstrdup("Invalid response: 'embedding' field not found");
-		goto error;
-	}
-
-	/* Process each embedding */
-	while (embedding_idx < count && p != NULL)
-	{
-		/* Find opening bracket */
-		p = strchr(p, '[');
-		if (p == NULL)
-			break;
-		p++;
-
-		/* Count dimensions if first embedding */
-		if (*dim == 0)
-		{
-			const char *temp = p;
-			int comma_count = 0;
-			while (*temp && *temp != ']')
-			{
-				if (*temp == ',')
-					comma_count++;
-				temp++;
-			}
-			*dim = comma_count + 1;
-		}
-
-		/* Allocate array for this embedding */
-		embeddings[embedding_idx] = (float *) palloc(sizeof(float) * (*dim));
-		value_idx = 0;
-
-		/* Parse values */
-		while (value_idx < *dim && *p && *p != ']')
-		{
-			/* Skip whitespace and commas */
-			while (*p && (*p == ' ' || *p == ',' || *p == '\t' || *p == '\n'))
-				p++;
-
-			if (*p == ']')
-				break;
-
-			/* Read numeric value */
-			value_pos = 0;
-			while (*p && (isdigit(*p) || *p == '.' || *p == '-' || *p == '+' || *p == 'e' || *p == 'E'))
-			{
-				if (value_pos < sizeof(value_buf) - 1)
-					value_buf[value_pos++] = *p;
-				p++;
-			}
-			value_buf[value_pos] = '\0';
-
-			if (value_pos > 0)
-			{
-				embeddings[embedding_idx][value_idx] = atof(value_buf);
-				value_idx++;
-			}
-		}
-
-		if (value_idx != *dim)
-		{
-			*error_msg = psprintf("Dimension mismatch: expected %d, got %d", *dim, value_idx);
-			goto error;
-		}
-
-		embedding_idx++;
-
-		/* Find next embedding */
-		p = strstr(p, "\"embedding\"");
-	}
-
-	if (embedding_idx != count)
-	{
-		*error_msg = psprintf("Expected %d embeddings, got %d", count, embedding_idx);
-		goto error;
-	}
-
-	return embeddings;
-
-error:
-	if (embeddings != NULL)
-	{
-		for (int i = 0; i < embedding_idx; i++)
-		{
-			if (embeddings[i] != NULL)
-				pfree(embeddings[i]);
-		}
-		pfree(embeddings);
-	}
-	return NULL;
 }

--- a/src/provider_openai.c
+++ b/src/provider_openai.c
@@ -3,32 +3,18 @@
  * provider_openai.c
  *		OpenAI embedding provider implementation
  *
- * This file implements the OpenAI embedding API integration using libcurl.
+ * Uses shared infrastructure from provider_common.c. Supports custom
+ * base URLs for OpenAI-compatible local providers (LM Studio, Docker
+ * Model Runner, EXO) where API key is optional.
  *
  * Copyright (c) 2025 - 2026, pgEdge, Inc.
  *
  *-------------------------------------------------------------------------
  */
-#include "pgedge_vectorizer.h"
+#include "provider_common.h"
 
-#include <curl/curl.h>
-#include <fcntl.h>
-#include <pwd.h>
-#include <sys/stat.h>
-#include <unistd.h>
-
-#include "utils/memutils.h"
-
-/* For JSON parsing - we'll use a simple manual parser */
-
-/*
- * Response buffer for libcurl
- */
-typedef struct
-{
-	char *data;
-	size_t size;
-} ResponseBuffer;
+/* Default base URL for OpenAI API */
+#define OPENAI_DEFAULT_BASE_URL "https://api.openai.com/v1"
 
 /*
  * Static variables
@@ -42,14 +28,8 @@ static bool provider_initialized = false;
 static bool openai_init(char **error_msg);
 static void openai_cleanup(void);
 static float *openai_generate(const char *text, int *dim, char **error_msg);
-static float **openai_generate_batch(const char **texts, int count, int *dim, char **error_msg);
-
-/* Helper functions */
-static char *load_api_key(const char *filepath, char **error_msg);
-static char *expand_tilde(const char *path);
-static char *escape_json_string(const char *str);
-static size_t write_callback(void *contents, size_t size, size_t nmemb, void *userp);
-static float **parse_batch_embedding_response(const char *json_response, int count, int *dim, char **error_msg);
+static float **openai_generate_batch(const char **texts, int count, int *dim,
+									 char **error_msg);
 
 /*
  * OpenAI Provider struct
@@ -64,22 +44,40 @@ EmbeddingProvider OpenAIProvider = {
 
 /*
  * Initialize OpenAI provider
+ *
+ * API key is required when using the default OpenAI URL. When a custom
+ * URL is set (for local OpenAI-compatible providers), key loading is
+ * attempted but failure is not fatal.
  */
 static bool
 openai_init(char **error_msg)
 {
+	bool using_custom_url;
+
 	if (provider_initialized)
 		return true;
 
 	/* Initialize curl globally */
 	curl_global_init(CURL_GLOBAL_DEFAULT);
 
+	/* Determine if using a custom URL */
+	using_custom_url = (pgedge_vectorizer_api_url != NULL &&
+						pgedge_vectorizer_api_url[0] != '\0');
+
 	/* Load API key */
-	api_key = load_api_key(pgedge_vectorizer_api_key_file, error_msg);
+	api_key = provider_load_api_key(pgedge_vectorizer_api_key_file, error_msg);
 	if (api_key == NULL)
 	{
-		curl_global_cleanup();
-		return false;
+		if (!using_custom_url)
+		{
+			/* Default OpenAI URL requires an API key */
+			curl_global_cleanup();
+			return false;
+		}
+
+		/* Custom URL: key is optional (local provider) */
+		elog(DEBUG1, "OpenAI provider: no API key loaded (custom URL, key optional)");
+		*error_msg = NULL;  /* Clear the error */
 	}
 
 	provider_initialized = true;
@@ -119,15 +117,12 @@ openai_generate(const char *text, int *dim, char **error_msg)
 	float **embeddings;
 	float *result;
 
-	/* Use batch function with count=1 */
 	embeddings = openai_generate_batch(texts, 1, dim, error_msg);
 	if (embeddings == NULL)
 		return NULL;
 
-	/* Extract the single embedding */
 	result = embeddings[0];
 	pfree(embeddings);
-
 	return result;
 }
 
@@ -137,16 +132,13 @@ openai_generate(const char *text, int *dim, char **error_msg)
 static float **
 openai_generate_batch(const char **texts, int count, int *dim, char **error_msg)
 {
-	CURL *curl;
-	CURLcode res;
-	struct curl_slist *headers = NULL;
 	char *json_request;
 	char *url;
-	StringInfoData request_buf;
-	ResponseBuffer response;
+	const char *base_url;
 	char auth_header[512];
-	float **embeddings = NULL;
-	long response_code;
+	const char *auth_header_ptr = NULL;
+	ResponseBuffer response;
+	float **embeddings;
 
 	if (!provider_initialized)
 	{
@@ -154,427 +146,42 @@ openai_generate_batch(const char **texts, int count, int *dim, char **error_msg)
 			return NULL;
 	}
 
-	/* Initialize response buffer */
-	response.data = palloc(1);
-	response.data[0] = '\0';
-	response.size = 0;
-
-	/* Build JSON request */
-	initStringInfo(&request_buf);
-	appendStringInfo(&request_buf, "{\"input\":[");
-	for (int i = 0; i < count; i++)
-	{
-		char *escaped = escape_json_string(texts[i]);
-		if (i > 0)
-			appendStringInfoChar(&request_buf, ',');
-		appendStringInfo(&request_buf, "\"%s\"", escaped);
-		pfree(escaped);
-	}
-	appendStringInfo(&request_buf, "],\"model\":\"%s\"}", pgedge_vectorizer_model);
-	json_request = request_buf.data;
+	/* Build request body */
+	json_request = provider_build_openai_request(texts, count,
+												 pgedge_vectorizer_model);
 
 	/* Build URL */
-	url = psprintf("%s/embeddings", pgedge_vectorizer_api_url);
+	base_url = (pgedge_vectorizer_api_url != NULL &&
+				pgedge_vectorizer_api_url[0] != '\0')
+		? pgedge_vectorizer_api_url
+		: OPENAI_DEFAULT_BASE_URL;
+	url = psprintf("%s/embeddings", base_url);
 
-	/* Initialize curl */
-	curl = curl_easy_init();
-	if (!curl)
+	/* Build auth header if we have a key */
+	if (api_key != NULL)
 	{
-		*error_msg = pstrdup("Failed to initialize libcurl");
-		pfree(response.data);
+		snprintf(auth_header, sizeof(auth_header),
+				 "Authorization: Bearer %s", api_key);
+		auth_header_ptr = auth_header;
+	}
+
+	/* Perform request */
+	if (!provider_do_curl_request(url, auth_header_ptr, json_request,
+								  "OpenAI", &response, error_msg))
+	{
+		pfree(json_request);
+		pfree(url);
+		if (response.data)
+			pfree(response.data);
 		return NULL;
 	}
 
-	/* Set up headers */
-	headers = curl_slist_append(headers, "Content-Type: application/json; charset=utf-8");
-	snprintf(auth_header, sizeof(auth_header), "Authorization: Bearer %s", api_key);
-	headers = curl_slist_append(headers, auth_header);
+	/* Parse response */
+	embeddings = provider_parse_openai_embedding_response(response.data, count,
+														  dim, error_msg);
 
-	/* Configure curl */
-	curl_easy_setopt(curl, CURLOPT_URL, url);
-	curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
-	curl_easy_setopt(curl, CURLOPT_POSTFIELDS, json_request);
-	/* flawfinder: ignore - json_request from cJSON is null-terminated */
-	curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, (long)strlen(json_request));
-	curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_callback);
-	curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response);
-	curl_easy_setopt(curl, CURLOPT_TIMEOUT, 300L);  /* 5 minute timeout */
-
-	/* Perform the request */
-	res = curl_easy_perform(curl);
-
-	if (res != CURLE_OK)
-	{
-		*error_msg = psprintf("curl_easy_perform() failed: %s", curl_easy_strerror(res));
-		goto cleanup;
-	}
-
-	/* Check HTTP response code */
-	curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &response_code);
-	if (response_code != 200)
-	{
-		*error_msg = psprintf("OpenAI API returned HTTP %ld: %s",
-							  response_code, response.data);
-		goto cleanup;
-	}
-
-	/* Parse the response */
-	embeddings = parse_batch_embedding_response(response.data, count, dim, error_msg);
-
-cleanup:
-	curl_slist_free_all(headers);
-	curl_easy_cleanup(curl);
 	pfree(json_request);
+	pfree(url);
 	pfree(response.data);
-
 	return embeddings;
-}
-
-/*
- * Curl write callback
- */
-static size_t
-write_callback(void *contents, size_t size, size_t nmemb, void *userp)
-{
-	size_t realsize = size * nmemb;
-	ResponseBuffer *mem = (ResponseBuffer *) userp;
-
-	char *ptr = repalloc(mem->data, mem->size + realsize + 1);
-	if (!ptr)
-		return 0;  /* Out of memory */
-
-	mem->data = ptr;
-	/* flawfinder: ignore - buffer was realloced to mem->size + realsize + 1 */
-	memcpy(&(mem->data[mem->size]), contents, realsize);  /* nosemgrep */
-	mem->size += realsize;
-	mem->data[mem->size] = 0;
-
-	return realsize;
-}
-
-/*
- * Load API key from file
- */
-static char *
-load_api_key(const char *filepath, char **error_msg)
-{
-	FILE *fp;
-	char *expanded_path;
-	StringInfoData key_buf;
-	int c;
-	int fd;
-	size_t bytes_read;
-	struct stat st;
-
-	if (filepath == NULL || filepath[0] == '\0')
-	{
-		*error_msg = pstrdup("API key file path is not configured");
-		return NULL;
-	}
-
-	/* Expand tilde */
-	expanded_path = expand_tilde(filepath);
-
-	/*
-	 * Open the file first, then validate with fstat() on the open descriptor
-	 * to avoid TOCTOU races between stat() and fopen().
-	 */
-	fd = open(expanded_path, O_RDONLY | O_CLOEXEC);
-	if (fd < 0)
-	{
-		*error_msg = psprintf("Failed to open API key file: %s", expanded_path);
-		pfree(expanded_path);
-		return NULL;
-	}
-
-	if (fstat(fd, &st) != 0)
-	{
-		*error_msg = psprintf("Failed to stat API key file: %s", expanded_path);
-		close(fd);
-		pfree(expanded_path);
-		return NULL;
-	}
-
-	/* Reject non-regular files (e.g. devices, FIFOs, directories) */
-	if (!S_ISREG(st.st_mode))
-	{
-		*error_msg = psprintf("API key path is not a regular file: %s",
-							  expanded_path);
-		close(fd);
-		pfree(expanded_path);
-		return NULL;
-	}
-
-	/* Warn if file is world-readable */
-	if (st.st_mode & (S_IRWXG | S_IRWXO))
-	{
-		elog(WARNING, "API key file %s has permissive permissions (should be 0600)",
-			 expanded_path);
-	}
-
-	/* Reject unreasonably large files before reading (CWE-20) */
-	if (st.st_size > MAX_API_KEY_FILE_SIZE)
-	{
-		*error_msg = psprintf("API key file exceeds maximum allowed size of %d bytes",
-							  MAX_API_KEY_FILE_SIZE);
-		close(fd);
-		pfree(expanded_path);
-		return NULL;
-	}
-
-	/* Convert to FILE* for character-at-a-time reading */
-	fp = fdopen(fd, "r");
-	if (fp == NULL)
-	{
-		*error_msg = psprintf("Failed to open API key file stream: %s",
-							  expanded_path);
-		close(fd);
-		pfree(expanded_path);
-		return NULL;
-	}
-
-	initStringInfo(&key_buf);
-
-	/*
-	 * Read the file, trimming whitespace.  Enforce a runtime size limit as a
-	 * defence-in-depth measure — the file could have grown since fstat().
-	 */
-	bytes_read = 0;
-	while ((c = fgetc(fp)) != EOF)
-	{
-		bytes_read++;
-		if (bytes_read > MAX_API_KEY_FILE_SIZE)
-		{
-			*error_msg = psprintf("API key file exceeds maximum allowed size "
-								  "of %d bytes during read",
-								  MAX_API_KEY_FILE_SIZE);
-			fclose(fp);
-			pfree(key_buf.data);
-			pfree(expanded_path);
-			return NULL;
-		}
-		if (c != '\n' && c != '\r' && c != ' ' && c != '\t')
-			appendStringInfoChar(&key_buf, c);
-	}
-
-	fclose(fp);	/* also closes fd */
-	pfree(expanded_path);
-
-	if (key_buf.len == 0)
-	{
-		*error_msg = pstrdup("API key file is empty");
-		pfree(key_buf.data);
-		return NULL;
-	}
-
-	/* Copy to TopMemoryContext so it persists across transactions */
-	{
-		char *persistent_key;
-		MemoryContext oldcontext;
-
-		oldcontext = MemoryContextSwitchTo(TopMemoryContext);
-		persistent_key = pstrdup(key_buf.data);
-		MemoryContextSwitchTo(oldcontext);
-
-		pfree(key_buf.data);
-		return persistent_key;
-	}
-}
-
-/*
- * Expand tilde in path
- */
-static char *
-expand_tilde(const char *path)
-{
-	if (path[0] == '~' && (path[1] == '/' || path[1] == '\0'))
-	{
-		const char *home = NULL;
-		struct passwd *pw;
-
-		/*
-		 * Use getpwuid() rather than getenv("HOME"): environment variables
-		 * are attacker-controllable and must not be trusted for path
-		 * resolution (CWE-807).
-		 */
-		pw = getpwuid(geteuid());
-		if (pw != NULL)
-			home = pw->pw_dir;
-
-		if (home != NULL && home[0] != '\0')
-			return psprintf("%s%s", home, path + 1);
-	}
-	return pstrdup(path);
-}
-
-/*
- * Escape a string for JSON
- */
-static char *
-escape_json_string(const char *str)
-{
-	StringInfoData buf;
-	const char *p;
-
-	initStringInfo(&buf);
-
-	for (p = str; *p; p++)
-	{
-		switch (*p)
-		{
-			case '"':
-				appendStringInfoString(&buf, "\\\"");
-				break;
-			case '\\':
-				appendStringInfoString(&buf, "\\\\");
-				break;
-			case '\b':
-				appendStringInfoString(&buf, "\\b");
-				break;
-			case '\f':
-				appendStringInfoString(&buf, "\\f");
-				break;
-			case '\n':
-				appendStringInfoString(&buf, "\\n");
-				break;
-			case '\r':
-				appendStringInfoString(&buf, "\\r");
-				break;
-			case '\t':
-				appendStringInfoString(&buf, "\\t");
-				break;
-			default:
-				if ((unsigned char) *p < 32)
-					appendStringInfo(&buf, "\\u%04x", (unsigned char) *p);
-				else
-					appendStringInfoChar(&buf, *p);
-				break;
-		}
-	}
-
-	return buf.data;
-}
-
-/*
- * Parse batch embedding response
- *
- * Expected format:
- * {"data":[{"embedding":[0.1,0.2,...]},{"embedding":[...]}],...}
- *
- * This is a simplified parser. For production, consider using a robust JSON library.
- */
-static float **
-parse_batch_embedding_response(const char *json_response, int count, int *dim, char **error_msg)
-{
-	const char *p;
-	float **embeddings = NULL;
-	int embedding_idx = 0;
-	int value_idx;
-	char value_buf[32];
-	int value_pos;
-
-	/* Allocate array for embeddings */
-	embeddings = (float **) palloc0(sizeof(float *) * count);
-
-	/* Find "data" array */
-	p = strstr(json_response, "\"data\"");
-	if (p == NULL)
-	{
-		*error_msg = pstrdup("Invalid response: 'data' field not found");
-		goto error;
-	}
-
-	/* Find first embedding array */
-	p = strstr(p, "\"embedding\"");
-	if (p == NULL)
-	{
-		*error_msg = pstrdup("Invalid response: 'embedding' field not found");
-		goto error;
-	}
-
-	/* Process each embedding */
-	while (embedding_idx < count && p != NULL)
-	{
-		/* Find opening bracket */
-		p = strchr(p, '[');
-		if (p == NULL)
-			break;
-		p++;
-
-		/* Count dimensions if first embedding */
-		if (*dim == 0)
-		{
-			const char *temp = p;
-			int comma_count = 0;
-			while (*temp && *temp != ']')
-			{
-				if (*temp == ',')
-					comma_count++;
-				temp++;
-			}
-			*dim = comma_count + 1;
-		}
-
-		/* Allocate array for this embedding */
-		embeddings[embedding_idx] = (float *) palloc(sizeof(float) * (*dim));
-		value_idx = 0;
-
-		/* Parse values */
-		while (value_idx < *dim && *p && *p != ']')
-		{
-			/* Skip whitespace and commas */
-			while (*p && (*p == ' ' || *p == ',' || *p == '\t' || *p == '\n'))
-				p++;
-
-			if (*p == ']')
-				break;
-
-			/* Read numeric value */
-			value_pos = 0;
-			while (*p && (isdigit(*p) || *p == '.' || *p == '-' || *p == '+' || *p == 'e' || *p == 'E'))
-			{
-				if (value_pos < sizeof(value_buf) - 1)
-					value_buf[value_pos++] = *p;
-				p++;
-			}
-			value_buf[value_pos] = '\0';
-
-			if (value_pos > 0)
-			{
-				embeddings[embedding_idx][value_idx] = atof(value_buf);
-				value_idx++;
-			}
-		}
-
-		if (value_idx != *dim)
-		{
-			*error_msg = psprintf("Dimension mismatch: expected %d, got %d", *dim, value_idx);
-			goto error;
-		}
-
-		embedding_idx++;
-
-		/* Find next embedding */
-		p = strstr(p, "\"embedding\"");
-	}
-
-	if (embedding_idx != count)
-	{
-		*error_msg = psprintf("Expected %d embeddings, got %d", count, embedding_idx);
-		goto error;
-	}
-
-	return embeddings;
-
-error:
-	if (embeddings != NULL)
-	{
-		for (int i = 0; i < embedding_idx; i++)
-		{
-			if (embeddings[i] != NULL)
-				pfree(embeddings[i]);
-		}
-		pfree(embeddings);
-	}
-	return NULL;
 }

--- a/src/provider_voyage.c
+++ b/src/provider_voyage.c
@@ -4,28 +4,17 @@
  *		Voyage AI embedding provider implementation
  *
  * Voyage AI provides high-quality embeddings. The API is compatible
- * with OpenAI's API format.
+ * with OpenAI's API format. Uses shared infrastructure from
+ * provider_common.c.
  *
  * Copyright (c) 2025 - 2026, pgEdge, Inc.
  *
  *-------------------------------------------------------------------------
  */
-#include "pgedge_vectorizer.h"
+#include "provider_common.h"
 
-#include <curl/curl.h>
-#include <sys/stat.h>
-#include <unistd.h>
-
-#include "utils/memutils.h"
-
-/*
- * Response buffer for libcurl
- */
-typedef struct
-{
-	char *data;
-	size_t size;
-} ResponseBuffer;
+/* Default base URL for Voyage AI API */
+#define VOYAGE_DEFAULT_BASE_URL "https://api.voyageai.com/v1"
 
 /*
  * Static variables
@@ -39,14 +28,8 @@ static bool provider_initialized = false;
 static bool voyage_init(char **error_msg);
 static void voyage_cleanup(void);
 static float *voyage_generate(const char *text, int *dim, char **error_msg);
-static float **voyage_generate_batch(const char **texts, int count, int *dim, char **error_msg);
-
-/* Helper functions */
-static char *load_api_key(const char *filepath, char **error_msg);
-static char *expand_tilde(const char *path);
-static char *escape_json_string(const char *str);
-static size_t write_callback(void *contents, size_t size, size_t nmemb, void *userp);
-static float **parse_batch_embedding_response(const char *json_response, int count, int *dim, char **error_msg);
+static float **voyage_generate_batch(const char **texts, int count, int *dim,
+									 char **error_msg);
 
 /*
  * Voyage AI Provider struct
@@ -68,11 +51,10 @@ voyage_init(char **error_msg)
 	if (provider_initialized)
 		return true;
 
-	/* Initialize curl globally */
 	curl_global_init(CURL_GLOBAL_DEFAULT);
 
-	/* Load API key */
-	api_key = load_api_key(pgedge_vectorizer_api_key_file, error_msg);
+	/* Voyage always requires an API key */
+	api_key = provider_load_api_key(pgedge_vectorizer_api_key_file, error_msg);
 	if (api_key == NULL)
 	{
 		curl_global_cleanup();
@@ -96,7 +78,7 @@ voyage_cleanup(void)
 	if (api_key != NULL)
 	{
 		/* flawfinder: ignore - api_key is palloc'd, always null-terminated */
-		memset(api_key, 0, strlen(api_key));  /* Zero out key */
+		memset(api_key, 0, strlen(api_key));
 		pfree(api_key);
 		api_key = NULL;
 	}
@@ -116,36 +98,27 @@ voyage_generate(const char *text, int *dim, char **error_msg)
 	float **embeddings;
 	float *result;
 
-	/* Use batch function with count=1 */
 	embeddings = voyage_generate_batch(texts, 1, dim, error_msg);
 	if (embeddings == NULL)
 		return NULL;
 
-	/* Extract the single embedding */
 	result = embeddings[0];
 	pfree(embeddings);
-
 	return result;
 }
 
 /*
  * Generate embeddings in batch
- *
- * Voyage AI API is compatible with OpenAI format
  */
 static float **
 voyage_generate_batch(const char **texts, int count, int *dim, char **error_msg)
 {
-	CURL *curl;
-	CURLcode res;
-	struct curl_slist *headers = NULL;
 	char *json_request;
 	char *url;
-	StringInfoData request_buf;
-	ResponseBuffer response;
+	const char *base_url;
 	char auth_header[512];
-	float **embeddings = NULL;
-	long response_code;
+	ResponseBuffer response;
+	float **embeddings;
 
 	if (!provider_initialized)
 	{
@@ -153,363 +126,38 @@ voyage_generate_batch(const char **texts, int count, int *dim, char **error_msg)
 			return NULL;
 	}
 
-	/* Initialize response buffer */
-	response.data = palloc(1);
-	response.data[0] = '\0';
-	response.size = 0;
+	/* Build request body */
+	json_request = provider_build_openai_request(texts, count,
+												 pgedge_vectorizer_model);
 
-	/* Build JSON request */
-	initStringInfo(&request_buf);
-	appendStringInfo(&request_buf, "{\"input\":[");
-	for (int i = 0; i < count; i++)
+	/* Build URL */
+	base_url = (pgedge_vectorizer_api_url != NULL &&
+				pgedge_vectorizer_api_url[0] != '\0')
+		? pgedge_vectorizer_api_url
+		: VOYAGE_DEFAULT_BASE_URL;
+	url = psprintf("%s/embeddings", base_url);
+
+	/* Build auth header */
+	snprintf(auth_header, sizeof(auth_header),
+			 "Authorization: Bearer %s", api_key);
+
+	/* Perform request */
+	if (!provider_do_curl_request(url, auth_header, json_request,
+								  "Voyage AI", &response, error_msg))
 	{
-		char *escaped = escape_json_string(texts[i]);
-		if (i > 0)
-			appendStringInfoChar(&request_buf, ',');
-		appendStringInfo(&request_buf, "\"%s\"", escaped);
-		pfree(escaped);
-	}
-	appendStringInfo(&request_buf, "],\"model\":\"%s\"}", pgedge_vectorizer_model);
-	json_request = request_buf.data;
-
-	/* Build URL - Voyage AI uses /embeddings endpoint */
-	url = psprintf("%s/embeddings", pgedge_vectorizer_api_url);
-
-	/* Initialize curl */
-	curl = curl_easy_init();
-	if (!curl)
-	{
-		*error_msg = pstrdup("Failed to initialize libcurl");
-		pfree(response.data);
+		pfree(json_request);
+		pfree(url);
+		if (response.data)
+			pfree(response.data);
 		return NULL;
 	}
 
-	/* Set up headers - Voyage AI uses Bearer authentication */
-	headers = curl_slist_append(headers, "Content-Type: application/json; charset=utf-8");
-	snprintf(auth_header, sizeof(auth_header), "Authorization: Bearer %s", api_key);
-	headers = curl_slist_append(headers, auth_header);
+	/* Parse response */
+	embeddings = provider_parse_openai_embedding_response(response.data, count,
+														  dim, error_msg);
 
-	/* Configure curl */
-	curl_easy_setopt(curl, CURLOPT_URL, url);
-	curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
-	curl_easy_setopt(curl, CURLOPT_POSTFIELDS, json_request);
-	/* flawfinder: ignore - json_request from cJSON is null-terminated */
-	curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, (long)strlen(json_request));
-	curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_callback);
-	curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response);
-	curl_easy_setopt(curl, CURLOPT_TIMEOUT, 300L);  /* 5 minute timeout */
-
-	/* Perform the request */
-	res = curl_easy_perform(curl);
-
-	if (res != CURLE_OK)
-	{
-		*error_msg = psprintf("curl_easy_perform() failed: %s", curl_easy_strerror(res));
-		goto cleanup;
-	}
-
-	/* Check HTTP response code */
-	curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &response_code);
-	if (response_code != 200)
-	{
-		*error_msg = psprintf("Voyage AI API returned HTTP %ld: %s",
-							  response_code, response.data);
-		goto cleanup;
-	}
-
-	/* Parse the response */
-	embeddings = parse_batch_embedding_response(response.data, count, dim, error_msg);
-
-cleanup:
-	curl_slist_free_all(headers);
-	curl_easy_cleanup(curl);
 	pfree(json_request);
+	pfree(url);
 	pfree(response.data);
-
 	return embeddings;
-}
-
-/*
- * Curl write callback
- */
-static size_t
-write_callback(void *contents, size_t size, size_t nmemb, void *userp)
-{
-	size_t realsize = size * nmemb;
-	ResponseBuffer *mem = (ResponseBuffer *) userp;
-
-	char *ptr = repalloc(mem->data, mem->size + realsize + 1);
-	if (!ptr)
-		return 0;  /* Out of memory */
-
-	mem->data = ptr;
-	/* flawfinder: ignore - buffer was realloced to mem->size + realsize + 1 */
-	memcpy(&(mem->data[mem->size]), contents, realsize);  /* nosemgrep */
-	mem->size += realsize;
-	mem->data[mem->size] = 0;
-
-	return realsize;
-}
-
-/*
- * Load API key from file
- */
-static char *
-load_api_key(const char *filepath, char **error_msg)
-{
-	FILE *fp;
-	char *expanded_path;
-	StringInfoData key_buf;
-	int c;
-	struct stat st;
-
-	if (filepath == NULL || filepath[0] == '\0')
-	{
-		*error_msg = pstrdup("API key file path is not configured");
-		return NULL;
-	}
-
-	/* Expand tilde */
-	expanded_path = expand_tilde(filepath);
-
-	/* Check file exists and has proper permissions */
-	if (stat(expanded_path, &st) != 0)
-	{
-		*error_msg = psprintf("API key file not found: %s", expanded_path);
-		pfree(expanded_path);
-		return NULL;
-	}
-
-	/* Warn if file is world-readable */
-	if (st.st_mode & (S_IRWXG | S_IRWXO))
-	{
-		elog(WARNING, "API key file %s has permissive permissions (should be 0600)",
-			 expanded_path);
-	}
-
-	/* Open and read file */
-	fp = fopen(expanded_path, "r");
-	if (fp == NULL)
-	{
-		*error_msg = psprintf("Failed to open API key file: %s", expanded_path);
-		pfree(expanded_path);
-		return NULL;
-	}
-
-	initStringInfo(&key_buf);
-
-	/* Read the file, trimming whitespace */
-	while ((c = fgetc(fp)) != EOF)
-	{
-		if (c != '\n' && c != '\r' && c != ' ' && c != '\t')
-			appendStringInfoChar(&key_buf, c);
-	}
-
-	fclose(fp);
-	pfree(expanded_path);
-
-	if (key_buf.len == 0)
-	{
-		*error_msg = pstrdup("API key file is empty");
-		pfree(key_buf.data);
-		return NULL;
-	}
-
-	/* Copy to TopMemoryContext so it persists across transactions */
-	{
-		char *persistent_key;
-		MemoryContext oldcontext;
-
-		oldcontext = MemoryContextSwitchTo(TopMemoryContext);
-		persistent_key = pstrdup(key_buf.data);
-		MemoryContextSwitchTo(oldcontext);
-
-		pfree(key_buf.data);
-		return persistent_key;
-	}
-}
-
-/*
- * Expand tilde in path
- */
-static char *
-expand_tilde(const char *path)
-{
-	if (path[0] == '~' && (path[1] == '/' || path[1] == '\0'))
-	{
-		const char *home = getenv("HOME");
-		if (home)
-			return psprintf("%s%s", home, path + 1);
-	}
-	return pstrdup(path);
-}
-
-/*
- * Escape a string for JSON
- */
-static char *
-escape_json_string(const char *str)
-{
-	StringInfoData buf;
-	const char *p;
-
-	initStringInfo(&buf);
-
-	for (p = str; *p; p++)
-	{
-		switch (*p)
-		{
-			case '"':
-				appendStringInfoString(&buf, "\\\"");
-				break;
-			case '\\':
-				appendStringInfoString(&buf, "\\\\");
-				break;
-			case '\b':
-				appendStringInfoString(&buf, "\\b");
-				break;
-			case '\f':
-				appendStringInfoString(&buf, "\\f");
-				break;
-			case '\n':
-				appendStringInfoString(&buf, "\\n");
-				break;
-			case '\r':
-				appendStringInfoString(&buf, "\\r");
-				break;
-			case '\t':
-				appendStringInfoString(&buf, "\\t");
-				break;
-			default:
-				if ((unsigned char) *p < 32)
-					appendStringInfo(&buf, "\\u%04x", (unsigned char) *p);
-				else
-					appendStringInfoChar(&buf, *p);
-				break;
-		}
-	}
-
-	return buf.data;
-}
-
-/*
- * Parse batch embedding response
- *
- * Voyage AI uses the same response format as OpenAI:
- * {"data":[{"embedding":[0.1,0.2,...]},{"embedding":[...]}],...}
- */
-static float **
-parse_batch_embedding_response(const char *json_response, int count, int *dim, char **error_msg)
-{
-	const char *p;
-	float **embeddings = NULL;
-	int embedding_idx = 0;
-	int value_idx;
-	char value_buf[32];
-	int value_pos;
-
-	/* Allocate array for embeddings */
-	embeddings = (float **) palloc0(sizeof(float *) * count);
-
-	/* Find "data" array */
-	p = strstr(json_response, "\"data\"");
-	if (p == NULL)
-	{
-		*error_msg = pstrdup("Invalid response: 'data' field not found");
-		goto error;
-	}
-
-	/* Find first embedding array */
-	p = strstr(p, "\"embedding\"");
-	if (p == NULL)
-	{
-		*error_msg = pstrdup("Invalid response: 'embedding' field not found");
-		goto error;
-	}
-
-	/* Process each embedding */
-	while (embedding_idx < count && p != NULL)
-	{
-		/* Find opening bracket */
-		p = strchr(p, '[');
-		if (p == NULL)
-			break;
-		p++;
-
-		/* Count dimensions if first embedding */
-		if (*dim == 0)
-		{
-			const char *temp = p;
-			int comma_count = 0;
-			while (*temp && *temp != ']')
-			{
-				if (*temp == ',')
-					comma_count++;
-				temp++;
-			}
-			*dim = comma_count + 1;
-		}
-
-		/* Allocate array for this embedding */
-		embeddings[embedding_idx] = (float *) palloc(sizeof(float) * (*dim));
-		value_idx = 0;
-
-		/* Parse values */
-		while (value_idx < *dim && *p && *p != ']')
-		{
-			/* Skip whitespace and commas */
-			while (*p && (*p == ' ' || *p == ',' || *p == '\t' || *p == '\n'))
-				p++;
-
-			if (*p == ']')
-				break;
-
-			/* Read numeric value */
-			value_pos = 0;
-			while (*p && (isdigit(*p) || *p == '.' || *p == '-' || *p == '+' || *p == 'e' || *p == 'E'))
-			{
-				if (value_pos < sizeof(value_buf) - 1)
-					value_buf[value_pos++] = *p;
-				p++;
-			}
-			value_buf[value_pos] = '\0';
-
-			if (value_pos > 0)
-			{
-				embeddings[embedding_idx][value_idx] = atof(value_buf);
-				value_idx++;
-			}
-		}
-
-		if (value_idx != *dim)
-		{
-			*error_msg = psprintf("Dimension mismatch: expected %d, got %d", *dim, value_idx);
-			goto error;
-		}
-
-		embedding_idx++;
-
-		/* Find next embedding */
-		p = strstr(p, "\"embedding\"");
-	}
-
-	if (embedding_idx != count)
-	{
-		*error_msg = psprintf("Expected %d embeddings, got %d", count, embedding_idx);
-		goto error;
-	}
-
-	return embeddings;
-
-error:
-	if (embeddings != NULL)
-	{
-		for (int i = 0; i < embedding_idx; i++)
-		{
-			if (embeddings[i] != NULL)
-				pfree(embeddings[i]);
-		}
-		pfree(embeddings);
-	}
-	return NULL;
 }

--- a/src/provider_voyage.c
+++ b/src/provider_voyage.c
@@ -4,31 +4,17 @@
  *		Voyage AI embedding provider implementation
  *
  * Voyage AI provides high-quality embeddings. The API is compatible
- * with OpenAI's API format.
+ * with OpenAI's API format. Uses shared infrastructure from
+ * provider_common.c.
  *
  * Copyright (c) 2025 - 2026, pgEdge, Inc.
  *
  *-------------------------------------------------------------------------
  */
-#include "pgedge_vectorizer.h"
+#include "provider_common.h"
 
-#include <curl/curl.h>
-#include <fcntl.h>
-#include <pwd.h>
-#include <sys/stat.h>
-#include <unistd.h>
-
-#include "utils/memutils.h"
-
-
-/*
- * Response buffer for libcurl
- */
-typedef struct
-{
-	char *data;
-	size_t size;
-} ResponseBuffer;
+/* Default base URL for Voyage AI API */
+#define VOYAGE_DEFAULT_BASE_URL "https://api.voyageai.com/v1"
 
 /*
  * Static variables
@@ -42,14 +28,8 @@ static bool provider_initialized = false;
 static bool voyage_init(char **error_msg);
 static void voyage_cleanup(void);
 static float *voyage_generate(const char *text, int *dim, char **error_msg);
-static float **voyage_generate_batch(const char **texts, int count, int *dim, char **error_msg);
-
-/* Helper functions */
-static char *load_api_key(const char *filepath, char **error_msg);
-static char *expand_tilde(const char *path);
-static char *escape_json_string(const char *str);
-static size_t write_callback(void *contents, size_t size, size_t nmemb, void *userp);
-static float **parse_batch_embedding_response(const char *json_response, int count, int *dim, char **error_msg);
+static float **voyage_generate_batch(const char **texts, int count, int *dim,
+									 char **error_msg);
 
 /*
  * Voyage AI Provider struct
@@ -71,11 +51,10 @@ voyage_init(char **error_msg)
 	if (provider_initialized)
 		return true;
 
-	/* Initialize curl globally */
 	curl_global_init(CURL_GLOBAL_DEFAULT);
 
-	/* Load API key */
-	api_key = load_api_key(pgedge_vectorizer_api_key_file, error_msg);
+	/* Voyage always requires an API key */
+	api_key = provider_load_api_key(pgedge_vectorizer_api_key_file, error_msg);
 	if (api_key == NULL)
 	{
 		curl_global_cleanup();
@@ -99,7 +78,7 @@ voyage_cleanup(void)
 	if (api_key != NULL)
 	{
 		/* flawfinder: ignore - api_key is palloc'd, always null-terminated */
-		memset(api_key, 0, strlen(api_key));  /* Zero out key */
+		memset(api_key, 0, strlen(api_key));
 		pfree(api_key);
 		api_key = NULL;
 	}
@@ -119,36 +98,27 @@ voyage_generate(const char *text, int *dim, char **error_msg)
 	float **embeddings;
 	float *result;
 
-	/* Use batch function with count=1 */
 	embeddings = voyage_generate_batch(texts, 1, dim, error_msg);
 	if (embeddings == NULL)
 		return NULL;
 
-	/* Extract the single embedding */
 	result = embeddings[0];
 	pfree(embeddings);
-
 	return result;
 }
 
 /*
  * Generate embeddings in batch
- *
- * Voyage AI API is compatible with OpenAI format
  */
 static float **
 voyage_generate_batch(const char **texts, int count, int *dim, char **error_msg)
 {
-	CURL *curl;
-	CURLcode res;
-	struct curl_slist *headers = NULL;
 	char *json_request;
 	char *url;
-	StringInfoData request_buf;
-	ResponseBuffer response;
+	const char *base_url;
 	char auth_header[512];
-	float **embeddings = NULL;
-	long response_code;
+	ResponseBuffer response;
+	float **embeddings;
 
 	if (!provider_initialized)
 	{
@@ -156,425 +126,38 @@ voyage_generate_batch(const char **texts, int count, int *dim, char **error_msg)
 			return NULL;
 	}
 
-	/* Initialize response buffer */
-	response.data = palloc(1);
-	response.data[0] = '\0';
-	response.size = 0;
+	/* Build request body */
+	json_request = provider_build_openai_request(texts, count,
+												 pgedge_vectorizer_model);
 
-	/* Build JSON request */
-	initStringInfo(&request_buf);
-	appendStringInfo(&request_buf, "{\"input\":[");
-	for (int i = 0; i < count; i++)
+	/* Build URL */
+	base_url = (pgedge_vectorizer_api_url != NULL &&
+				pgedge_vectorizer_api_url[0] != '\0')
+		? pgedge_vectorizer_api_url
+		: VOYAGE_DEFAULT_BASE_URL;
+	url = psprintf("%s/embeddings", base_url);
+
+	/* Build auth header */
+	snprintf(auth_header, sizeof(auth_header),
+			 "Authorization: Bearer %s", api_key);
+
+	/* Perform request */
+	if (!provider_do_curl_request(url, auth_header, json_request,
+								  "Voyage AI", &response, error_msg))
 	{
-		char *escaped = escape_json_string(texts[i]);
-		if (i > 0)
-			appendStringInfoChar(&request_buf, ',');
-		appendStringInfo(&request_buf, "\"%s\"", escaped);
-		pfree(escaped);
-	}
-	appendStringInfo(&request_buf, "],\"model\":\"%s\"}", pgedge_vectorizer_model);
-	json_request = request_buf.data;
-
-	/* Build URL - Voyage AI uses /embeddings endpoint */
-	url = psprintf("%s/embeddings", pgedge_vectorizer_api_url);
-
-	/* Initialize curl */
-	curl = curl_easy_init();
-	if (!curl)
-	{
-		*error_msg = pstrdup("Failed to initialize libcurl");
-		pfree(response.data);
+		pfree(json_request);
+		pfree(url);
+		if (response.data)
+			pfree(response.data);
 		return NULL;
 	}
 
-	/* Set up headers - Voyage AI uses Bearer authentication */
-	headers = curl_slist_append(headers, "Content-Type: application/json; charset=utf-8");
-	snprintf(auth_header, sizeof(auth_header), "Authorization: Bearer %s", api_key);
-	headers = curl_slist_append(headers, auth_header);
+	/* Parse response */
+	embeddings = provider_parse_openai_embedding_response(response.data, count,
+														  dim, error_msg);
 
-	/* Configure curl */
-	curl_easy_setopt(curl, CURLOPT_URL, url);
-	curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
-	curl_easy_setopt(curl, CURLOPT_POSTFIELDS, json_request);
-	/* flawfinder: ignore - json_request from cJSON is null-terminated */
-	curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, (long)strlen(json_request));
-	curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_callback);
-	curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response);
-	curl_easy_setopt(curl, CURLOPT_TIMEOUT, 300L);  /* 5 minute timeout */
-
-	/* Perform the request */
-	res = curl_easy_perform(curl);
-
-	if (res != CURLE_OK)
-	{
-		*error_msg = psprintf("curl_easy_perform() failed: %s", curl_easy_strerror(res));
-		goto cleanup;
-	}
-
-	/* Check HTTP response code */
-	curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &response_code);
-	if (response_code != 200)
-	{
-		*error_msg = psprintf("Voyage AI API returned HTTP %ld: %s",
-							  response_code, response.data);
-		goto cleanup;
-	}
-
-	/* Parse the response */
-	embeddings = parse_batch_embedding_response(response.data, count, dim, error_msg);
-
-cleanup:
-	curl_slist_free_all(headers);
-	curl_easy_cleanup(curl);
 	pfree(json_request);
+	pfree(url);
 	pfree(response.data);
-
 	return embeddings;
-}
-
-/*
- * Curl write callback
- */
-static size_t
-write_callback(void *contents, size_t size, size_t nmemb, void *userp)
-{
-	size_t realsize = size * nmemb;
-	ResponseBuffer *mem = (ResponseBuffer *) userp;
-
-	char *ptr = repalloc(mem->data, mem->size + realsize + 1);
-	if (!ptr)
-		return 0;  /* Out of memory */
-
-	mem->data = ptr;
-	/* flawfinder: ignore - buffer was realloced to mem->size + realsize + 1 */
-	memcpy(&(mem->data[mem->size]), contents, realsize);  /* nosemgrep */
-	mem->size += realsize;
-	mem->data[mem->size] = 0;
-
-	return realsize;
-}
-
-/*
- * Load API key from file
- */
-static char *
-load_api_key(const char *filepath, char **error_msg)
-{
-	FILE *fp;
-	char *expanded_path;
-	StringInfoData key_buf;
-	int c;
-	int fd;
-	size_t bytes_read;
-	struct stat st;
-
-	if (filepath == NULL || filepath[0] == '\0')
-	{
-		*error_msg = pstrdup("API key file path is not configured");
-		return NULL;
-	}
-
-	/* Expand tilde */
-	expanded_path = expand_tilde(filepath);
-
-	/*
-	 * Open the file first, then validate with fstat() on the open descriptor
-	 * to avoid TOCTOU races between stat() and fopen().
-	 */
-	fd = open(expanded_path, O_RDONLY | O_CLOEXEC);
-	if (fd < 0)
-	{
-		*error_msg = psprintf("Failed to open API key file: %s", expanded_path);
-		pfree(expanded_path);
-		return NULL;
-	}
-
-	if (fstat(fd, &st) != 0)
-	{
-		*error_msg = psprintf("Failed to stat API key file: %s", expanded_path);
-		close(fd);
-		pfree(expanded_path);
-		return NULL;
-	}
-
-	/* Reject non-regular files (e.g. devices, FIFOs, directories) */
-	if (!S_ISREG(st.st_mode))
-	{
-		*error_msg = psprintf("API key path is not a regular file: %s",
-							  expanded_path);
-		close(fd);
-		pfree(expanded_path);
-		return NULL;
-	}
-
-	/* Warn if file is world-readable */
-	if (st.st_mode & (S_IRWXG | S_IRWXO))
-	{
-		elog(WARNING, "API key file %s has permissive permissions (should be 0600)",
-			 expanded_path);
-	}
-
-	/* Reject unreasonably large files before reading (CWE-20) */
-	if (st.st_size > MAX_API_KEY_FILE_SIZE)
-	{
-		*error_msg = psprintf("API key file exceeds maximum allowed size of %d bytes",
-							  MAX_API_KEY_FILE_SIZE);
-		close(fd);
-		pfree(expanded_path);
-		return NULL;
-	}
-
-	/* Convert to FILE* for character-at-a-time reading */
-	fp = fdopen(fd, "r");
-	if (fp == NULL)
-	{
-		*error_msg = psprintf("Failed to open API key file stream: %s",
-							  expanded_path);
-		close(fd);
-		pfree(expanded_path);
-		return NULL;
-	}
-
-	initStringInfo(&key_buf);
-
-	/*
-	 * Read the file, trimming whitespace.  Enforce a runtime size limit as a
-	 * defence-in-depth measure — the file could have grown since fstat().
-	 */
-	bytes_read = 0;
-	while ((c = fgetc(fp)) != EOF)
-	{
-		bytes_read++;
-		if (bytes_read > MAX_API_KEY_FILE_SIZE)
-		{
-			*error_msg = psprintf("API key file exceeds maximum allowed size "
-								  "of %d bytes during read",
-								  MAX_API_KEY_FILE_SIZE);
-			fclose(fp);
-			pfree(key_buf.data);
-			pfree(expanded_path);
-			return NULL;
-		}
-		if (c != '\n' && c != '\r' && c != ' ' && c != '\t')
-			appendStringInfoChar(&key_buf, c);
-	}
-
-	fclose(fp);	/* also closes fd */
-	pfree(expanded_path);
-
-	if (key_buf.len == 0)
-	{
-		*error_msg = pstrdup("API key file is empty");
-		pfree(key_buf.data);
-		return NULL;
-	}
-
-	/* Copy to TopMemoryContext so it persists across transactions */
-	{
-		char *persistent_key;
-		MemoryContext oldcontext;
-
-		oldcontext = MemoryContextSwitchTo(TopMemoryContext);
-		persistent_key = pstrdup(key_buf.data);
-		MemoryContextSwitchTo(oldcontext);
-
-		pfree(key_buf.data);
-		return persistent_key;
-	}
-}
-
-/*
- * Expand tilde in path
- */
-static char *
-expand_tilde(const char *path)
-{
-	if (path[0] == '~' && (path[1] == '/' || path[1] == '\0'))
-	{
-		const char *home = NULL;
-		struct passwd *pw;
-
-		/*
-		 * Use getpwuid() rather than getenv("HOME"): environment variables
-		 * are attacker-controllable and must not be trusted for path
-		 * resolution (CWE-807).
-		 */
-		pw = getpwuid(geteuid());
-		if (pw != NULL)
-			home = pw->pw_dir;
-
-		if (home != NULL && home[0] != '\0')
-			return psprintf("%s%s", home, path + 1);
-	}
-	return pstrdup(path);
-}
-
-/*
- * Escape a string for JSON
- */
-static char *
-escape_json_string(const char *str)
-{
-	StringInfoData buf;
-	const char *p;
-
-	initStringInfo(&buf);
-
-	for (p = str; *p; p++)
-	{
-		switch (*p)
-		{
-			case '"':
-				appendStringInfoString(&buf, "\\\"");
-				break;
-			case '\\':
-				appendStringInfoString(&buf, "\\\\");
-				break;
-			case '\b':
-				appendStringInfoString(&buf, "\\b");
-				break;
-			case '\f':
-				appendStringInfoString(&buf, "\\f");
-				break;
-			case '\n':
-				appendStringInfoString(&buf, "\\n");
-				break;
-			case '\r':
-				appendStringInfoString(&buf, "\\r");
-				break;
-			case '\t':
-				appendStringInfoString(&buf, "\\t");
-				break;
-			default:
-				if ((unsigned char) *p < 32)
-					appendStringInfo(&buf, "\\u%04x", (unsigned char) *p);
-				else
-					appendStringInfoChar(&buf, *p);
-				break;
-		}
-	}
-
-	return buf.data;
-}
-
-/*
- * Parse batch embedding response
- *
- * Voyage AI uses the same response format as OpenAI:
- * {"data":[{"embedding":[0.1,0.2,...]},{"embedding":[...]}],...}
- */
-static float **
-parse_batch_embedding_response(const char *json_response, int count, int *dim, char **error_msg)
-{
-	const char *p;
-	float **embeddings = NULL;
-	int embedding_idx = 0;
-	int value_idx;
-	char value_buf[32];
-	int value_pos;
-
-	/* Allocate array for embeddings */
-	embeddings = (float **) palloc0(sizeof(float *) * count);
-
-	/* Find "data" array */
-	p = strstr(json_response, "\"data\"");
-	if (p == NULL)
-	{
-		*error_msg = pstrdup("Invalid response: 'data' field not found");
-		goto error;
-	}
-
-	/* Find first embedding array */
-	p = strstr(p, "\"embedding\"");
-	if (p == NULL)
-	{
-		*error_msg = pstrdup("Invalid response: 'embedding' field not found");
-		goto error;
-	}
-
-	/* Process each embedding */
-	while (embedding_idx < count && p != NULL)
-	{
-		/* Find opening bracket */
-		p = strchr(p, '[');
-		if (p == NULL)
-			break;
-		p++;
-
-		/* Count dimensions if first embedding */
-		if (*dim == 0)
-		{
-			const char *temp = p;
-			int comma_count = 0;
-			while (*temp && *temp != ']')
-			{
-				if (*temp == ',')
-					comma_count++;
-				temp++;
-			}
-			*dim = comma_count + 1;
-		}
-
-		/* Allocate array for this embedding */
-		embeddings[embedding_idx] = (float *) palloc(sizeof(float) * (*dim));
-		value_idx = 0;
-
-		/* Parse values */
-		while (value_idx < *dim && *p && *p != ']')
-		{
-			/* Skip whitespace and commas */
-			while (*p && (*p == ' ' || *p == ',' || *p == '\t' || *p == '\n'))
-				p++;
-
-			if (*p == ']')
-				break;
-
-			/* Read numeric value */
-			value_pos = 0;
-			while (*p && (isdigit(*p) || *p == '.' || *p == '-' || *p == '+' || *p == 'e' || *p == 'E'))
-			{
-				if (value_pos < sizeof(value_buf) - 1)
-					value_buf[value_pos++] = *p;
-				p++;
-			}
-			value_buf[value_pos] = '\0';
-
-			if (value_pos > 0)
-			{
-				embeddings[embedding_idx][value_idx] = atof(value_buf);
-				value_idx++;
-			}
-		}
-
-		if (value_idx != *dim)
-		{
-			*error_msg = psprintf("Dimension mismatch: expected %d, got %d", *dim, value_idx);
-			goto error;
-		}
-
-		embedding_idx++;
-
-		/* Find next embedding */
-		p = strstr(p, "\"embedding\"");
-	}
-
-	if (embedding_idx != count)
-	{
-		*error_msg = psprintf("Expected %d embeddings, got %d", count, embedding_idx);
-		goto error;
-	}
-
-	return embeddings;
-
-error:
-	if (embeddings != NULL)
-	{
-		for (int i = 0; i < embedding_idx; i++)
-		{
-			if (embeddings[i] != NULL)
-				pfree(embeddings[i]);
-		}
-		pfree(embeddings);
-	}
-	return NULL;
 }

--- a/test/expected/providers.out
+++ b/test/expected/providers.out
@@ -93,8 +93,8 @@ SHOW pgedge_vectorizer.provider;
 (1 row)
 
 SHOW pgedge_vectorizer.api_url;
-                pgedge_vectorizer.api_url                 
-----------------------------------------------------------
+            pgedge_vectorizer.api_url             
+--------------------------------------------------
  https://generativelanguage.googleapis.com/v1beta
 (1 row)
 
@@ -107,8 +107,8 @@ SHOW pgedge_vectorizer.model;
 -- Test extra headers configuration
 SET pgedge_vectorizer.extra_headers = 'x-portkey-provider: openai; x-custom-header: value123';
 SHOW pgedge_vectorizer.extra_headers;
-               pgedge_vectorizer.extra_headers                
---------------------------------------------------------------
+            pgedge_vectorizer.extra_headers            
+-------------------------------------------------------
  x-portkey-provider: openai; x-custom-header: value123
 (1 row)
 
@@ -131,8 +131,8 @@ SHOW pgedge_vectorizer.provider;
 (1 row)
 
 SHOW pgedge_vectorizer.api_url;
-  pgedge_vectorizer.api_url  
------------------------------
+ pgedge_vectorizer.api_url 
+---------------------------
  http://localhost:1234/v1
 (1 row)
 

--- a/test/expected/providers.out
+++ b/test/expected/providers.out
@@ -82,6 +82,66 @@ SHOW pgedge_vectorizer.model;
  nomic-embed-text
 (1 row)
 
+-- Test Gemini provider configuration
+SET pgedge_vectorizer.provider = 'gemini';
+SET pgedge_vectorizer.api_url = 'https://generativelanguage.googleapis.com/v1beta';
+SET pgedge_vectorizer.model = 'text-embedding-004';
+SHOW pgedge_vectorizer.provider;
+ pgedge_vectorizer.provider 
+----------------------------
+ gemini
+(1 row)
+
+SHOW pgedge_vectorizer.api_url;
+                pgedge_vectorizer.api_url                 
+----------------------------------------------------------
+ https://generativelanguage.googleapis.com/v1beta
+(1 row)
+
+SHOW pgedge_vectorizer.model;
+ pgedge_vectorizer.model 
+-------------------------
+ text-embedding-004
+(1 row)
+
+-- Test extra headers configuration
+SET pgedge_vectorizer.extra_headers = 'x-portkey-provider: openai; x-custom-header: value123';
+SHOW pgedge_vectorizer.extra_headers;
+               pgedge_vectorizer.extra_headers                
+--------------------------------------------------------------
+ x-portkey-provider: openai; x-custom-header: value123
+(1 row)
+
+-- Test empty extra headers (default)
+RESET pgedge_vectorizer.extra_headers;
+SHOW pgedge_vectorizer.extra_headers;
+ pgedge_vectorizer.extra_headers 
+---------------------------------
+ 
+(1 row)
+
+-- Test OpenAI-compatible local provider configuration (custom URL, no key needed)
+SET pgedge_vectorizer.provider = 'openai';
+SET pgedge_vectorizer.api_url = 'http://localhost:1234/v1';
+SET pgedge_vectorizer.model = 'local-embed-model';
+SHOW pgedge_vectorizer.provider;
+ pgedge_vectorizer.provider 
+----------------------------
+ openai
+(1 row)
+
+SHOW pgedge_vectorizer.api_url;
+  pgedge_vectorizer.api_url  
+-----------------------------
+ http://localhost:1234/v1
+(1 row)
+
+SHOW pgedge_vectorizer.model;
+ pgedge_vectorizer.model 
+-------------------------
+ local-embed-model
+(1 row)
+
 -- Reset to defaults
 RESET pgedge_vectorizer.provider;
 RESET pgedge_vectorizer.api_url;
@@ -90,5 +150,11 @@ SHOW pgedge_vectorizer.provider;
  pgedge_vectorizer.provider 
 ----------------------------
  openai
+(1 row)
+
+SHOW pgedge_vectorizer.api_url;
+ pgedge_vectorizer.api_url 
+---------------------------
+ 
 (1 row)
 

--- a/test/sql/providers.sql
+++ b/test/sql/providers.sql
@@ -37,8 +37,33 @@ SHOW pgedge_vectorizer.provider;
 SHOW pgedge_vectorizer.api_url;
 SHOW pgedge_vectorizer.model;
 
+-- Test Gemini provider configuration
+SET pgedge_vectorizer.provider = 'gemini';
+SET pgedge_vectorizer.api_url = 'https://generativelanguage.googleapis.com/v1beta';
+SET pgedge_vectorizer.model = 'text-embedding-004';
+SHOW pgedge_vectorizer.provider;
+SHOW pgedge_vectorizer.api_url;
+SHOW pgedge_vectorizer.model;
+
+-- Test extra headers configuration
+SET pgedge_vectorizer.extra_headers = 'x-portkey-provider: openai; x-custom-header: value123';
+SHOW pgedge_vectorizer.extra_headers;
+
+-- Test empty extra headers (default)
+RESET pgedge_vectorizer.extra_headers;
+SHOW pgedge_vectorizer.extra_headers;
+
+-- Test OpenAI-compatible local provider configuration (custom URL, no key needed)
+SET pgedge_vectorizer.provider = 'openai';
+SET pgedge_vectorizer.api_url = 'http://localhost:1234/v1';
+SET pgedge_vectorizer.model = 'local-embed-model';
+SHOW pgedge_vectorizer.provider;
+SHOW pgedge_vectorizer.api_url;
+SHOW pgedge_vectorizer.model;
+
 -- Reset to defaults
 RESET pgedge_vectorizer.provider;
 RESET pgedge_vectorizer.api_url;
 RESET pgedge_vectorizer.model;
 SHOW pgedge_vectorizer.provider;
+SHOW pgedge_vectorizer.api_url;


### PR DESCRIPTION
## Summary

- **Shared provider infrastructure**: Extract duplicated code from OpenAI/Voyage into `provider_common.c` (curl, JSON, API key loading, response parsing). Slims existing providers from ~516 lines each to ~163-187 lines.
- **Google Gemini provider**: New `provider_gemini.c` with `x-goog-api-key` auth, model-in-URL-path, and native batch support via `batchEmbedContents`.
- **Custom base URLs**: `api_url` GUC now defaults to empty; each provider supplies its own default URL. Enables pointing any provider at a custom endpoint.
- **OpenAI-compatible local providers**: API key is optional when a custom URL is set, enabling LM Studio, Docker Model Runner, llama.cpp, and EXO.
- **Extra HTTP headers**: New `extra_headers` GUC (semicolon-separated `key: value` pairs) for proxy servers like Portkey.

## Test plan

- [ ] `make clean && make` builds cleanly with zero warnings
- [ ] `make install && make installcheck` passes all existing tests plus new provider/GUC test cases
- [ ] Verify Gemini embeddings work with a real API key
- [ ] Verify OpenAI-compatible local provider (e.g., LM Studio) works without an API key
- [ ] Verify extra headers are sent correctly (e.g., via Portkey or request inspection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)