### PR TITLE
Fix hybrid_test.sql Test 13 to be deterministic regardless of postgre…

### DIFF
--- a/test/expected/hybrid_test.out
+++ b/test/expected/hybrid_test.out
@@ -195,6 +195,8 @@ RESET pgedge_vectorizer.enable_hybrid;
 ---------------------------------------------------------------------------
 -- Test 13: hybrid_search raises when enable_hybrid is false
 ---------------------------------------------------------------------------
+-- Explicitly disable so the test is deterministic regardless of postgresql.conf
+SET pgedge_vectorizer.enable_hybrid = false;
 DO $$
 BEGIN
     PERFORM pgedge_vectorizer.hybrid_search(
@@ -211,6 +213,7 @@ EXCEPTION
 END;
 $$;
 NOTICE:  Got expected exception: Hybrid search is disabled. Set pgedge_vectorizer.enable_hybrid = true and allow workers to populate sparse_embedding.
+RESET pgedge_vectorizer.enable_hybrid;
 ---------------------------------------------------------------------------
 -- Test 14: bm25_query_vector returns a non-null sparsevec
 ---------------------------------------------------------------------------

--- a/test/sql/hybrid_test.sql
+++ b/test/sql/hybrid_test.sql
@@ -156,6 +156,9 @@ RESET pgedge_vectorizer.enable_hybrid;
 -- Test 13: hybrid_search raises when enable_hybrid is false
 ---------------------------------------------------------------------------
 
+-- Explicitly disable so the test is deterministic regardless of postgresql.conf
+SET pgedge_vectorizer.enable_hybrid = false;
+
 DO $$
 BEGIN
     PERFORM pgedge_vectorizer.hybrid_search(
@@ -171,6 +174,8 @@ EXCEPTION
         END IF;
 END;
 $$;
+
+RESET pgedge_vectorizer.enable_hybrid;
 
 ---------------------------------------------------------------------------
 -- Test 14: bm25_query_vector returns a non-null sparsevec


### PR DESCRIPTION
…sql.conf

Test 13 relied on the GUC defaulting to false. Add explicit SET before and RESET after the DO block so the test passes even when enable_hybrid = true is set in postgresql.conf.