### PR TITLE
Address Codacy security findings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Install PostgreSQL (Ubuntu)
         if: runner.os == 'Linux'
@@ -131,7 +131,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: test-results-pg${{ matrix.pg }}-${{ matrix.os }}
           path: |
@@ -147,7 +147,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Check for trailing whitespace
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
 
       - name: Install PostgreSQL (Ubuntu)
         if: runner.os == 'Linux'
@@ -148,6 +150,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
 
       - name: Check for trailing whitespace
         run: |

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -22,6 +22,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   environment cannot redirect the path (CWE-807)
 - Replaced `strncpy` + manual null-termination in the background worker with
   `strlcpy`, guaranteeing null termination of the database name buffer (CWE-120)
+- Pinned all GitHub Actions in the CI workflow to full commit SHAs rather than
+  mutable `@v4` tags, so a repointed tag in an upstream action cannot silently
+  change what runs in CI (CWE-1357)
+- Replaced `strtok()` with `strtok_r()` when parsing
+  `pgedge_vectorizer.databases` in the background worker; `strtok()` keeps its
+  parsing position in a single process-wide static, which any other `strtok()`
+  caller reached from the same loop would corrupt (CWE-676)
 
 ## [1.0] - 2026-03-13
 

--- a/src/worker.c
+++ b/src/worker.c
@@ -132,6 +132,7 @@ pgedge_vectorizer_worker_main(Datum main_arg)
 	char *db_list;
 	char *db_name;
 	char *db_copy;
+	char *db_saveptr;
 	int db_count = 0;
 	bool extension_exists = false;
 	int ext_retry_interval = 5000;	/* Start at 5s, doubles up to max */
@@ -185,8 +186,12 @@ pgedge_vectorizer_worker_main(Datum main_arg)
 	db_list = pstrdup(pgedge_vectorizer_databases);
 	db_copy = db_list;
 
-	/* Count databases */
-	while ((db_name = strtok(db_copy, ",")) != NULL)
+	/*
+	 * Count databases.  Use strtok_r() rather than strtok(): the latter keeps
+	 * its parsing position in a single process-wide static, so any other
+	 * strtok() caller reached from this loop would silently corrupt it.
+	 */
+	while ((db_name = strtok_r(db_copy, ",", &db_saveptr)) != NULL)
 	{
 		db_copy = NULL;
 		db_count++;
@@ -206,9 +211,15 @@ pgedge_vectorizer_worker_main(Datum main_arg)
 
 	for (int i = 0; i <= (worker_id % db_count); i++)
 	{
-		db_name = strtok(db_copy, ",");
+		db_name = strtok_r(db_copy, ",", &db_saveptr);
 		db_copy = NULL;
 	}
+
+	/*
+	 * The count pass found db_count tokens and worker_id % db_count is less
+	 * than that, so the loop above cannot have run off the end of the list.
+	 */
+	Assert(db_name != NULL);
 
 	/* Trim whitespace */
 	while (*db_name == ' ' || *db_name == '\t')


### PR DESCRIPTION
## Summary

Clears the five findings Semgrep reports in Codacy's Security category for this repo: three mutable GitHub Action tags and two uses of `strtok()`.

The findings were reproduced locally with Semgrep (`p/c`, `p/security-audit`, `p/github-actions`, `p/default`), which is the engine Codacy uses here — confirmed by the existing `/* nosemgrep */` suppressions in `src/provider_common.c`. All four rulesets independently surfaced the same five findings, and all five are now gone.

## Mutable GitHub Action tags — 3 findings (CWE-1357)

`.github/workflows/ci.yml` referenced actions by `@v4`. A tag can be silently repointed by the action owner, which is the supply-chain vector behind the `trivy-action` and `kics-github-action` compromises. Pinned to full commit SHAs, resolved via the GitHub API and verified to be real commits:

- `actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4` (2 sites)
- `actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4`

This matches how the same complaint was resolved in `pgedge-docloader` (commit `7cf0be1`, "Address Codacy security findings"), which pinned `codecov-action` and `goreleaser-action` the same way.

Both actions now have `v7.0.1` releases. Pinning at v4 is deliberate — the finding is about pinning, not version currency, and a major-version bump deserves its own PR.

## `strtok()` in the background worker — 2 findings (CWE-676)

`pgedge_vectorizer_worker_main()` parsed `pgedge_vectorizer.databases` with `strtok()`, which keeps its parsing position in a single process-wide static. Any other `strtok()` caller reached from within the parsing loop would silently corrupt it. Replaced with `strtok_r()` and a local save pointer.

`strtok_r()` is portable in a Postgres extension: core uses it throughout (e.g. `src/backend/utils/misc/tzparser.c`) and `src/include/port/win32_port.h` maps it to `strtok_s` on Windows.

Also adds `Assert(db_name != NULL)` documenting the invariant that the selection loop cannot run past the end of the list, since the counting pass found `db_count` tokens and `worker_id % db_count` is strictly less than that.
