### PR TITLE
SPOC-471: fix Codacy-reported security concerns

### DIFF
--- a/src/pgedge_vectorizer.h
+++ b/src/pgedge_vectorizer.h
@@ -43,6 +43,9 @@
 #define PGEDGE_NORETURN_SUFFIX
 #endif
 
+/* Maximum size of an API key file; guards against unbounded reads (CWE-20) */
+#define MAX_API_KEY_FILE_SIZE	4096
+
 /*
  * GUC Variables (declared extern, defined in guc.c)
  */

--- a/src/provider_openai.c
+++ b/src/provider_openai.c
@@ -12,6 +12,7 @@
 #include "pgedge_vectorizer.h"
 
 #include <curl/curl.h>
+#include <pwd.h>
 #include <sys/stat.h>
 #include <unistd.h>
 
@@ -286,6 +287,15 @@ load_api_key(const char *filepath, char **error_msg)
 			 expanded_path);
 	}
 
+	/* Reject unreasonably large files before reading (CWE-20) */
+	if (st.st_size > MAX_API_KEY_FILE_SIZE)
+	{
+		*error_msg = psprintf("API key file exceeds maximum allowed size of %d bytes",
+							  MAX_API_KEY_FILE_SIZE);
+		pfree(expanded_path);
+		return NULL;
+	}
+
 	/* Open and read file */
 	fp = fopen(expanded_path, "r");
 	if (fp == NULL)
@@ -336,8 +346,19 @@ expand_tilde(const char *path)
 {
 	if (path[0] == '~' && (path[1] == '/' || path[1] == '\0'))
 	{
-		const char *home = getenv("HOME");
-		if (home)
+		const char *home = NULL;
+		struct passwd *pw;
+
+		/*
+		 * Use getpwuid() rather than getenv("HOME"): environment variables
+		 * are attacker-controllable and must not be trusted for path
+		 * resolution (CWE-807).
+		 */
+		pw = getpwuid(geteuid());
+		if (pw != NULL)
+			home = pw->pw_dir;
+
+		if (home != NULL && home[0] != '\0')
 			return psprintf("%s%s", home, path + 1);
 	}
 	return pstrdup(path);

--- a/src/provider_openai.c
+++ b/src/provider_openai.c
@@ -12,6 +12,7 @@
 #include "pgedge_vectorizer.h"
 
 #include <curl/curl.h>
+#include <fcntl.h>
 #include <pwd.h>
 #include <sys/stat.h>
 #include <unistd.h>
@@ -261,6 +262,8 @@ load_api_key(const char *filepath, char **error_msg)
 	char *expanded_path;
 	StringInfoData key_buf;
 	int c;
+	int fd;
+	size_t bytes_read;
 	struct stat st;
 
 	if (filepath == NULL || filepath[0] == '\0')
@@ -272,10 +275,32 @@ load_api_key(const char *filepath, char **error_msg)
 	/* Expand tilde */
 	expanded_path = expand_tilde(filepath);
 
-	/* Check file exists and has proper permissions */
-	if (stat(expanded_path, &st) != 0)
+	/*
+	 * Open the file first, then validate with fstat() on the open descriptor
+	 * to avoid TOCTOU races between stat() and fopen().
+	 */
+	fd = open(expanded_path, O_RDONLY | O_CLOEXEC);
+	if (fd < 0)
 	{
-		*error_msg = psprintf("API key file not found: %s", expanded_path);
+		*error_msg = psprintf("Failed to open API key file: %s", expanded_path);
+		pfree(expanded_path);
+		return NULL;
+	}
+
+	if (fstat(fd, &st) != 0)
+	{
+		*error_msg = psprintf("Failed to stat API key file: %s", expanded_path);
+		close(fd);
+		pfree(expanded_path);
+		return NULL;
+	}
+
+	/* Reject non-regular files (e.g. devices, FIFOs, directories) */
+	if (!S_ISREG(st.st_mode))
+	{
+		*error_msg = psprintf("API key path is not a regular file: %s",
+							  expanded_path);
+		close(fd);
 		pfree(expanded_path);
 		return NULL;
 	}
@@ -292,29 +317,47 @@ load_api_key(const char *filepath, char **error_msg)
 	{
 		*error_msg = psprintf("API key file exceeds maximum allowed size of %d bytes",
 							  MAX_API_KEY_FILE_SIZE);
+		close(fd);
 		pfree(expanded_path);
 		return NULL;
 	}
 
-	/* Open and read file */
-	fp = fopen(expanded_path, "r");
+	/* Convert to FILE* for character-at-a-time reading */
+	fp = fdopen(fd, "r");
 	if (fp == NULL)
 	{
-		*error_msg = psprintf("Failed to open API key file: %s", expanded_path);
+		*error_msg = psprintf("Failed to open API key file stream: %s",
+							  expanded_path);
+		close(fd);
 		pfree(expanded_path);
 		return NULL;
 	}
 
 	initStringInfo(&key_buf);
 
-	/* Read the file, trimming whitespace */
+	/*
+	 * Read the file, trimming whitespace.  Enforce a runtime size limit as a
+	 * defence-in-depth measure — the file could have grown since fstat().
+	 */
+	bytes_read = 0;
 	while ((c = fgetc(fp)) != EOF)
 	{
+		bytes_read++;
+		if (bytes_read > MAX_API_KEY_FILE_SIZE)
+		{
+			*error_msg = psprintf("API key file exceeds maximum allowed size "
+								  "of %d bytes during read",
+								  MAX_API_KEY_FILE_SIZE);
+			fclose(fp);
+			pfree(key_buf.data);
+			pfree(expanded_path);
+			return NULL;
+		}
 		if (c != '\n' && c != '\r' && c != ' ' && c != '\t')
 			appendStringInfoChar(&key_buf, c);
 	}
 
-	fclose(fp);
+	fclose(fp);	/* also closes fd */
 	pfree(expanded_path);
 
 	if (key_buf.len == 0)

--- a/src/provider_voyage.c
+++ b/src/provider_voyage.c
@@ -13,10 +13,12 @@
 #include "pgedge_vectorizer.h"
 
 #include <curl/curl.h>
+#include <pwd.h>
 #include <sys/stat.h>
 #include <unistd.h>
 
 #include "utils/memutils.h"
+
 
 /*
  * Response buffer for libcurl
@@ -287,6 +289,15 @@ load_api_key(const char *filepath, char **error_msg)
 			 expanded_path);
 	}
 
+	/* Reject unreasonably large files before reading (CWE-20) */
+	if (st.st_size > MAX_API_KEY_FILE_SIZE)
+	{
+		*error_msg = psprintf("API key file exceeds maximum allowed size of %d bytes",
+							  MAX_API_KEY_FILE_SIZE);
+		pfree(expanded_path);
+		return NULL;
+	}
+
 	/* Open and read file */
 	fp = fopen(expanded_path, "r");
 	if (fp == NULL)
@@ -337,8 +348,19 @@ expand_tilde(const char *path)
 {
 	if (path[0] == '~' && (path[1] == '/' || path[1] == '\0'))
 	{
-		const char *home = getenv("HOME");
-		if (home)
+		const char *home = NULL;
+		struct passwd *pw;
+
+		/*
+		 * Use getpwuid() rather than getenv("HOME"): environment variables
+		 * are attacker-controllable and must not be trusted for path
+		 * resolution (CWE-807).
+		 */
+		pw = getpwuid(geteuid());
+		if (pw != NULL)
+			home = pw->pw_dir;
+
+		if (home != NULL && home[0] != '\0')
 			return psprintf("%s%s", home, path + 1);
 	}
 	return pstrdup(path);

--- a/src/provider_voyage.c
+++ b/src/provider_voyage.c
@@ -13,6 +13,7 @@
 #include "pgedge_vectorizer.h"
 
 #include <curl/curl.h>
+#include <fcntl.h>
 #include <pwd.h>
 #include <sys/stat.h>
 #include <unistd.h>
@@ -263,6 +264,8 @@ load_api_key(const char *filepath, char **error_msg)
 	char *expanded_path;
 	StringInfoData key_buf;
 	int c;
+	int fd;
+	size_t bytes_read;
 	struct stat st;
 
 	if (filepath == NULL || filepath[0] == '\0')
@@ -274,10 +277,32 @@ load_api_key(const char *filepath, char **error_msg)
 	/* Expand tilde */
 	expanded_path = expand_tilde(filepath);
 
-	/* Check file exists and has proper permissions */
-	if (stat(expanded_path, &st) != 0)
+	/*
+	 * Open the file first, then validate with fstat() on the open descriptor
+	 * to avoid TOCTOU races between stat() and fopen().
+	 */
+	fd = open(expanded_path, O_RDONLY | O_CLOEXEC);
+	if (fd < 0)
 	{
-		*error_msg = psprintf("API key file not found: %s", expanded_path);
+		*error_msg = psprintf("Failed to open API key file: %s", expanded_path);
+		pfree(expanded_path);
+		return NULL;
+	}
+
+	if (fstat(fd, &st) != 0)
+	{
+		*error_msg = psprintf("Failed to stat API key file: %s", expanded_path);
+		close(fd);
+		pfree(expanded_path);
+		return NULL;
+	}
+
+	/* Reject non-regular files (e.g. devices, FIFOs, directories) */
+	if (!S_ISREG(st.st_mode))
+	{
+		*error_msg = psprintf("API key path is not a regular file: %s",
+							  expanded_path);
+		close(fd);
 		pfree(expanded_path);
 		return NULL;
 	}
@@ -294,29 +319,47 @@ load_api_key(const char *filepath, char **error_msg)
 	{
 		*error_msg = psprintf("API key file exceeds maximum allowed size of %d bytes",
 							  MAX_API_KEY_FILE_SIZE);
+		close(fd);
 		pfree(expanded_path);
 		return NULL;
 	}
 
-	/* Open and read file */
-	fp = fopen(expanded_path, "r");
+	/* Convert to FILE* for character-at-a-time reading */
+	fp = fdopen(fd, "r");
 	if (fp == NULL)
 	{
-		*error_msg = psprintf("Failed to open API key file: %s", expanded_path);
+		*error_msg = psprintf("Failed to open API key file stream: %s",
+							  expanded_path);
+		close(fd);
 		pfree(expanded_path);
 		return NULL;
 	}
 
 	initStringInfo(&key_buf);
 
-	/* Read the file, trimming whitespace */
+	/*
+	 * Read the file, trimming whitespace.  Enforce a runtime size limit as a
+	 * defence-in-depth measure — the file could have grown since fstat().
+	 */
+	bytes_read = 0;
 	while ((c = fgetc(fp)) != EOF)
 	{
+		bytes_read++;
+		if (bytes_read > MAX_API_KEY_FILE_SIZE)
+		{
+			*error_msg = psprintf("API key file exceeds maximum allowed size "
+								  "of %d bytes during read",
+								  MAX_API_KEY_FILE_SIZE);
+			fclose(fp);
+			pfree(key_buf.data);
+			pfree(expanded_path);
+			return NULL;
+		}
 		if (c != '\n' && c != '\r' && c != ' ' && c != '\t')
 			appendStringInfoChar(&key_buf, c);
 	}
 
-	fclose(fp);
+	fclose(fp);	/* also closes fd */
 	pfree(expanded_path);
 
 	if (key_buf.len == 0)

--- a/src/worker.c
+++ b/src/worker.c
@@ -214,12 +214,9 @@ pgedge_vectorizer_worker_main(Datum main_arg)
 	while (*db_name == ' ' || *db_name == '\t')
 		db_name++;
 
-	/* flawfinder: ignore - explicitly null-terminated on next line */
-	strncpy(dbname, db_name, NAMEDATALEN - 1);
-	dbname[NAMEDATALEN - 1] = '\0';
+	strlcpy(dbname, db_name, NAMEDATALEN);
 
 	/* Remove trailing whitespace */
-	/* flawfinder: ignore - dbname was just null-terminated above */
 	for (int i = strlen(dbname) - 1; i >= 0 && (dbname[i] == ' ' || dbname[i] == '\t'); i--)
 		dbname[i] = '\0';
 


### PR DESCRIPTION
## Summary

Fix three Codacy-reported security issues in the pgedge-vectorizer extension.

**CWE-20 / CWE-120 — unbounded API key file reads (`provider_openai.c`, `provider_voyage.c`)**

`load_api_key()` used `fgetc()` in an unbounded loop backed by a `StringInfoData` buffer that grows without limit. A large or malicious key file could exhaust server memory. The fix checks `st.st_size` against `MAX_API_KEY_FILE_SIZE` (4096 bytes) before `fopen()`, using the `stat()` result that was already available for the permissions check. The constant is defined once in `pgedge_vectorizer.h` and shared by both providers.

**CWE-807 — untrusted `HOME` environment variable (`provider_openai.c`, `provider_voyage.c`)**

`expand_tilde()` resolved `~` using `getenv("HOME")`, which is fully attacker-controllable via the process environment. Replaced with `getpwuid(geteuid())`, which reads the home directory from the system user database and cannot be overridden by unprivileged callers.

**CWE-120 — `strncpy` without guaranteed null termination (`worker.c`)**

`strncpy(dbname, db_name, NAMEDATALEN - 1)` followed by a manual `dbname[NAMEDATALEN - 1] = '\0'` is error-prone and was accompanied by now-incorrect flawfinder suppression comments. Replaced with `strlcpy(dbname, db_name, NAMEDATALEN)`, which always null-terminates and needs no fixup line.
