### PR TITLE
Fix Makefile PG version check breaking on pre-release versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,13 +63,17 @@ endif
 include $(PGXS)
 
 # Version compatibility check
-pg_version_num := $(shell $(PG_CONFIG) --version | sed 's/^PostgreSQL *//' | \
-	sed 's/\([0-9]*\)\.\([0-9]*\).*/\1\2/')
+# Extract only the leading major version integer. This must cope with
+# pre-release strings such as "PostgreSQL 19beta1 (Ubuntu 19~beta1-1.noble)"
+# where there is no MAJOR.MINOR dot; a dotted regex would leave the whole
+# descriptive string (including the "(...)" suffix) in place and break the
+# shell test below under dash (/bin/sh on Debian/Ubuntu).
+pg_version_num := $(shell $(PG_CONFIG) --version | sed -E 's/^PostgreSQL ([0-9]+).*/\1/')
 
 # Ensure we're building for PostgreSQL 14+
 check-pg-version:
 	@echo "Building for PostgreSQL version: $(shell $(PG_CONFIG) --version)"
-	@if [ $(pg_version_num) -lt 14 ]; then \
+	@if [ "$(pg_version_num)" -lt 14 ]; then \
 		echo "Error: PostgreSQL 14 or later is required"; \
 		exit 1; \
 	fi


### PR DESCRIPTION
## Problem

The `check-pg-version` target derives `pg_version_num` with a regex that requires a `MAJOR.MINOR` dotted format:

```makefile
pg_version_num := $(shell $(PG_CONFIG) --version | sed 's/^PostgreSQL *//' | \
	sed 's/\([0-9]*\)\.\([0-9]*\).*/\1\2/')
```

PostgreSQL pre-release builds report a version like `19beta1` — **no dot** — so the substitution does not match and the full descriptive string is left in place.

On Debian/Ubuntu, `pg_config --version` also appends a distro suffix, e.g.:

```
PostgreSQL 19beta1 (Ubuntu 19~beta1-1.noble)
```

The unmatched string then flows into the shell test as:

```sh
if [ 19beta1 (Ubuntu 19~beta1-1.noble) -lt 14 ]; then
```

which fails under `dash` (`/bin/sh` on Debian/Ubuntu):

```
/bin/sh: 1: Syntax error: "(" unexpected (expecting "then")
make[1]: *** [Makefile:67: check-pg-version] Error 2
```

This breaks the PostgreSQL 19 `.deb` build. RPM builds happened to survive only because the RHEL version string has no parenthetical suffix (`PostgreSQL 19beta1`), so the numeric test quietly no-op'd and the `if` fell through.

Note the extension's C sources compile cleanly against PG19 on both platforms — this is purely a version-check parsing bug.

## Fix

Parse just the leading major-version integer and quote the value in the test, so it is robust for both pre-release and stable versions under `dash` and `bash`:

```makefile
pg_version_num := $(shell $(PG_CONFIG) --version | sed -E 's/^PostgreSQL ([0-9]+).*/\1/')
...
	@if [ "$(pg_version_num)" -lt 14 ]; then
```

## Verification

Parsed major + `[ … -lt 14 ]` under `dash` for each real version string:

| `pg_config --version` | parsed | result |
|---|---|---|
| `PostgreSQL 19beta1 (Ubuntu 19~beta1-1.noble)` | `19` | OK |
| `PostgreSQL 19beta1` | `19` | OK |
| `PostgreSQL 17.6` | `17` | OK |
| `PostgreSQL 14.12 (Debian 14.12-1)` | `14` | OK |
| `PostgreSQL 13.2` | `13` | correctly rejected |