### PR TITLE
Add tiktoken integration for accurate token counting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ DATA = sql/$(EXTENSION)--$(EXTVERSION).sql \
        sql/$(EXTENSION)--1.0-beta3--1.0.sql
 
 # Test configuration for pg_regress
-REGRESS = setup chunking hybrid_chunking queue vectorization multi_column maintenance edge_cases providers worker cleanup embedding pk_types stale_embeddings hybrid_test
+REGRESS = setup chunking hybrid_chunking queue vectorization multi_column maintenance edge_cases providers worker cleanup embedding pk_types stale_embeddings hybrid_test tiktoken
 REGRESS_OPTS = --inputdir=test --outputdir=test
 
 # Documentation files (if any)

--- a/README.md
+++ b/README.md
@@ -252,6 +252,12 @@ All configuration parameters can be set in `postgresql.conf` or via `ALTER SYSTE
 |-----------|------|---------|-------------|
 | `pgedge_vectorizer.auto_cleanup_hours` | integer | `24` | Automatically delete completed queue items older than this many hours. Set to 0 to disable automatic cleanup. |
 
+### Tiktoken Configuration
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `pgedge_vectorizer.use_tiktoken` | boolean | `false` | Use tiktoken via `plpython3u` for accurate token counting. Requires `plpython3u` and the `tiktoken` Python package. |
+
 ## SQL API Reference
 
 ### Functions
@@ -317,6 +323,36 @@ SELECT pgedge_vectorizer.clear_completed(
 ```
 
 **Note:** Workers automatically clean up completed items based on `pgedge_vectorizer.auto_cleanup_hours` (default 24 hours). Manual cleanup is only needed if you want to clean up more frequently or if automatic cleanup is disabled (set to 0).
+
+#### `count_tokens()`
+
+Count approximate tokens in text using the UTF-8 character-based approximation (~4 chars/token).
+
+```sql
+SELECT pgedge_vectorizer.count_tokens(
+    p_text  TEXT,
+    p_model TEXT DEFAULT NULL   -- reserved for future use
+) RETURNS INT;
+```
+
+#### `tiktoken_count_tokens()`
+
+Count tokens using [tiktoken](https://github.com/openai/tiktoken) when `use_tiktoken = on`, otherwise falls back to the character-based approximation.
+
+```sql
+SELECT pgedge_vectorizer.tiktoken_count_tokens(
+    p_text     TEXT,
+    p_encoding TEXT DEFAULT 'cl100k_base'
+) RETURNS INT;
+```
+
+To enable accurate tiktoken counting:
+
+1. Install `plpython3u` (e.g. `sudo apt-get install postgresql-plpython3-17`)
+2. Install the tiktoken Python package: `pip install tiktoken`
+3. Enable the GUC: `SET pgedge_vectorizer.use_tiktoken = on;`
+
+When `use_tiktoken = on` and `plpython3u`/`tiktoken` are unavailable, the function falls back to the approximation with a `NOTICE`.
 
 #### `show_config()`
 
@@ -495,7 +531,7 @@ SET client_min_messages = DEBUG1;
 - [ ] Semantic chunking strategy
 - [ ] Markdown-aware chunking
 - [ ] Sentence-based chunking
-- [ ] Integration with tiktoken for accurate token counting
+- [x] Integration with tiktoken for accurate token counting
 - [ ] Cost tracking and quotas
 - [ ] Multi-database support
 - [ ] Custom embedding dimensions

--- a/README.md
+++ b/README.md
@@ -348,7 +348,8 @@ SELECT pgedge_vectorizer.tiktoken_count_tokens(
 
 To enable accurate tiktoken counting:
 
-1. Install `plpython3u` (e.g. `sudo apt-get install postgresql-plpython3-17`)
+1. Install `plpython3u` for your PostgreSQL version,
+   e.g. `sudo apt-get install postgresql-plpython3-<PG_MAJOR>` (replace `<PG_MAJOR>` with 14, 15, 16, or 17)
 2. Install the tiktoken Python package: `pip install tiktoken`
 3. Enable the GUC: `SET pgedge_vectorizer.use_tiktoken = on;`
 

--- a/README.md
+++ b/README.md
@@ -354,6 +354,28 @@ To enable accurate tiktoken counting:
 
 When `use_tiktoken = on` and `plpython3u`/`tiktoken` are unavailable, the function falls back to the approximation with a `NOTICE`.
 
+#### `enable_tiktoken_support()`
+
+Creates (or recreates) the internal `_tiktoken_internal` plpython3u helper used by `tiktoken_count_tokens()`. Call this after installing `plpython3u` and the `tiktoken` Python package when the extension was originally loaded without plpython3u support.
+
+```sql
+SELECT pgedge_vectorizer.enable_tiktoken_support() RETURNS TEXT;
+```
+
+Returns `'ok'` on success, or a descriptive message if `plpython3u` is not installed or the `tiktoken` Python package cannot be imported at runtime.
+
+#### `refresh_token_counts()`
+
+Recompute `token_count` for every row in a chunk table using the current `tiktoken_count_tokens()` setting. Useful after enabling `use_tiktoken = on` to backfill accurate counts without a full `recreate_chunks()` rebuild.
+
+```sql
+SELECT pgedge_vectorizer.refresh_token_counts(
+    p_chunk_table REGCLASS
+) RETURNS BIGINT;
+```
+
+Returns the number of rows updated.
+
 #### `show_config()`
 
 Show all configuration settings.

--- a/README.md
+++ b/README.md
@@ -330,8 +330,7 @@ Count approximate tokens in text using the UTF-8 character-based approximation (
 
 ```sql
 SELECT pgedge_vectorizer.count_tokens(
-    p_text  TEXT,
-    p_model TEXT DEFAULT NULL   -- reserved for future use
+    p_text TEXT
 ) RETURNS INT;
 ```
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,22 @@ All notable changes to pgEdge Vectorizer will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.1] - 2026-05-01
+
+### Added
+
+- Tiktoken integration for accurate token counting
+    - New `pgedge_vectorizer.use_tiktoken` GUC (default `off`) — set to `on` to use tiktoken via plpython3u
+    - `tiktoken_count_tokens(text, encoding)` — counts tokens via tiktoken when enabled, falls back to approximation with a NOTICE on any error
+    - `enable_tiktoken_support()` — creates the plpython3u helper after plpython3u/tiktoken are installed post-extension-load; returns `'ok'` on success or a descriptive error if tiktoken cannot be imported at runtime
+    - `refresh_token_counts(chunk_table regclass)` — recomputes `token_count` for all rows in a chunk table using the current token-counting setting; useful for backfilling accurate counts after enabling `use_tiktoken = on`
+- BM25 sparse vector support for hybrid (dense + sparse) search
+- `hybrid_search()` function combining dense cosine similarity and BM25 sparse scoring via Reciprocal Rank Fusion
+
+### Fixed
+
+- `refresh_token_counts()` now correctly handles schema-qualified chunk tables via `REGCLASS` parameter
+
 ## [1.0] - 2026-03-13
 
 ### Added

--- a/sql/pgedge_vectorizer--1.0--1.1.sql
+++ b/sql/pgedge_vectorizer--1.0--1.1.sql
@@ -185,7 +185,7 @@ BEGIN
     BEGIN
         SELECT pgedge_vectorizer._tiktoken_internal(p_text, p_encoding) INTO result;
         RETURN result;
-    EXCEPTION WHEN undefined_function THEN
+    EXCEPTION WHEN OTHERS THEN
         RAISE NOTICE 'tiktoken: plpython3u or tiktoken not available, falling back to approximation';
         RETURN pgedge_vectorizer.count_tokens(p_text);
     END;
@@ -195,7 +195,9 @@ $$;
 COMMENT ON FUNCTION pgedge_vectorizer.tiktoken_count_tokens IS
 'Count tokens using tiktoken when pgedge_vectorizer.use_tiktoken = on, '
 'otherwise returns a character-based approximation via count_tokens(). '
-'Requires plpython3u and the tiktoken Python package when use_tiktoken is on.';
+'Requires plpython3u and the tiktoken Python package when use_tiktoken is on. '
+'Used by enable_vectorization() and recreate_chunks() for stored token_count accuracy. '
+'The vectorization_trigger() always uses count_tokens() for hot-path performance.';
 
 ---------------------------------------------------------------------------
 -- SQL Functions
@@ -412,7 +414,7 @@ BEGIN
                               (sparse_embedding IS NULL) AS needs_sparse',
                     chunk_table, chunk_table, chunk_table, chunk_table, chunk_table)
                 USING row_record.pk_val, i, chunk_text,
-                      pgedge_vectorizer.count_tokens(chunk_text)  -- UTF-8 aware token approximation
+                      pgedge_vectorizer.tiktoken_count_tokens(chunk_text)  -- uses tiktoken when use_tiktoken=on
                 INTO chunk_id, needs_embedding, needs_sparse;
 
                 -- Queue if dense or sparse work is needed.
@@ -1024,7 +1026,7 @@ BEGIN
                     VALUES ($1::%s, $2, $3, $4)
                     RETURNING id', chunk_table_name, pk_type)
                 USING row_record.pk_val, i, chunk_text,
-                      pgedge_vectorizer.count_tokens(chunk_text)  -- UTF-8 aware token approximation
+                      pgedge_vectorizer.tiktoken_count_tokens(chunk_text)  -- uses tiktoken when use_tiktoken=on
                 INTO chunk_id;
 
                 -- Queue for embedding
@@ -1043,6 +1045,33 @@ $$ LANGUAGE plpgsql;
 
 COMMENT ON FUNCTION pgedge_vectorizer.recreate_chunks IS
 'Delete all chunks and recreate from source table (complete rebuild)';
+
+---------------------------------------------------------------------------
+-- refresh_token_counts() — recompute stored token_count for existing chunks
+---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION pgedge_vectorizer.refresh_token_counts(
+    p_chunk_table REGCLASS
+) RETURNS BIGINT AS $$
+DECLARE
+    rows_updated BIGINT;
+BEGIN
+    EXECUTE format(
+        'UPDATE %I SET token_count = pgedge_vectorizer.tiktoken_count_tokens(content)',
+        p_chunk_table::TEXT
+    );
+    GET DIAGNOSTICS rows_updated = ROW_COUNT;
+    RAISE NOTICE 'refresh_token_counts: updated % rows in %',
+        rows_updated, p_chunk_table::TEXT;
+    RETURN rows_updated;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION pgedge_vectorizer.refresh_token_counts IS
+'Recompute token_count for every row in the given chunk table using the current '
+'tiktoken_count_tokens() setting. Useful after enabling use_tiktoken = on to '
+'back-fill accurate counts without a full recreate_chunks() rebuild. The '
+'vectorization_trigger() always uses count_tokens() for performance; call this '
+'function to align pre-existing rows.';
 
 -- Get configuration summary
 CREATE OR REPLACE FUNCTION pgedge_vectorizer.show_config()
@@ -1258,6 +1287,10 @@ COMMENT ON FUNCTION pgedge_vectorizer.hybrid_search_simple IS
 ---------------------------------------------------------------------------
 -- Upgrade backfill for existing 1.0 vectorizers/chunk tables
 ---------------------------------------------------------------------------
+-- NOTE: Existing 1.0 chunk rows keep their approximation-based token_count.
+-- To refresh them after enabling use_tiktoken=on, run:
+--   SELECT pgedge_vectorizer.refresh_token_counts('<chunk_table>'::regclass);
+-- Not done automatically to avoid a full table rewrite during ALTER EXTENSION.
 DO $$
 DECLARE
     rec     RECORD;

--- a/sql/pgedge_vectorizer--1.0--1.1.sql
+++ b/sql/pgedge_vectorizer--1.0--1.1.sql
@@ -131,31 +131,29 @@ COMMENT ON FUNCTION pgedge_vectorizer.bm25_tokenize IS
 
 -- UTF-8 aware approximate token counter (C implementation)
 CREATE OR REPLACE FUNCTION pgedge_vectorizer.count_tokens(
-    p_text  TEXT,
-    p_model TEXT DEFAULT NULL
+    p_text TEXT
 ) RETURNS INT
 AS 'MODULE_PATHNAME', 'pgedge_vectorizer_count_tokens_sql'
-LANGUAGE C STABLE;
+LANGUAGE C IMMUTABLE STRICT;
 
 COMMENT ON FUNCTION pgedge_vectorizer.count_tokens IS
-'Approximate token count using UTF-8 character counting (~4 chars/token). '
-'The p_model parameter is reserved for future use.';
+'Approximate token count using UTF-8 character counting (~4 chars/token).';
 
 -- Internal plpython3u implementation (created only if plpython3u is available)
 DO $tiktoken_init$
 BEGIN
-    CREATE OR REPLACE FUNCTION pgedge_vectorizer._tiktoken_internal(
-        p_text     TEXT,
-        p_encoding TEXT DEFAULT 'cl100k_base'
-    ) RETURNS INT
-    LANGUAGE plpython3u STABLE STRICT
-    AS $py$
-        import tiktoken
-        enc = tiktoken.get_encoding(p_encoding)
-        return len(enc.encode(p_text))
-    $py$;
-EXCEPTION WHEN OTHERS THEN
-    NULL;  -- plpython3u not available, silently skip
+    IF EXISTS (SELECT 1 FROM pg_language WHERE lanname = 'plpython3u') THEN
+        CREATE OR REPLACE FUNCTION pgedge_vectorizer._tiktoken_internal(
+            p_text     TEXT,
+            p_encoding TEXT DEFAULT 'cl100k_base'
+        ) RETURNS INT
+        LANGUAGE plpython3u STABLE STRICT
+        AS $py$
+            import tiktoken
+            enc = tiktoken.get_encoding(p_encoding)
+            return len(enc.encode(p_text))
+        $py$;
+    END IF;
 END;
 $tiktoken_init$;
 
@@ -177,7 +175,7 @@ BEGIN
         current_setting('pgedge_vectorizer.use_tiktoken', true),
         'false'
     )::BOOLEAN THEN
-        RETURN (length(p_text) + 3) / 4;
+        RETURN pgedge_vectorizer.count_tokens(p_text);
     END IF;
 
     -- use_tiktoken = on: delegate to plpython3u internal function
@@ -186,14 +184,14 @@ BEGIN
         RETURN result;
     EXCEPTION WHEN undefined_function THEN
         RAISE NOTICE 'tiktoken: plpython3u or tiktoken not available, falling back to approximation';
-        RETURN (length(p_text) + 3) / 4;
+        RETURN pgedge_vectorizer.count_tokens(p_text);
     END;
 END;
 $$;
 
 COMMENT ON FUNCTION pgedge_vectorizer.tiktoken_count_tokens IS
 'Count tokens using tiktoken when pgedge_vectorizer.use_tiktoken = on, '
-'otherwise returns a character-based approximation (~4 chars/token). '
+'otherwise returns a character-based approximation via count_tokens(). '
 'Requires plpython3u and the tiktoken Python package when use_tiktoken is on.';
 
 ---------------------------------------------------------------------------
@@ -411,7 +409,7 @@ BEGIN
                               (sparse_embedding IS NULL) AS needs_sparse',
                     chunk_table, chunk_table, chunk_table, chunk_table, chunk_table)
                 USING row_record.pk_val, i, chunk_text,
-                      pgedge_vectorizer.count_tokens(chunk_text, NULL)  -- UTF-8 aware token approximation
+                      pgedge_vectorizer.count_tokens(chunk_text)  -- UTF-8 aware token approximation
                 INTO chunk_id, needs_embedding, needs_sparse;
 
                 -- Queue if dense or sparse work is needed.
@@ -728,7 +726,7 @@ BEGIN
             VALUES ($1::%s, $2, $3, $4)
             RETURNING id', chunk_table, pk_type)
         USING source_id_val, i, chunk_text,
-              pgedge_vectorizer.count_tokens(chunk_text, NULL)  -- UTF-8 aware token approximation
+              pgedge_vectorizer.count_tokens(chunk_text)  -- UTF-8 aware token approximation
         INTO chunk_id;
 
         -- Queue for embedding
@@ -1023,7 +1021,7 @@ BEGIN
                     VALUES ($1::%s, $2, $3, $4)
                     RETURNING id', chunk_table_name, pk_type)
                 USING row_record.pk_val, i, chunk_text,
-                      pgedge_vectorizer.count_tokens(chunk_text, NULL)  -- UTF-8 aware token approximation
+                      pgedge_vectorizer.count_tokens(chunk_text)  -- UTF-8 aware token approximation
                 INTO chunk_id;
 
                 -- Queue for embedding

--- a/sql/pgedge_vectorizer--1.0--1.1.sql
+++ b/sql/pgedge_vectorizer--1.0--1.1.sql
@@ -160,6 +160,46 @@ BEGIN
 END;
 $tiktoken_init$;
 
+-- Recovery path: (re)creates _tiktoken_internal when plpython3u is installed
+-- after the extension was first loaded.  Call via enable_tiktoken_support().
+CREATE OR REPLACE FUNCTION pgedge_vectorizer.enable_tiktoken_support()
+RETURNS TEXT
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_language WHERE lanname = 'plpython3u') THEN
+        RETURN 'plpython3u is not available; install the postgresql-plpython3 '
+               'package for your PostgreSQL version and retry';
+    END IF;
+
+    EXECUTE $inner$
+        CREATE OR REPLACE FUNCTION pgedge_vectorizer._tiktoken_internal(
+            p_text     TEXT,
+            p_encoding TEXT DEFAULT 'cl100k_base'
+        ) RETURNS INT
+        LANGUAGE plpython3u STABLE STRICT
+        AS $py$
+            import tiktoken
+            enc = tiktoken.get_encoding(p_encoding)
+            return len(enc.encode(p_text))
+        $py$
+    $inner$;
+
+    EXECUTE $inner$
+        COMMENT ON FUNCTION pgedge_vectorizer._tiktoken_internal(TEXT, TEXT) IS
+        'Internal plpython3u helper used by tiktoken_count_tokens(); do not call directly.'
+    $inner$;
+
+    RETURN 'ok';
+END;
+$$;
+
+COMMENT ON FUNCTION pgedge_vectorizer.enable_tiktoken_support IS
+'Creates or recreates the _tiktoken_internal plpython3u helper. Call this '
+'after installing plpython3u (postgresql-plpython3-XX) and the tiktoken '
+'Python package when the extension was originally installed without plpython3u. '
+'Returns ''ok'' on success or a message describing what is missing.';
+
 -- Tiktoken-based token counting with graceful fallback to approximation
 CREATE OR REPLACE FUNCTION pgedge_vectorizer.tiktoken_count_tokens(
     p_text     TEXT,
@@ -1056,8 +1096,8 @@ DECLARE
     rows_updated BIGINT;
 BEGIN
     EXECUTE format(
-        'UPDATE %I SET token_count = pgedge_vectorizer.tiktoken_count_tokens(content)',
-        p_chunk_table::TEXT
+        'UPDATE %s SET token_count = pgedge_vectorizer.tiktoken_count_tokens(content)',
+        p_chunk_table
     );
     GET DIAGNOSTICS rows_updated = ROW_COUNT;
     RAISE NOTICE 'refresh_token_counts: updated % rows in %',

--- a/sql/pgedge_vectorizer--1.0--1.1.sql
+++ b/sql/pgedge_vectorizer--1.0--1.1.sql
@@ -233,7 +233,6 @@ BEGIN
         SELECT pgedge_vectorizer._tiktoken_internal(p_text, p_encoding) INTO result;
         RETURN result;
     EXCEPTION WHEN OTHERS THEN
-        RAISE NOTICE 'tiktoken: plpython3u or tiktoken not available, falling back to approximation';
         RETURN pgedge_vectorizer.count_tokens(p_text);
     END;
 END;

--- a/sql/pgedge_vectorizer--1.0--1.1.sql
+++ b/sql/pgedge_vectorizer--1.0--1.1.sql
@@ -152,7 +152,7 @@ BEGIN
             """Return the exact token count for p_text using the given tiktoken encoding."""
             import tiktoken
             enc = tiktoken.get_encoding(p_encoding)
-            return len(enc.encode(p_text))
+            return len(enc.encode(p_text, disallowed_special=()))
         $py$;
         COMMENT ON FUNCTION pgedge_vectorizer._tiktoken_internal IS
         'Internal plpython3u helper used by tiktoken_count_tokens(); do not call directly.';
@@ -181,9 +181,20 @@ BEGIN
         AS $py$
             import tiktoken
             enc = tiktoken.get_encoding(p_encoding)
-            return len(enc.encode(p_text))
+            return len(enc.encode(p_text, disallowed_special=()))
         $py$
     $inner$;
+
+    -- Register with the extension; silently skip if already a member
+    -- (happens when plpython3u was available at CREATE EXTENSION time).
+    BEGIN
+        EXECUTE $inner$
+            ALTER EXTENSION pgedge_vectorizer ADD FUNCTION
+                pgedge_vectorizer._tiktoken_internal(TEXT, TEXT)
+        $inner$;
+    EXCEPTION WHEN OTHERS THEN
+        NULL;
+    END;
 
     EXECUTE $inner$
         COMMENT ON FUNCTION pgedge_vectorizer._tiktoken_internal(TEXT, TEXT) IS

--- a/sql/pgedge_vectorizer--1.0--1.1.sql
+++ b/sql/pgedge_vectorizer--1.0--1.1.sql
@@ -129,6 +129,73 @@ LANGUAGE C STRICT;
 COMMENT ON FUNCTION pgedge_vectorizer.bm25_tokenize IS
 'Tokenize text and return the non-stopword terms (useful for testing)';
 
+-- UTF-8 aware approximate token counter (C implementation)
+CREATE OR REPLACE FUNCTION pgedge_vectorizer.count_tokens(
+    p_text  TEXT,
+    p_model TEXT DEFAULT NULL
+) RETURNS INT
+AS 'MODULE_PATHNAME', 'pgedge_vectorizer_count_tokens_sql'
+LANGUAGE C STABLE;
+
+COMMENT ON FUNCTION pgedge_vectorizer.count_tokens IS
+'Approximate token count using UTF-8 character counting (~4 chars/token). '
+'The p_model parameter is reserved for future use.';
+
+-- Internal plpython3u implementation (created only if plpython3u is available)
+DO $tiktoken_init$
+BEGIN
+    CREATE OR REPLACE FUNCTION pgedge_vectorizer._tiktoken_internal(
+        p_text     TEXT,
+        p_encoding TEXT DEFAULT 'cl100k_base'
+    ) RETURNS INT
+    LANGUAGE plpython3u STABLE STRICT
+    AS $py$
+        import tiktoken
+        enc = tiktoken.get_encoding(p_encoding)
+        return len(enc.encode(p_text))
+    $py$;
+EXCEPTION WHEN OTHERS THEN
+    NULL;  -- plpython3u not available, silently skip
+END;
+$tiktoken_init$;
+
+-- Tiktoken-based token counting with graceful fallback to approximation
+CREATE OR REPLACE FUNCTION pgedge_vectorizer.tiktoken_count_tokens(
+    p_text     TEXT,
+    p_encoding TEXT DEFAULT 'cl100k_base'
+) RETURNS INT
+LANGUAGE plpgsql STABLE
+AS $$
+DECLARE
+    result INT;
+BEGIN
+    IF p_text IS NULL OR p_text = '' THEN
+        RETURN 0;
+    END IF;
+
+    IF NOT COALESCE(
+        current_setting('pgedge_vectorizer.use_tiktoken', true),
+        'false'
+    )::BOOLEAN THEN
+        RETURN (length(p_text) + 3) / 4;
+    END IF;
+
+    -- use_tiktoken = on: delegate to plpython3u internal function
+    BEGIN
+        SELECT pgedge_vectorizer._tiktoken_internal(p_text, p_encoding) INTO result;
+        RETURN result;
+    EXCEPTION WHEN undefined_function THEN
+        RAISE NOTICE 'tiktoken: plpython3u or tiktoken not available, falling back to approximation';
+        RETURN (length(p_text) + 3) / 4;
+    END;
+END;
+$$;
+
+COMMENT ON FUNCTION pgedge_vectorizer.tiktoken_count_tokens IS
+'Count tokens using tiktoken when pgedge_vectorizer.use_tiktoken = on, '
+'otherwise returns a character-based approximation (~4 chars/token). '
+'Requires plpython3u and the tiktoken Python package when use_tiktoken is on.';
+
 ---------------------------------------------------------------------------
 -- SQL Functions
 ---------------------------------------------------------------------------
@@ -344,7 +411,7 @@ BEGIN
                               (sparse_embedding IS NULL) AS needs_sparse',
                     chunk_table, chunk_table, chunk_table, chunk_table, chunk_table)
                 USING row_record.pk_val, i, chunk_text,
-                      length(chunk_text) / 4  -- Approximate token count
+                      pgedge_vectorizer.count_tokens(chunk_text, NULL)  -- UTF-8 aware token approximation
                 INTO chunk_id, needs_embedding, needs_sparse;
 
                 -- Queue if dense or sparse work is needed.
@@ -661,7 +728,7 @@ BEGIN
             VALUES ($1::%s, $2, $3, $4)
             RETURNING id', chunk_table, pk_type)
         USING source_id_val, i, chunk_text,
-              length(chunk_text) / 4  -- Approximate token count
+              pgedge_vectorizer.count_tokens(chunk_text, NULL)  -- UTF-8 aware token approximation
         INTO chunk_id;
 
         -- Queue for embedding
@@ -956,7 +1023,7 @@ BEGIN
                     VALUES ($1::%s, $2, $3, $4)
                     RETURNING id', chunk_table_name, pk_type)
                 USING row_record.pk_val, i, chunk_text,
-                      length(chunk_text) / 4  -- Approximate token count
+                      pgedge_vectorizer.count_tokens(chunk_text, NULL)  -- UTF-8 aware token approximation
                 INTO chunk_id;
 
                 -- Queue for embedding

--- a/sql/pgedge_vectorizer--1.0--1.1.sql
+++ b/sql/pgedge_vectorizer--1.0--1.1.sql
@@ -149,10 +149,13 @@ BEGIN
         ) RETURNS INT
         LANGUAGE plpython3u STABLE STRICT
         AS $py$
+            """Return the exact token count for p_text using the given tiktoken encoding."""
             import tiktoken
             enc = tiktoken.get_encoding(p_encoding)
             return len(enc.encode(p_text))
         $py$;
+        COMMENT ON FUNCTION pgedge_vectorizer._tiktoken_internal IS
+        'Internal plpython3u helper used by tiktoken_count_tokens(); do not call directly.';
     END IF;
 END;
 $tiktoken_init$;

--- a/sql/pgedge_vectorizer--1.0--1.1.sql
+++ b/sql/pgedge_vectorizer--1.0--1.1.sql
@@ -190,6 +190,13 @@ BEGIN
         'Internal plpython3u helper used by tiktoken_count_tokens(); do not call directly.'
     $inner$;
 
+    -- Verify tiktoken Python package is importable at runtime
+    BEGIN
+        PERFORM pgedge_vectorizer._tiktoken_internal('', 'cl100k_base');
+    EXCEPTION WHEN OTHERS THEN
+        RETURN 'tiktoken not available: ' || SQLERRM;
+    END;
+
     RETURN 'ok';
 END;
 $$;

--- a/sql/pgedge_vectorizer--1.1.sql
+++ b/sql/pgedge_vectorizer--1.1.sql
@@ -129,6 +129,73 @@ LANGUAGE C STRICT;
 COMMENT ON FUNCTION pgedge_vectorizer.bm25_tokenize IS
 'Tokenize text and return the non-stopword terms (useful for testing)';
 
+-- UTF-8 aware approximate token counter (C implementation)
+CREATE FUNCTION pgedge_vectorizer.count_tokens(
+    p_text  TEXT,
+    p_model TEXT DEFAULT NULL
+) RETURNS INT
+AS 'MODULE_PATHNAME', 'pgedge_vectorizer_count_tokens_sql'
+LANGUAGE C STABLE;
+
+COMMENT ON FUNCTION pgedge_vectorizer.count_tokens IS
+'Approximate token count using UTF-8 character counting (~4 chars/token). '
+'The p_model parameter is reserved for future use.';
+
+-- Internal plpython3u implementation (created only if plpython3u is available)
+DO $tiktoken_init$
+BEGIN
+    CREATE FUNCTION pgedge_vectorizer._tiktoken_internal(
+        p_text     TEXT,
+        p_encoding TEXT DEFAULT 'cl100k_base'
+    ) RETURNS INT
+    LANGUAGE plpython3u STABLE STRICT
+    AS $py$
+        import tiktoken
+        enc = tiktoken.get_encoding(p_encoding)
+        return len(enc.encode(p_text))
+    $py$;
+EXCEPTION WHEN OTHERS THEN
+    NULL;  -- plpython3u not available, silently skip
+END;
+$tiktoken_init$;
+
+-- Tiktoken-based token counting with graceful fallback to approximation
+CREATE FUNCTION pgedge_vectorizer.tiktoken_count_tokens(
+    p_text     TEXT,
+    p_encoding TEXT DEFAULT 'cl100k_base'
+) RETURNS INT
+LANGUAGE plpgsql STABLE
+AS $$
+DECLARE
+    result INT;
+BEGIN
+    IF p_text IS NULL OR p_text = '' THEN
+        RETURN 0;
+    END IF;
+
+    IF NOT COALESCE(
+        current_setting('pgedge_vectorizer.use_tiktoken', true),
+        'false'
+    )::BOOLEAN THEN
+        RETURN (length(p_text) + 3) / 4;
+    END IF;
+
+    -- use_tiktoken = on: delegate to plpython3u internal function
+    BEGIN
+        SELECT pgedge_vectorizer._tiktoken_internal(p_text, p_encoding) INTO result;
+        RETURN result;
+    EXCEPTION WHEN undefined_function THEN
+        RAISE NOTICE 'tiktoken: plpython3u or tiktoken not available, falling back to approximation';
+        RETURN (length(p_text) + 3) / 4;
+    END;
+END;
+$$;
+
+COMMENT ON FUNCTION pgedge_vectorizer.tiktoken_count_tokens IS
+'Count tokens using tiktoken when pgedge_vectorizer.use_tiktoken = on, '
+'otherwise returns a character-based approximation (~4 chars/token). '
+'Requires plpython3u and the tiktoken Python package when use_tiktoken is on.';
+
 ---------------------------------------------------------------------------
 -- SQL Functions
 ---------------------------------------------------------------------------
@@ -344,7 +411,7 @@ BEGIN
                               (sparse_embedding IS NULL) AS needs_sparse',
                     chunk_table, chunk_table, chunk_table, chunk_table, chunk_table)
                 USING row_record.pk_val, i, chunk_text,
-                      length(chunk_text) / 4  -- Approximate token count
+                      pgedge_vectorizer.count_tokens(chunk_text, NULL)  -- UTF-8 aware token approximation
                 INTO chunk_id, needs_embedding, needs_sparse;
 
                 -- Queue if dense or sparse work is needed.
@@ -661,7 +728,7 @@ BEGIN
             VALUES ($1::%s, $2, $3, $4)
             RETURNING id', chunk_table, pk_type)
         USING source_id_val, i, chunk_text,
-              length(chunk_text) / 4  -- Approximate token count
+              pgedge_vectorizer.count_tokens(chunk_text, NULL)  -- UTF-8 aware token approximation
         INTO chunk_id;
 
         -- Queue for embedding
@@ -956,7 +1023,7 @@ BEGIN
                     VALUES ($1::%s, $2, $3, $4)
                     RETURNING id', chunk_table_name, pk_type)
                 USING row_record.pk_val, i, chunk_text,
-                      length(chunk_text) / 4  -- Approximate token count
+                      pgedge_vectorizer.count_tokens(chunk_text, NULL)  -- UTF-8 aware token approximation
                 INTO chunk_id;
 
                 -- Queue for embedding

--- a/sql/pgedge_vectorizer--1.1.sql
+++ b/sql/pgedge_vectorizer--1.1.sql
@@ -160,6 +160,46 @@ BEGIN
 END;
 $tiktoken_init$;
 
+-- Recovery path: (re)creates _tiktoken_internal when plpython3u is installed
+-- after the extension was first loaded.  Call via enable_tiktoken_support().
+CREATE FUNCTION pgedge_vectorizer.enable_tiktoken_support()
+RETURNS TEXT
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_language WHERE lanname = 'plpython3u') THEN
+        RETURN 'plpython3u is not available; install the postgresql-plpython3 '
+               'package for your PostgreSQL version and retry';
+    END IF;
+
+    EXECUTE $inner$
+        CREATE OR REPLACE FUNCTION pgedge_vectorizer._tiktoken_internal(
+            p_text     TEXT,
+            p_encoding TEXT DEFAULT 'cl100k_base'
+        ) RETURNS INT
+        LANGUAGE plpython3u STABLE STRICT
+        AS $py$
+            import tiktoken
+            enc = tiktoken.get_encoding(p_encoding)
+            return len(enc.encode(p_text))
+        $py$
+    $inner$;
+
+    EXECUTE $inner$
+        COMMENT ON FUNCTION pgedge_vectorizer._tiktoken_internal(TEXT, TEXT) IS
+        'Internal plpython3u helper used by tiktoken_count_tokens(); do not call directly.'
+    $inner$;
+
+    RETURN 'ok';
+END;
+$$;
+
+COMMENT ON FUNCTION pgedge_vectorizer.enable_tiktoken_support IS
+'Creates or recreates the _tiktoken_internal plpython3u helper. Call this '
+'after installing plpython3u (postgresql-plpython3-XX) and the tiktoken '
+'Python package when the extension was originally installed without plpython3u. '
+'Returns ''ok'' on success or a message describing what is missing.';
+
 -- Tiktoken-based token counting with graceful fallback to approximation
 CREATE FUNCTION pgedge_vectorizer.tiktoken_count_tokens(
     p_text     TEXT,
@@ -1056,8 +1096,8 @@ DECLARE
     rows_updated BIGINT;
 BEGIN
     EXECUTE format(
-        'UPDATE %I SET token_count = pgedge_vectorizer.tiktoken_count_tokens(content)',
-        p_chunk_table::TEXT
+        'UPDATE %s SET token_count = pgedge_vectorizer.tiktoken_count_tokens(content)',
+        p_chunk_table
     );
     GET DIAGNOSTICS rows_updated = ROW_COUNT;
     RAISE NOTICE 'refresh_token_counts: updated % rows in %',

--- a/sql/pgedge_vectorizer--1.1.sql
+++ b/sql/pgedge_vectorizer--1.1.sql
@@ -233,7 +233,6 @@ BEGIN
         SELECT pgedge_vectorizer._tiktoken_internal(p_text, p_encoding) INTO result;
         RETURN result;
     EXCEPTION WHEN OTHERS THEN
-        RAISE NOTICE 'tiktoken: plpython3u or tiktoken not available, falling back to approximation';
         RETURN pgedge_vectorizer.count_tokens(p_text);
     END;
 END;

--- a/sql/pgedge_vectorizer--1.1.sql
+++ b/sql/pgedge_vectorizer--1.1.sql
@@ -152,7 +152,7 @@ BEGIN
             """Return the exact token count for p_text using the given tiktoken encoding."""
             import tiktoken
             enc = tiktoken.get_encoding(p_encoding)
-            return len(enc.encode(p_text))
+            return len(enc.encode(p_text, disallowed_special=()))
         $py$;
         COMMENT ON FUNCTION pgedge_vectorizer._tiktoken_internal IS
         'Internal plpython3u helper used by tiktoken_count_tokens(); do not call directly.';
@@ -181,9 +181,20 @@ BEGIN
         AS $py$
             import tiktoken
             enc = tiktoken.get_encoding(p_encoding)
-            return len(enc.encode(p_text))
+            return len(enc.encode(p_text, disallowed_special=()))
         $py$
     $inner$;
+
+    -- Register with the extension; silently skip if already a member
+    -- (happens when plpython3u was available at CREATE EXTENSION time).
+    BEGIN
+        EXECUTE $inner$
+            ALTER EXTENSION pgedge_vectorizer ADD FUNCTION
+                pgedge_vectorizer._tiktoken_internal(TEXT, TEXT)
+        $inner$;
+    EXCEPTION WHEN OTHERS THEN
+        NULL;
+    END;
 
     EXECUTE $inner$
         COMMENT ON FUNCTION pgedge_vectorizer._tiktoken_internal(TEXT, TEXT) IS

--- a/sql/pgedge_vectorizer--1.1.sql
+++ b/sql/pgedge_vectorizer--1.1.sql
@@ -131,31 +131,29 @@ COMMENT ON FUNCTION pgedge_vectorizer.bm25_tokenize IS
 
 -- UTF-8 aware approximate token counter (C implementation)
 CREATE FUNCTION pgedge_vectorizer.count_tokens(
-    p_text  TEXT,
-    p_model TEXT DEFAULT NULL
+    p_text TEXT
 ) RETURNS INT
 AS 'MODULE_PATHNAME', 'pgedge_vectorizer_count_tokens_sql'
-LANGUAGE C STABLE;
+LANGUAGE C IMMUTABLE STRICT;
 
 COMMENT ON FUNCTION pgedge_vectorizer.count_tokens IS
-'Approximate token count using UTF-8 character counting (~4 chars/token). '
-'The p_model parameter is reserved for future use.';
+'Approximate token count using UTF-8 character counting (~4 chars/token).';
 
 -- Internal plpython3u implementation (created only if plpython3u is available)
 DO $tiktoken_init$
 BEGIN
-    CREATE FUNCTION pgedge_vectorizer._tiktoken_internal(
-        p_text     TEXT,
-        p_encoding TEXT DEFAULT 'cl100k_base'
-    ) RETURNS INT
-    LANGUAGE plpython3u STABLE STRICT
-    AS $py$
-        import tiktoken
-        enc = tiktoken.get_encoding(p_encoding)
-        return len(enc.encode(p_text))
-    $py$;
-EXCEPTION WHEN OTHERS THEN
-    NULL;  -- plpython3u not available, silently skip
+    IF EXISTS (SELECT 1 FROM pg_language WHERE lanname = 'plpython3u') THEN
+        CREATE FUNCTION pgedge_vectorizer._tiktoken_internal(
+            p_text     TEXT,
+            p_encoding TEXT DEFAULT 'cl100k_base'
+        ) RETURNS INT
+        LANGUAGE plpython3u STABLE STRICT
+        AS $py$
+            import tiktoken
+            enc = tiktoken.get_encoding(p_encoding)
+            return len(enc.encode(p_text))
+        $py$;
+    END IF;
 END;
 $tiktoken_init$;
 
@@ -177,7 +175,7 @@ BEGIN
         current_setting('pgedge_vectorizer.use_tiktoken', true),
         'false'
     )::BOOLEAN THEN
-        RETURN (length(p_text) + 3) / 4;
+        RETURN pgedge_vectorizer.count_tokens(p_text);
     END IF;
 
     -- use_tiktoken = on: delegate to plpython3u internal function
@@ -186,14 +184,14 @@ BEGIN
         RETURN result;
     EXCEPTION WHEN undefined_function THEN
         RAISE NOTICE 'tiktoken: plpython3u or tiktoken not available, falling back to approximation';
-        RETURN (length(p_text) + 3) / 4;
+        RETURN pgedge_vectorizer.count_tokens(p_text);
     END;
 END;
 $$;
 
 COMMENT ON FUNCTION pgedge_vectorizer.tiktoken_count_tokens IS
 'Count tokens using tiktoken when pgedge_vectorizer.use_tiktoken = on, '
-'otherwise returns a character-based approximation (~4 chars/token). '
+'otherwise returns a character-based approximation via count_tokens(). '
 'Requires plpython3u and the tiktoken Python package when use_tiktoken is on.';
 
 ---------------------------------------------------------------------------
@@ -411,7 +409,7 @@ BEGIN
                               (sparse_embedding IS NULL) AS needs_sparse',
                     chunk_table, chunk_table, chunk_table, chunk_table, chunk_table)
                 USING row_record.pk_val, i, chunk_text,
-                      pgedge_vectorizer.count_tokens(chunk_text, NULL)  -- UTF-8 aware token approximation
+                      pgedge_vectorizer.count_tokens(chunk_text)  -- UTF-8 aware token approximation
                 INTO chunk_id, needs_embedding, needs_sparse;
 
                 -- Queue if dense or sparse work is needed.
@@ -728,7 +726,7 @@ BEGIN
             VALUES ($1::%s, $2, $3, $4)
             RETURNING id', chunk_table, pk_type)
         USING source_id_val, i, chunk_text,
-              pgedge_vectorizer.count_tokens(chunk_text, NULL)  -- UTF-8 aware token approximation
+              pgedge_vectorizer.count_tokens(chunk_text)  -- UTF-8 aware token approximation
         INTO chunk_id;
 
         -- Queue for embedding
@@ -1023,7 +1021,7 @@ BEGIN
                     VALUES ($1::%s, $2, $3, $4)
                     RETURNING id', chunk_table_name, pk_type)
                 USING row_record.pk_val, i, chunk_text,
-                      pgedge_vectorizer.count_tokens(chunk_text, NULL)  -- UTF-8 aware token approximation
+                      pgedge_vectorizer.count_tokens(chunk_text)  -- UTF-8 aware token approximation
                 INTO chunk_id;
 
                 -- Queue for embedding

--- a/sql/pgedge_vectorizer--1.1.sql
+++ b/sql/pgedge_vectorizer--1.1.sql
@@ -185,7 +185,7 @@ BEGIN
     BEGIN
         SELECT pgedge_vectorizer._tiktoken_internal(p_text, p_encoding) INTO result;
         RETURN result;
-    EXCEPTION WHEN undefined_function THEN
+    EXCEPTION WHEN OTHERS THEN
         RAISE NOTICE 'tiktoken: plpython3u or tiktoken not available, falling back to approximation';
         RETURN pgedge_vectorizer.count_tokens(p_text);
     END;
@@ -195,7 +195,9 @@ $$;
 COMMENT ON FUNCTION pgedge_vectorizer.tiktoken_count_tokens IS
 'Count tokens using tiktoken when pgedge_vectorizer.use_tiktoken = on, '
 'otherwise returns a character-based approximation via count_tokens(). '
-'Requires plpython3u and the tiktoken Python package when use_tiktoken is on.';
+'Requires plpython3u and the tiktoken Python package when use_tiktoken is on. '
+'Used by enable_vectorization() and recreate_chunks() for stored token_count accuracy. '
+'The vectorization_trigger() always uses count_tokens() for hot-path performance.';
 
 ---------------------------------------------------------------------------
 -- SQL Functions
@@ -412,7 +414,7 @@ BEGIN
                               (sparse_embedding IS NULL) AS needs_sparse',
                     chunk_table, chunk_table, chunk_table, chunk_table, chunk_table)
                 USING row_record.pk_val, i, chunk_text,
-                      pgedge_vectorizer.count_tokens(chunk_text)  -- UTF-8 aware token approximation
+                      pgedge_vectorizer.tiktoken_count_tokens(chunk_text)  -- uses tiktoken when use_tiktoken=on
                 INTO chunk_id, needs_embedding, needs_sparse;
 
                 -- Queue if dense or sparse work is needed.
@@ -1024,7 +1026,7 @@ BEGIN
                     VALUES ($1::%s, $2, $3, $4)
                     RETURNING id', chunk_table_name, pk_type)
                 USING row_record.pk_val, i, chunk_text,
-                      pgedge_vectorizer.count_tokens(chunk_text)  -- UTF-8 aware token approximation
+                      pgedge_vectorizer.tiktoken_count_tokens(chunk_text)  -- uses tiktoken when use_tiktoken=on
                 INTO chunk_id;
 
                 -- Queue for embedding
@@ -1043,6 +1045,33 @@ $$ LANGUAGE plpgsql;
 
 COMMENT ON FUNCTION pgedge_vectorizer.recreate_chunks IS
 'Delete all chunks and recreate from source table (complete rebuild)';
+
+---------------------------------------------------------------------------
+-- refresh_token_counts() — recompute stored token_count for existing chunks
+---------------------------------------------------------------------------
+CREATE FUNCTION pgedge_vectorizer.refresh_token_counts(
+    p_chunk_table REGCLASS
+) RETURNS BIGINT AS $$
+DECLARE
+    rows_updated BIGINT;
+BEGIN
+    EXECUTE format(
+        'UPDATE %I SET token_count = pgedge_vectorizer.tiktoken_count_tokens(content)',
+        p_chunk_table::TEXT
+    );
+    GET DIAGNOSTICS rows_updated = ROW_COUNT;
+    RAISE NOTICE 'refresh_token_counts: updated % rows in %',
+        rows_updated, p_chunk_table::TEXT;
+    RETURN rows_updated;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION pgedge_vectorizer.refresh_token_counts IS
+'Recompute token_count for every row in the given chunk table using the current '
+'tiktoken_count_tokens() setting. Useful after enabling use_tiktoken = on to '
+'back-fill accurate counts without a full recreate_chunks() rebuild. The '
+'vectorization_trigger() always uses count_tokens() for performance; call this '
+'function to align pre-existing rows.';
 
 -- Get configuration summary
 CREATE FUNCTION pgedge_vectorizer.show_config()

--- a/sql/pgedge_vectorizer--1.1.sql
+++ b/sql/pgedge_vectorizer--1.1.sql
@@ -149,10 +149,13 @@ BEGIN
         ) RETURNS INT
         LANGUAGE plpython3u STABLE STRICT
         AS $py$
+            """Return the exact token count for p_text using the given tiktoken encoding."""
             import tiktoken
             enc = tiktoken.get_encoding(p_encoding)
             return len(enc.encode(p_text))
         $py$;
+        COMMENT ON FUNCTION pgedge_vectorizer._tiktoken_internal IS
+        'Internal plpython3u helper used by tiktoken_count_tokens(); do not call directly.';
     END IF;
 END;
 $tiktoken_init$;

--- a/sql/pgedge_vectorizer--1.1.sql
+++ b/sql/pgedge_vectorizer--1.1.sql
@@ -190,6 +190,13 @@ BEGIN
         'Internal plpython3u helper used by tiktoken_count_tokens(); do not call directly.'
     $inner$;
 
+    -- Verify tiktoken Python package is importable at runtime
+    BEGIN
+        PERFORM pgedge_vectorizer._tiktoken_internal('', 'cl100k_base');
+    EXCEPTION WHEN OTHERS THEN
+        RETURN 'tiktoken not available: ' || SQLERRM;
+    END;
+
     RETURN 'ok';
 END;
 $$;

--- a/src/guc.c
+++ b/src/guc.c
@@ -268,10 +268,13 @@ pgedge_vectorizer_init_guc(void)
 	/* Tiktoken configuration */
 	DefineCustomBoolVariable(
 		"pgedge_vectorizer.use_tiktoken",
-		"Use tiktoken (via plpython3u) for accurate token counting",
+		"Use tiktoken (via plpython3u) for accurate token counting in bulk operations",
 		"When enabled, tiktoken_count_tokens() calls the internal plpython3u function "
 		"instead of the character-based approximation. Requires plpython3u and the "
-		"tiktoken Python package.",
+		"tiktoken Python package. "
+		"Affects stored token_count in enable_vectorization() and recreate_chunks() "
+		"(bulk/backfill paths). The vectorization_trigger() always uses count_tokens() "
+		"for hot-path performance regardless of this setting.",
 		&pgedge_vectorizer_use_tiktoken,
 		false,
 		PGC_USERSET,

--- a/src/guc.c
+++ b/src/guc.c
@@ -52,6 +52,11 @@ double pgedge_vectorizer_bm25_k1       = 1.2;
 double pgedge_vectorizer_bm25_b        = 0.75;
 
 /*
+ * GUC Variables - Tiktoken configuration
+ */
+bool pgedge_vectorizer_use_tiktoken = false;
+
+/*
  * Initialize all GUC variables
  */
 void
@@ -256,6 +261,19 @@ pgedge_vectorizer_init_guc(void)
 		0.75,   /* default */
 		0.0,    /* min */
 		1.0,    /* max */
+		PGC_USERSET,
+		0,
+		NULL, NULL, NULL);
+
+	/* Tiktoken configuration */
+	DefineCustomBoolVariable(
+		"pgedge_vectorizer.use_tiktoken",
+		"Use tiktoken (via plpython3u) for accurate token counting",
+		"When enabled, tiktoken_count_tokens() calls the internal plpython3u function "
+		"instead of the character-based approximation. Requires plpython3u and the "
+		"tiktoken Python package.",
+		&pgedge_vectorizer_use_tiktoken,
+		false,
 		PGC_USERSET,
 		0,
 		NULL, NULL, NULL);

--- a/src/pgedge_vectorizer.h
+++ b/src/pgedge_vectorizer.h
@@ -73,6 +73,11 @@ extern double pgedge_vectorizer_bm25_k1;
 extern double pgedge_vectorizer_bm25_b;
 
 /*
+ * GUC Variables - Tiktoken configuration
+ */
+extern bool pgedge_vectorizer_use_tiktoken;
+
+/*
  * Chunking strategy enumeration
  */
 typedef enum

--- a/src/tokenizer.c
+++ b/src/tokenizer.c
@@ -128,7 +128,7 @@ get_char_offset_for_tokens(const char *text, int target_tokens, const char *mode
  * SQL-callable wrapper for count_tokens
  *
  * Exposes the C token counting approximation to SQL as
- * pgedge_vectorizer.count_tokens(text, model).
+ * pgedge_vectorizer.count_tokens(text).
  */
 PG_FUNCTION_INFO_V1(pgedge_vectorizer_count_tokens_sql);
 
@@ -137,7 +137,6 @@ pgedge_vectorizer_count_tokens_sql(PG_FUNCTION_ARGS)
 {
 	text	   *input;
 	char	   *str;
-	char	   *model = NULL;
 	int			token_count;
 
 	if (PG_ARGISNULL(0))
@@ -145,14 +144,7 @@ pgedge_vectorizer_count_tokens_sql(PG_FUNCTION_ARGS)
 
 	input = PG_GETARG_TEXT_PP(0);
 	str = text_to_cstring(input);
-
-	if (!PG_ARGISNULL(1))
-	{
-		text *model_text = PG_GETARG_TEXT_PP(1);
-		model = text_to_cstring(model_text);
-	}
-
-	token_count = count_tokens(str, model);
+	token_count = count_tokens(str, NULL);
 	PG_RETURN_INT32(token_count);
 }
 

--- a/src/tokenizer.c
+++ b/src/tokenizer.c
@@ -125,6 +125,38 @@ get_char_offset_for_tokens(const char *text, int target_tokens, const char *mode
 }
 
 /*
+ * SQL-callable wrapper for count_tokens
+ *
+ * Exposes the C token counting approximation to SQL as
+ * pgedge_vectorizer.count_tokens(text, model).
+ */
+PG_FUNCTION_INFO_V1(pgedge_vectorizer_count_tokens_sql);
+
+Datum
+pgedge_vectorizer_count_tokens_sql(PG_FUNCTION_ARGS)
+{
+	text	   *input;
+	char	   *str;
+	char	   *model = NULL;
+	int			token_count;
+
+	if (PG_ARGISNULL(0))
+		PG_RETURN_NULL();
+
+	input = PG_GETARG_TEXT_PP(0);
+	str = text_to_cstring(input);
+
+	if (!PG_ARGISNULL(1))
+	{
+		text *model_text = PG_GETARG_TEXT_PP(1);
+		model = text_to_cstring(model_text);
+	}
+
+	token_count = count_tokens(str, model);
+	PG_RETURN_INT32(token_count);
+}
+
+/*
  * Find a good break point near the target position
  *
  * Tries to break at sentence or paragraph boundaries if possible.

--- a/test/expected/hybrid_test.out
+++ b/test/expected/hybrid_test.out
@@ -195,6 +195,8 @@ RESET pgedge_vectorizer.enable_hybrid;
 ---------------------------------------------------------------------------
 -- Test 13: hybrid_search raises when enable_hybrid is false
 ---------------------------------------------------------------------------
+-- Explicitly disable hybrid search regardless of postgresql.conf value
+SET pgedge_vectorizer.enable_hybrid = false;
 DO $$
 BEGIN
     PERFORM pgedge_vectorizer.hybrid_search(
@@ -211,6 +213,7 @@ EXCEPTION
 END;
 $$;
 NOTICE:  Got expected exception: Hybrid search is disabled. Set pgedge_vectorizer.enable_hybrid = true and allow workers to populate sparse_embedding.
+RESET pgedge_vectorizer.enable_hybrid;
 ---------------------------------------------------------------------------
 -- Test 14: bm25_query_vector returns a non-null sparsevec
 ---------------------------------------------------------------------------

--- a/test/expected/tiktoken.out
+++ b/test/expected/tiktoken.out
@@ -1,0 +1,149 @@
+-- tiktoken.sql
+-- Regression tests for tiktoken integration (accurate token counting).
+-- All assertions are deterministic regardless of plpython3u availability.
+---------------------------------------------------------------------------
+-- Test 1: GUC pgedge_vectorizer.use_tiktoken is registered
+---------------------------------------------------------------------------
+SELECT name
+FROM pg_settings
+WHERE name = 'pgedge_vectorizer.use_tiktoken';
+              name              
+--------------------------------
+ pgedge_vectorizer.use_tiktoken
+(1 row)
+
+---------------------------------------------------------------------------
+-- Test 2: count_tokens() C function is registered
+---------------------------------------------------------------------------
+SELECT proname
+FROM pg_proc
+WHERE proname = 'count_tokens'
+  AND pronamespace = (
+      SELECT oid FROM pg_namespace WHERE nspname = 'pgedge_vectorizer'
+  );
+   proname    
+--------------
+ count_tokens
+(1 row)
+
+---------------------------------------------------------------------------
+-- Test 3: count_tokens() returns correct approximation values
+---------------------------------------------------------------------------
+-- 'hello world' = 11 chars, (11+3)/4 = 3
+SELECT pgedge_vectorizer.count_tokens('hello world', NULL) AS tokens;
+ tokens 
+--------
+      3
+(1 row)
+
+-- empty string returns 0
+SELECT pgedge_vectorizer.count_tokens('', NULL) AS tokens;
+ tokens 
+--------
+      0
+(1 row)
+
+-- 'test' = 4 chars, (4+3)/4 = 1
+SELECT pgedge_vectorizer.count_tokens('test', NULL) AS tokens;
+ tokens 
+--------
+      1
+(1 row)
+
+-- NULL input returns NULL
+SELECT pgedge_vectorizer.count_tokens(NULL, NULL) IS NULL AS is_null;
+ is_null 
+---------
+ t
+(1 row)
+
+---------------------------------------------------------------------------
+-- Test 4: tiktoken_count_tokens() PL/pgSQL wrapper is registered
+---------------------------------------------------------------------------
+SELECT proname
+FROM pg_proc
+WHERE proname = 'tiktoken_count_tokens'
+  AND pronamespace = (
+      SELECT oid FROM pg_namespace WHERE nspname = 'pgedge_vectorizer'
+  );
+        proname        
+-----------------------
+ tiktoken_count_tokens
+(1 row)
+
+---------------------------------------------------------------------------
+-- Test 5: tiktoken_count_tokens() with use_tiktoken=off uses approximation
+---------------------------------------------------------------------------
+SET pgedge_vectorizer.use_tiktoken = off;
+-- (11+3)/4 = 3
+SELECT pgedge_vectorizer.tiktoken_count_tokens('hello world', 'cl100k_base') AS tokens;
+ tokens 
+--------
+      3
+(1 row)
+
+-- empty string returns 0
+SELECT pgedge_vectorizer.tiktoken_count_tokens('', 'cl100k_base') AS tokens;
+ tokens 
+--------
+      0
+(1 row)
+
+-- NULL input returns 0
+SELECT pgedge_vectorizer.tiktoken_count_tokens(NULL, 'cl100k_base') AS tokens;
+ tokens 
+--------
+      0
+(1 row)
+
+RESET pgedge_vectorizer.use_tiktoken;
+---------------------------------------------------------------------------
+-- Test 6: Integration - chunk table token_count is populated
+---------------------------------------------------------------------------
+CREATE TABLE tiktoken_test_docs (
+    id      BIGSERIAL PRIMARY KEY,
+    content TEXT
+);
+INSERT INTO tiktoken_test_docs (content)
+VALUES ('This is a test document for token count verification.');
+SELECT pgedge_vectorizer.enable_vectorization(
+    'tiktoken_test_docs'::regclass,
+    'content',
+    'token_based',
+    100,
+    10,
+    1536
+);
+NOTICE:  Using primary key column: id (bigint)
+NOTICE:  column "sparse_embedding" of relation "tiktoken_test_docs_content_chunks" already exists, skipping
+NOTICE:  Vectorization enabled: tiktoken_test_docs -> tiktoken_test_docs_content_chunks
+NOTICE:  Strategy: token_based, chunk_size: 100, overlap: 10
+NOTICE:  Processing existing rows...
+NOTICE:  Processed 1 existing rows
+ enable_vectorization 
+----------------------
+ 
+(1 row)
+
+-- token_count column exists and holds a positive integer
+SELECT token_count > 0 AS token_count_positive
+FROM tiktoken_test_docs_content_chunks
+LIMIT 1;
+ token_count_positive 
+----------------------
+ t
+(1 row)
+
+---------------------------------------------------------------------------
+-- Cleanup
+---------------------------------------------------------------------------
+SELECT pgedge_vectorizer.disable_vectorization(
+    'tiktoken_test_docs'::regclass, 'content', true
+);
+NOTICE:  Vectorization disabled and chunk table dropped: tiktoken_test_docs_content_chunks
+ disable_vectorization 
+-----------------------
+ 
+(1 row)
+
+DROP TABLE tiktoken_test_docs;

--- a/test/expected/tiktoken.out
+++ b/test/expected/tiktoken.out
@@ -146,7 +146,7 @@ BEGIN
             ) RETURNS INT LANGUAGE plpython3u STABLE STRICT AS $py$
                 import tiktoken
                 enc = tiktoken.get_encoding(p_encoding)
-                return len(enc.encode(p_text))
+                return len(enc.encode(p_text, disallowed_special=()))
             $py$
         $f$;
     END IF;

--- a/test/expected/tiktoken.out
+++ b/test/expected/tiktoken.out
@@ -120,8 +120,9 @@ BEGIN
 END;
 $$;
 SET pgedge_vectorizer.use_tiktoken = on;
--- Should fall back gracefully and return a non-negative value
-SELECT pgedge_vectorizer.tiktoken_count_tokens('hello world') >= 0 AS fallback_works;
+-- Should fall back to count_tokens() approximation
+SELECT pgedge_vectorizer.tiktoken_count_tokens('hello world')
+     = pgedge_vectorizer.count_tokens('hello world') AS fallback_works;
 NOTICE:  tiktoken: plpython3u or tiktoken not available, falling back to approximation
  fallback_works 
 ----------------

--- a/test/expected/tiktoken.out
+++ b/test/expected/tiktoken.out
@@ -130,7 +130,6 @@ SET pgedge_vectorizer.use_tiktoken = on;
 -- Should fall back to count_tokens() approximation
 SELECT pgedge_vectorizer.tiktoken_count_tokens('hello world')
      = pgedge_vectorizer.count_tokens('hello world') AS fallback_works;
-NOTICE:  tiktoken: plpython3u or tiktoken not available, falling back to approximation
  fallback_works 
 ----------------
  t

--- a/test/expected/tiktoken.out
+++ b/test/expected/tiktoken.out
@@ -98,6 +98,54 @@ SELECT pgedge_vectorizer.tiktoken_count_tokens(NULL, 'cl100k_base') AS tokens;
 
 RESET pgedge_vectorizer.use_tiktoken;
 ---------------------------------------------------------------------------
+-- Test 7: tiktoken_count_tokens() falls back on any exception (WHEN OTHERS)
+-- Simulates 'tiktoken package missing at runtime' by replacing _tiktoken_internal
+-- with a plpgsql stub that raises SQLSTATE 38000, then restoring it.
+-- Both DO blocks are no-ops when plpython3u is absent.
+---------------------------------------------------------------------------
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_language WHERE lanname = 'plpython3u') THEN
+        EXECUTE $f$
+            CREATE OR REPLACE FUNCTION pgedge_vectorizer._tiktoken_internal(
+                p_text TEXT, p_encoding TEXT DEFAULT 'cl100k_base'
+            ) RETURNS INT LANGUAGE plpgsql AS $body$
+            BEGIN
+                RAISE EXCEPTION USING ERRCODE = '38000',
+                    MESSAGE = 'simulated tiktoken import error';
+            END;
+            $body$
+        $f$;
+    END IF;
+END;
+$$;
+SET pgedge_vectorizer.use_tiktoken = on;
+-- Should fall back gracefully and return a non-negative value
+SELECT pgedge_vectorizer.tiktoken_count_tokens('hello world') >= 0 AS fallback_works;
+NOTICE:  tiktoken: plpython3u or tiktoken not available, falling back to approximation
+ fallback_works 
+----------------
+ t
+(1 row)
+
+RESET pgedge_vectorizer.use_tiktoken;
+-- Restore original _tiktoken_internal (no-op if plpython3u is absent)
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_language WHERE lanname = 'plpython3u') THEN
+        EXECUTE $f$
+            CREATE OR REPLACE FUNCTION pgedge_vectorizer._tiktoken_internal(
+                p_text TEXT, p_encoding TEXT DEFAULT 'cl100k_base'
+            ) RETURNS INT LANGUAGE plpython3u STABLE STRICT AS $py$
+                import tiktoken
+                enc = tiktoken.get_encoding(p_encoding)
+                return len(enc.encode(p_text))
+            $py$
+        $f$;
+    END IF;
+END;
+$$;
+---------------------------------------------------------------------------
 -- Test 6: Integration - chunk table token_count is populated
 ---------------------------------------------------------------------------
 CREATE TABLE tiktoken_test_docs (
@@ -134,6 +182,88 @@ FROM tiktoken_test_docs_content_chunks;
  t            | t
 (1 row)
 
+---------------------------------------------------------------------------
+-- Test 8: refresh_token_counts() is registered
+---------------------------------------------------------------------------
+SELECT proname
+FROM pg_proc
+WHERE proname = 'refresh_token_counts'
+  AND pronamespace = (
+      SELECT oid FROM pg_namespace WHERE nspname = 'pgedge_vectorizer'
+  );
+       proname        
+----------------------
+ refresh_token_counts
+(1 row)
+
+---------------------------------------------------------------------------
+-- Test 9: refresh_token_counts() updates all rows and returns row count
+---------------------------------------------------------------------------
+CREATE TABLE tiktoken_refresh_test (
+    id      BIGSERIAL PRIMARY KEY,
+    content TEXT
+);
+INSERT INTO tiktoken_refresh_test (content)
+VALUES ('Refresh test document one.'),
+       ('Refresh test document two.');
+SELECT pgedge_vectorizer.enable_vectorization(
+    'tiktoken_refresh_test'::regclass,
+    'content',
+    'token_based',
+    100,
+    10,
+    1536
+);
+NOTICE:  Using primary key column: id (bigint)
+NOTICE:  column "sparse_embedding" of relation "tiktoken_refresh_test_content_chunks" already exists, skipping
+NOTICE:  Vectorization enabled: tiktoken_refresh_test -> tiktoken_refresh_test_content_chunks
+NOTICE:  Strategy: token_based, chunk_size: 100, overlap: 10
+NOTICE:  Processing existing rows...
+NOTICE:  Processed 2 existing rows
+ enable_vectorization 
+----------------------
+ 
+(1 row)
+
+-- Force all token_counts to 0 to simulate stale values
+UPDATE tiktoken_refresh_test_content_chunks SET token_count = 0;
+SELECT COUNT(*) AS zeroed
+FROM tiktoken_refresh_test_content_chunks
+WHERE token_count = 0;
+ zeroed 
+--------
+      2
+(1 row)
+
+-- refresh_token_counts() should update all rows and return the count
+SELECT pgedge_vectorizer.refresh_token_counts(
+    'tiktoken_refresh_test_content_chunks'::regclass
+) >= 1 AS refresh_returned_count;
+NOTICE:  refresh_token_counts: updated 2 rows in tiktoken_refresh_test_content_chunks
+ refresh_returned_count 
+------------------------
+ t
+(1 row)
+
+-- Verify all token_counts are now positive
+SELECT COALESCE(BOOL_AND(token_count > 0), false) AS all_refreshed
+FROM tiktoken_refresh_test_content_chunks;
+ all_refreshed 
+---------------
+ t
+(1 row)
+
+-- Cleanup test 9
+SELECT pgedge_vectorizer.disable_vectorization(
+    'tiktoken_refresh_test'::regclass, 'content', true
+);
+NOTICE:  Vectorization disabled and chunk table dropped: tiktoken_refresh_test_content_chunks
+ disable_vectorization 
+-----------------------
+ 
+(1 row)
+
+DROP TABLE tiktoken_refresh_test;
 ---------------------------------------------------------------------------
 -- Cleanup
 ---------------------------------------------------------------------------

--- a/test/expected/tiktoken.out
+++ b/test/expected/tiktoken.out
@@ -30,28 +30,28 @@ WHERE proname = 'count_tokens'
 -- Test 3: count_tokens() returns correct approximation values
 ---------------------------------------------------------------------------
 -- 'hello world' = 11 chars, (11+3)/4 = 3
-SELECT pgedge_vectorizer.count_tokens('hello world', NULL) AS tokens;
+SELECT pgedge_vectorizer.count_tokens('hello world') AS tokens;
  tokens 
 --------
       3
 (1 row)
 
 -- empty string returns 0
-SELECT pgedge_vectorizer.count_tokens('', NULL) AS tokens;
+SELECT pgedge_vectorizer.count_tokens('') AS tokens;
  tokens 
 --------
       0
 (1 row)
 
 -- 'test' = 4 chars, (4+3)/4 = 1
-SELECT pgedge_vectorizer.count_tokens('test', NULL) AS tokens;
+SELECT pgedge_vectorizer.count_tokens('test') AS tokens;
  tokens 
 --------
       1
 (1 row)
 
--- NULL input returns NULL
-SELECT pgedge_vectorizer.count_tokens(NULL, NULL) IS NULL AS is_null;
+-- NULL input returns NULL (STRICT function)
+SELECT pgedge_vectorizer.count_tokens(NULL) IS NULL AS is_null;
  is_null 
 ---------
  t
@@ -125,13 +125,13 @@ NOTICE:  Processed 1 existing rows
  
 (1 row)
 
--- token_count column exists and holds a positive integer
-SELECT token_count > 0 AS token_count_positive
-FROM tiktoken_test_docs_content_chunks
-LIMIT 1;
- token_count_positive 
-----------------------
- t
+-- Verify at least one chunk exists and all have a positive token_count
+SELECT COUNT(*) > 0 AS chunks_exist,
+       COALESCE(BOOL_AND(token_count > 0), false) AS all_positive
+FROM tiktoken_test_docs_content_chunks;
+ chunks_exist | all_positive 
+--------------+--------------
+ t            | t
 (1 row)
 
 ---------------------------------------------------------------------------

--- a/test/expected/tiktoken.out
+++ b/test/expected/tiktoken.out
@@ -57,6 +57,13 @@ SELECT pgedge_vectorizer.count_tokens(NULL) IS NULL AS is_null;
  t
 (1 row)
 
+-- '你好世界' = 4 UTF-8 characters, not 12 bytes; (4+3)/4 = 1
+SELECT pgedge_vectorizer.count_tokens('你好世界') AS tokens;
+ tokens 
+--------
+      1
+(1 row)
+
 ---------------------------------------------------------------------------
 -- Test 4: tiktoken_count_tokens() PL/pgSQL wrapper is registered
 ---------------------------------------------------------------------------
@@ -265,6 +272,48 @@ NOTICE:  Vectorization disabled and chunk table dropped: tiktoken_refresh_test_c
 (1 row)
 
 DROP TABLE tiktoken_refresh_test;
+---------------------------------------------------------------------------
+-- Test 10: refresh_token_counts() works with a schema-qualified chunk table
+-- Exercises the %s/REGCLASS fix to ensure non-default schemas are handled.
+---------------------------------------------------------------------------
+CREATE SCHEMA tiktoken_ns_test;
+CREATE TABLE tiktoken_ns_test.ns_chunks (
+    id          BIGSERIAL PRIMARY KEY,
+    source_id   BIGINT    NOT NULL DEFAULT 1,
+    content     TEXT      NOT NULL,
+    token_count INT
+);
+INSERT INTO tiktoken_ns_test.ns_chunks (content)
+VALUES ('Schema-qualified refresh test.'),
+       ('Another row for schema test.');
+UPDATE tiktoken_ns_test.ns_chunks SET token_count = 0;
+SELECT COUNT(*) AS zeroed
+FROM tiktoken_ns_test.ns_chunks
+WHERE token_count = 0;
+ zeroed 
+--------
+      2
+(1 row)
+
+SELECT pgedge_vectorizer.refresh_token_counts(
+    'tiktoken_ns_test.ns_chunks'::regclass
+) >= 1 AS refresh_returned_count;
+NOTICE:  refresh_token_counts: updated 2 rows in tiktoken_ns_test.ns_chunks
+ refresh_returned_count 
+------------------------
+ t
+(1 row)
+
+SELECT COALESCE(BOOL_AND(token_count > 0), false) AS all_refreshed
+FROM tiktoken_ns_test.ns_chunks;
+ all_refreshed 
+---------------
+ t
+(1 row)
+
+-- Cleanup test 10
+DROP TABLE tiktoken_ns_test.ns_chunks;
+DROP SCHEMA tiktoken_ns_test;
 ---------------------------------------------------------------------------
 -- Cleanup
 ---------------------------------------------------------------------------

--- a/test/sql/hybrid_test.sql
+++ b/test/sql/hybrid_test.sql
@@ -156,6 +156,9 @@ RESET pgedge_vectorizer.enable_hybrid;
 -- Test 13: hybrid_search raises when enable_hybrid is false
 ---------------------------------------------------------------------------
 
+-- Explicitly disable hybrid search regardless of postgresql.conf value
+SET pgedge_vectorizer.enable_hybrid = false;
+
 DO $$
 BEGIN
     PERFORM pgedge_vectorizer.hybrid_search(
@@ -171,6 +174,8 @@ EXCEPTION
         END IF;
 END;
 $$;
+
+RESET pgedge_vectorizer.enable_hybrid;
 
 ---------------------------------------------------------------------------
 -- Test 14: bm25_query_vector returns a non-null sparsevec

--- a/test/sql/tiktoken.sql
+++ b/test/sql/tiktoken.sql
@@ -24,16 +24,16 @@ WHERE proname = 'count_tokens'
 ---------------------------------------------------------------------------
 
 -- 'hello world' = 11 chars, (11+3)/4 = 3
-SELECT pgedge_vectorizer.count_tokens('hello world', NULL) AS tokens;
+SELECT pgedge_vectorizer.count_tokens('hello world') AS tokens;
 
 -- empty string returns 0
-SELECT pgedge_vectorizer.count_tokens('', NULL) AS tokens;
+SELECT pgedge_vectorizer.count_tokens('') AS tokens;
 
 -- 'test' = 4 chars, (4+3)/4 = 1
-SELECT pgedge_vectorizer.count_tokens('test', NULL) AS tokens;
+SELECT pgedge_vectorizer.count_tokens('test') AS tokens;
 
--- NULL input returns NULL
-SELECT pgedge_vectorizer.count_tokens(NULL, NULL) IS NULL AS is_null;
+-- NULL input returns NULL (STRICT function)
+SELECT pgedge_vectorizer.count_tokens(NULL) IS NULL AS is_null;
 
 ---------------------------------------------------------------------------
 -- Test 4: tiktoken_count_tokens() PL/pgSQL wrapper is registered
@@ -81,10 +81,10 @@ SELECT pgedge_vectorizer.enable_vectorization(
     1536
 );
 
--- token_count column exists and holds a positive integer
-SELECT token_count > 0 AS token_count_positive
-FROM tiktoken_test_docs_content_chunks
-LIMIT 1;
+-- Verify at least one chunk exists and all have a positive token_count
+SELECT COUNT(*) > 0 AS chunks_exist,
+       COALESCE(BOOL_AND(token_count > 0), false) AS all_positive
+FROM tiktoken_test_docs_content_chunks;
 
 ---------------------------------------------------------------------------
 -- Cleanup

--- a/test/sql/tiktoken.sql
+++ b/test/sql/tiktoken.sql
@@ -86,8 +86,9 @@ $$;
 
 SET pgedge_vectorizer.use_tiktoken = on;
 
--- Should fall back gracefully and return a non-negative value
-SELECT pgedge_vectorizer.tiktoken_count_tokens('hello world') >= 0 AS fallback_works;
+-- Should fall back to count_tokens() approximation
+SELECT pgedge_vectorizer.tiktoken_count_tokens('hello world')
+     = pgedge_vectorizer.count_tokens('hello world') AS fallback_works;
 
 RESET pgedge_vectorizer.use_tiktoken;
 

--- a/test/sql/tiktoken.sql
+++ b/test/sql/tiktoken.sql
@@ -62,6 +62,53 @@ SELECT pgedge_vectorizer.tiktoken_count_tokens(NULL, 'cl100k_base') AS tokens;
 RESET pgedge_vectorizer.use_tiktoken;
 
 ---------------------------------------------------------------------------
+-- Test 7: tiktoken_count_tokens() falls back on any exception (WHEN OTHERS)
+-- Simulates 'tiktoken package missing at runtime' by replacing _tiktoken_internal
+-- with a plpgsql stub that raises SQLSTATE 38000, then restoring it.
+-- Both DO blocks are no-ops when plpython3u is absent.
+---------------------------------------------------------------------------
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_language WHERE lanname = 'plpython3u') THEN
+        EXECUTE $f$
+            CREATE OR REPLACE FUNCTION pgedge_vectorizer._tiktoken_internal(
+                p_text TEXT, p_encoding TEXT DEFAULT 'cl100k_base'
+            ) RETURNS INT LANGUAGE plpgsql AS $body$
+            BEGIN
+                RAISE EXCEPTION USING ERRCODE = '38000',
+                    MESSAGE = 'simulated tiktoken import error';
+            END;
+            $body$
+        $f$;
+    END IF;
+END;
+$$;
+
+SET pgedge_vectorizer.use_tiktoken = on;
+
+-- Should fall back gracefully and return a non-negative value
+SELECT pgedge_vectorizer.tiktoken_count_tokens('hello world') >= 0 AS fallback_works;
+
+RESET pgedge_vectorizer.use_tiktoken;
+
+-- Restore original _tiktoken_internal (no-op if plpython3u is absent)
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_language WHERE lanname = 'plpython3u') THEN
+        EXECUTE $f$
+            CREATE OR REPLACE FUNCTION pgedge_vectorizer._tiktoken_internal(
+                p_text TEXT, p_encoding TEXT DEFAULT 'cl100k_base'
+            ) RETURNS INT LANGUAGE plpython3u STABLE STRICT AS $py$
+                import tiktoken
+                enc = tiktoken.get_encoding(p_encoding)
+                return len(enc.encode(p_text))
+            $py$
+        $f$;
+    END IF;
+END;
+$$;
+
+---------------------------------------------------------------------------
 -- Test 6: Integration - chunk table token_count is populated
 ---------------------------------------------------------------------------
 CREATE TABLE tiktoken_test_docs (
@@ -85,6 +132,59 @@ SELECT pgedge_vectorizer.enable_vectorization(
 SELECT COUNT(*) > 0 AS chunks_exist,
        COALESCE(BOOL_AND(token_count > 0), false) AS all_positive
 FROM tiktoken_test_docs_content_chunks;
+
+---------------------------------------------------------------------------
+-- Test 8: refresh_token_counts() is registered
+---------------------------------------------------------------------------
+SELECT proname
+FROM pg_proc
+WHERE proname = 'refresh_token_counts'
+  AND pronamespace = (
+      SELECT oid FROM pg_namespace WHERE nspname = 'pgedge_vectorizer'
+  );
+
+---------------------------------------------------------------------------
+-- Test 9: refresh_token_counts() updates all rows and returns row count
+---------------------------------------------------------------------------
+CREATE TABLE tiktoken_refresh_test (
+    id      BIGSERIAL PRIMARY KEY,
+    content TEXT
+);
+
+INSERT INTO tiktoken_refresh_test (content)
+VALUES ('Refresh test document one.'),
+       ('Refresh test document two.');
+
+SELECT pgedge_vectorizer.enable_vectorization(
+    'tiktoken_refresh_test'::regclass,
+    'content',
+    'token_based',
+    100,
+    10,
+    1536
+);
+
+-- Force all token_counts to 0 to simulate stale values
+UPDATE tiktoken_refresh_test_content_chunks SET token_count = 0;
+
+SELECT COUNT(*) AS zeroed
+FROM tiktoken_refresh_test_content_chunks
+WHERE token_count = 0;
+
+-- refresh_token_counts() should update all rows and return the count
+SELECT pgedge_vectorizer.refresh_token_counts(
+    'tiktoken_refresh_test_content_chunks'::regclass
+) >= 1 AS refresh_returned_count;
+
+-- Verify all token_counts are now positive
+SELECT COALESCE(BOOL_AND(token_count > 0), false) AS all_refreshed
+FROM tiktoken_refresh_test_content_chunks;
+
+-- Cleanup test 9
+SELECT pgedge_vectorizer.disable_vectorization(
+    'tiktoken_refresh_test'::regclass, 'content', true
+);
+DROP TABLE tiktoken_refresh_test;
 
 ---------------------------------------------------------------------------
 -- Cleanup

--- a/test/sql/tiktoken.sql
+++ b/test/sql/tiktoken.sql
@@ -105,7 +105,7 @@ BEGIN
             ) RETURNS INT LANGUAGE plpython3u STABLE STRICT AS $py$
                 import tiktoken
                 enc = tiktoken.get_encoding(p_encoding)
-                return len(enc.encode(p_text))
+                return len(enc.encode(p_text, disallowed_special=()))
             $py$
         $f$;
     END IF;

--- a/test/sql/tiktoken.sql
+++ b/test/sql/tiktoken.sql
@@ -1,0 +1,95 @@
+-- tiktoken.sql
+-- Regression tests for tiktoken integration (accurate token counting).
+-- All assertions are deterministic regardless of plpython3u availability.
+
+---------------------------------------------------------------------------
+-- Test 1: GUC pgedge_vectorizer.use_tiktoken is registered
+---------------------------------------------------------------------------
+SELECT name
+FROM pg_settings
+WHERE name = 'pgedge_vectorizer.use_tiktoken';
+
+---------------------------------------------------------------------------
+-- Test 2: count_tokens() C function is registered
+---------------------------------------------------------------------------
+SELECT proname
+FROM pg_proc
+WHERE proname = 'count_tokens'
+  AND pronamespace = (
+      SELECT oid FROM pg_namespace WHERE nspname = 'pgedge_vectorizer'
+  );
+
+---------------------------------------------------------------------------
+-- Test 3: count_tokens() returns correct approximation values
+---------------------------------------------------------------------------
+
+-- 'hello world' = 11 chars, (11+3)/4 = 3
+SELECT pgedge_vectorizer.count_tokens('hello world', NULL) AS tokens;
+
+-- empty string returns 0
+SELECT pgedge_vectorizer.count_tokens('', NULL) AS tokens;
+
+-- 'test' = 4 chars, (4+3)/4 = 1
+SELECT pgedge_vectorizer.count_tokens('test', NULL) AS tokens;
+
+-- NULL input returns NULL
+SELECT pgedge_vectorizer.count_tokens(NULL, NULL) IS NULL AS is_null;
+
+---------------------------------------------------------------------------
+-- Test 4: tiktoken_count_tokens() PL/pgSQL wrapper is registered
+---------------------------------------------------------------------------
+SELECT proname
+FROM pg_proc
+WHERE proname = 'tiktoken_count_tokens'
+  AND pronamespace = (
+      SELECT oid FROM pg_namespace WHERE nspname = 'pgedge_vectorizer'
+  );
+
+---------------------------------------------------------------------------
+-- Test 5: tiktoken_count_tokens() with use_tiktoken=off uses approximation
+---------------------------------------------------------------------------
+SET pgedge_vectorizer.use_tiktoken = off;
+
+-- (11+3)/4 = 3
+SELECT pgedge_vectorizer.tiktoken_count_tokens('hello world', 'cl100k_base') AS tokens;
+
+-- empty string returns 0
+SELECT pgedge_vectorizer.tiktoken_count_tokens('', 'cl100k_base') AS tokens;
+
+-- NULL input returns 0
+SELECT pgedge_vectorizer.tiktoken_count_tokens(NULL, 'cl100k_base') AS tokens;
+
+RESET pgedge_vectorizer.use_tiktoken;
+
+---------------------------------------------------------------------------
+-- Test 6: Integration - chunk table token_count is populated
+---------------------------------------------------------------------------
+CREATE TABLE tiktoken_test_docs (
+    id      BIGSERIAL PRIMARY KEY,
+    content TEXT
+);
+
+INSERT INTO tiktoken_test_docs (content)
+VALUES ('This is a test document for token count verification.');
+
+SELECT pgedge_vectorizer.enable_vectorization(
+    'tiktoken_test_docs'::regclass,
+    'content',
+    'token_based',
+    100,
+    10,
+    1536
+);
+
+-- token_count column exists and holds a positive integer
+SELECT token_count > 0 AS token_count_positive
+FROM tiktoken_test_docs_content_chunks
+LIMIT 1;
+
+---------------------------------------------------------------------------
+-- Cleanup
+---------------------------------------------------------------------------
+SELECT pgedge_vectorizer.disable_vectorization(
+    'tiktoken_test_docs'::regclass, 'content', true
+);
+DROP TABLE tiktoken_test_docs;

--- a/test/sql/tiktoken.sql
+++ b/test/sql/tiktoken.sql
@@ -35,6 +35,9 @@ SELECT pgedge_vectorizer.count_tokens('test') AS tokens;
 -- NULL input returns NULL (STRICT function)
 SELECT pgedge_vectorizer.count_tokens(NULL) IS NULL AS is_null;
 
+-- '你好世界' = 4 UTF-8 characters, not 12 bytes; (4+3)/4 = 1
+SELECT pgedge_vectorizer.count_tokens('你好世界') AS tokens;
+
 ---------------------------------------------------------------------------
 -- Test 4: tiktoken_count_tokens() PL/pgSQL wrapper is registered
 ---------------------------------------------------------------------------
@@ -186,6 +189,40 @@ SELECT pgedge_vectorizer.disable_vectorization(
     'tiktoken_refresh_test'::regclass, 'content', true
 );
 DROP TABLE tiktoken_refresh_test;
+
+---------------------------------------------------------------------------
+-- Test 10: refresh_token_counts() works with a schema-qualified chunk table
+-- Exercises the %s/REGCLASS fix to ensure non-default schemas are handled.
+---------------------------------------------------------------------------
+CREATE SCHEMA tiktoken_ns_test;
+
+CREATE TABLE tiktoken_ns_test.ns_chunks (
+    id          BIGSERIAL PRIMARY KEY,
+    source_id   BIGINT    NOT NULL DEFAULT 1,
+    content     TEXT      NOT NULL,
+    token_count INT
+);
+
+INSERT INTO tiktoken_ns_test.ns_chunks (content)
+VALUES ('Schema-qualified refresh test.'),
+       ('Another row for schema test.');
+
+UPDATE tiktoken_ns_test.ns_chunks SET token_count = 0;
+
+SELECT COUNT(*) AS zeroed
+FROM tiktoken_ns_test.ns_chunks
+WHERE token_count = 0;
+
+SELECT pgedge_vectorizer.refresh_token_counts(
+    'tiktoken_ns_test.ns_chunks'::regclass
+) >= 1 AS refresh_returned_count;
+
+SELECT COALESCE(BOOL_AND(token_count > 0), false) AS all_refreshed
+FROM tiktoken_ns_test.ns_chunks;
+
+-- Cleanup test 10
+DROP TABLE tiktoken_ns_test.ns_chunks;
+DROP SCHEMA tiktoken_ns_test;
 
 ---------------------------------------------------------------------------
 -- Cleanup


### PR DESCRIPTION
- Expose count_tokens() as SQL-callable C function (UTF-8 aware, wraps the existing char-based approximation in tokenizer.c)
- Add pgedge_vectorizer.use_tiktoken GUC (bool, default off, USERSET)
- Add tiktoken_count_tokens() PL/pgSQL wrapper: delegates to an internal plpython3u function when use_tiktoken=on, falls back to approximation otherwise (graceful fallback if plpython3u absent)
- Add _tiktoken_internal() via DO block (plpython3u, silently skipped when plpython3u is not installed — CI remains unaffected)
- Replace length(chunk_text)/4 SQL approximation with count_tokens() in enable_vectorization(), vectorization_trigger(), recreate_chunks()
- Fix hybrid_test Test 13 to explicitly SET enable_hybrid=false before testing the disabled path, rather than relying on RESET
- Add tiktoken regression test (all assertions fully deterministic)
- Mark roadmap item done; document new functions and setup instructions