### PR TITLE
Spawn per-database workers from a launcher

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,8 @@ jobs:
             postgresql-${{ matrix.pg }} \
             postgresql-server-dev-${{ matrix.pg }} \
             libcurl4-openssl-dev \
-            build-essential
+            build-essential \
+            libipc-run-perl
 
       - name: Install PostgreSQL (macOS)
         if: runner.os == 'macOS'

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,9 @@ test/results/*.out
 test/results/*.diff
 test/tmp_check/
 test/isolationcheck_tmp_check/
+# PGXS creates tmp_check at the top level for TAP tests, since that is where
+# the Makefile invoking prove lives
+tmp_check/
 
 # PostgreSQL extension build files
 *.control.in

--- a/Makefile
+++ b/Makefile
@@ -66,13 +66,26 @@ endif
 # against a single database and cannot set shared_preload_libraries, so those
 # properties are tested with TAP instead.
 #
-# Only enable them when this installation actually ships the PostgreSQL Perl
-# test modules: Homebrew builds on macOS do not, and an unconditional TAP_TESTS
-# would fail the suite there rather than simply not running it.
+# Only enable them when this installation can actually run them, so that an
+# environment lacking the plumbing simply does not run them rather than failing
+# the whole suite. Two things are needed:
+#
+#   - The PostgreSQL Perl test modules. Homebrew builds on macOS do not ship
+#     these at all.
+#   - IPC::Run, which PostgreSQL::Test::Cluster requires at compile time. It is
+#     a separate package (libipc-run-perl on Debian and Ubuntu) and is not
+#     pulled in by the server development package, so the modules being present
+#     does not imply it is.
+#
+# CI installs IPC::Run explicitly so that these tests really do run there; a
+# silent skip everywhere would be worse than useless, because it would look like
+# the coverage property was being verified when it was not.
 PG_PERL_TEST_DIR := $(dir $(PGXS))../../src/test/perl
 ifneq ($(wildcard $(PG_PERL_TEST_DIR)/PostgreSQL/Test/Cluster.pm),)
+ifeq ($(shell perl -MIPC::Run -e 'print "yes"' 2>/dev/null),yes)
 TAP_TESTS = 1
 PROVE_TESTS = test/t/*.pl
+endif
 endif
 
 include $(PGXS)

--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,21 @@ ifeq ($(PGXS),)
 $(error pg_config not found. Please install PostgreSQL development packages or set PG_CONFIG)
 endif
 
+# TAP tests
+#
+# Multi-database worker coverage cannot be expressed in pg_regress, which runs
+# against a single database and cannot set shared_preload_libraries, so those
+# properties are tested with TAP instead.
+#
+# Only enable them when this installation actually ships the PostgreSQL Perl
+# test modules: Homebrew builds on macOS do not, and an unconditional TAP_TESTS
+# would fail the suite there rather than simply not running it.
+PG_PERL_TEST_DIR := $(dir $(PGXS))../../src/test/perl
+ifneq ($(wildcard $(PG_PERL_TEST_DIR)/PostgreSQL/Test/Cluster.pm),)
+TAP_TESTS = 1
+PROVE_TESTS = test/t/*.pl
+endif
+
 include $(PGXS)
 
 # Version compatibility check

--- a/README.md
+++ b/README.md
@@ -232,7 +232,8 @@ All configuration parameters can be set in `postgresql.conf` or via `ALTER SYSTE
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `pgedge_vectorizer.num_workers` | integer | `2` | Number of background workers (requires restart) |
+| `pgedge_vectorizer.num_workers` | integer | `2` | Maximum number of concurrent background workers. Databases are serviced in rotation, so every configured database is processed even when there are more databases than workers |
+| `pgedge_vectorizer.worker_service_quantum` | integer | `60s` | Seconds a worker services one database before yielding its slot, when there are more databases than workers. Ignored when every database can have its own worker |
 | `pgedge_vectorizer.batch_size` | integer | `10` | Batch size for embedding generation |
 | `pgedge_vectorizer.max_retries` | integer | `3` | Maximum retry attempts for failed embeddings |
 | `pgedge_vectorizer.worker_poll_interval` | integer | `1000` | Worker polling interval in milliseconds |

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -30,6 +30,35 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   parsing position in a single process-wide static, which any other `strtok()`
   caller reached from the same loop would corrupt (CWE-676)
 
+### Added
+
+- Added `pgedge_vectorizer.worker_service_quantum`, which bounds how long a
+  worker services one database before yielding its slot when there are more
+  configured databases than workers. It is ignored when every configured
+  database can have its own worker, in which case workers stay resident.
+
+### Changed
+
+- `pgedge_vectorizer.num_workers` now sets the maximum number of *concurrent*
+  workers rather than a fixed pool size, and can be changed with a reload
+  instead of requiring a restart. Configurations that raised it purely to obtain
+  coverage of every configured database no longer need to do so. Note that this
+  is a change in meaning: a value chosen to guarantee coverage now caps
+  concurrency instead.
+- Background workers are now spawned per database by a launcher process rather
+  than being statically registered at startup, so the set of serviced databases
+  follows `pgedge_vectorizer.databases` as it changes, without a restart.
+
+### Fixed
+
+- Fixed databases beyond `pgedge_vectorizer.num_workers` never being processed
+  ([#23](https://github.com/pgEdge/pgedge-vectorizer/issues/23)). Workers were
+  assigned to databases by `worker_id % db_count`, and because `worker_id` only
+  ranged over `0` to `num_workers-1`, any database at a later position in the
+  list was silently never serviced: its queue accumulated entries that were
+  never handled, with nothing logged to indicate it. With the default
+  `num_workers = 2` and five databases configured, three of them were affected.
+
 ## [1.0] - 2026-03-13
 
 ### Added

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -20,8 +20,9 @@ These settings control the background workers that process the embedding queue, 
 
 | Parameter | Default | Description | Reload | Restart | Superuser |
 |-----------|---------|-------------|--------|---------|-----------|
-| `pgedge_vectorizer.num_workers` | `2` | Number of workers | No | Yes | Yes |
+| `pgedge_vectorizer.num_workers` | `2` | Maximum number of concurrent workers. Databases are serviced in rotation, so every configured database is processed even when there are more databases than workers | Yes | No | Yes |
 | `pgedge_vectorizer.databases` | (empty) | **Required.** Comma-separated list of databases to monitor. Workers will not process any embeddings if this is not set. | Yes | Yes | No |
+| `pgedge_vectorizer.worker_service_quantum` | `60s` | Seconds a worker services one database before yielding its slot, when there are more databases than workers. Ignored when every database can have its own worker | Yes | No | No |
 | `pgedge_vectorizer.batch_size` | `10` | Batch size for embeddings | Yes | No | No |
 | `pgedge_vectorizer.max_retries` | `3` | Max retry attempts | Yes | No | No |
 | `pgedge_vectorizer.worker_poll_interval` | `1000` | Poll interval in ms | Yes | No | No |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -21,7 +21,7 @@ These settings control the background workers that process the embedding queue, 
 | Parameter | Default | Description | Reload | Restart | Superuser |
 |-----------|---------|-------------|--------|---------|-----------|
 | `pgedge_vectorizer.num_workers` | `2` | Maximum number of concurrent workers. Databases are serviced in rotation, so every configured database is processed even when there are more databases than workers | Yes | No | Yes |
-| `pgedge_vectorizer.databases` | (empty) | **Required.** Comma-separated list of databases to monitor. Workers will not process any embeddings if this is not set. | Yes | Yes | No |
+| `pgedge_vectorizer.databases` | (empty) | **Required.** Comma-separated list of databases to monitor. Workers will not process any embeddings if this is not set. | Yes | No | No |
 | `pgedge_vectorizer.worker_service_quantum` | `60s` | Seconds a worker services one database before yielding its slot, when there are more databases than workers. Ignored when every database can have its own worker | Yes | No | No |
 | `pgedge_vectorizer.batch_size` | `10` | Batch size for embeddings | Yes | No | No |
 | `pgedge_vectorizer.max_retries` | `3` | Max retry attempts | Yes | No | No |

--- a/src/guc.c
+++ b/src/guc.c
@@ -27,6 +27,7 @@ char *pgedge_vectorizer_extra_headers = NULL;
  */
 char *pgedge_vectorizer_databases = NULL;
 int pgedge_vectorizer_num_workers = 2;
+int pgedge_vectorizer_worker_service_quantum = 60;
 int pgedge_vectorizer_batch_size = 10;
 int pgedge_vectorizer_max_retries = 3;
 int pgedge_vectorizer_worker_poll_interval = 1000;
@@ -128,15 +129,34 @@ pgedge_vectorizer_init_guc(void)
 								NULL, NULL, NULL);
 
 	DefineCustomIntVariable("pgedge_vectorizer.num_workers",
-							"Number of background workers",
-							"Number of background worker processes to spawn. "
-							"Requires PostgreSQL restart to change.",
+							"Maximum number of concurrent background workers",
+							"Upper bound on how many per-database workers may run at "
+							"once. Databases are serviced in rotation, so every "
+							"configured database is processed even when there are more "
+							"databases than workers. Workers are spawned dynamically "
+							"and draw from max_worker_processes.",
 							&pgedge_vectorizer_num_workers,
 							2,      /* default */
 							1,      /* min */
-							32,     /* max */
-							PGC_POSTMASTER,
+							PGEDGE_VECTORIZER_MAX_WORKERS,
+							PGC_SIGHUP,
 							0,
+							NULL, NULL, NULL);
+
+	DefineCustomIntVariable("pgedge_vectorizer.worker_service_quantum",
+							"Seconds a worker services one database before yielding",
+							"When more databases are configured than num_workers can "
+							"service at once, a worker gives up its slot after this "
+							"many seconds so that the next database in the rotation "
+							"can be processed. Ignored entirely when every configured "
+							"database can have its own worker, in which case workers "
+							"stay resident.",
+							&pgedge_vectorizer_worker_service_quantum,
+							60,     /* default */
+							1,      /* min */
+							3600,   /* max */
+							PGC_SIGHUP,
+							GUC_UNIT_S,
 							NULL, NULL, NULL);
 
 	DefineCustomIntVariable("pgedge_vectorizer.batch_size",

--- a/src/pgedge_vectorizer.c
+++ b/src/pgedge_vectorizer.c
@@ -31,7 +31,7 @@ _PG_init(void)
 	if (process_shared_preload_libraries_in_progress)
 	{
 		register_background_workers();
-		elog(LOG, "pgedge_vectorizer: %d background worker(s) registered",
+		elog(LOG, "pgedge_vectorizer: launcher registered (max %d concurrent worker(s))",
 			 pgedge_vectorizer_num_workers);
 	}
 

--- a/src/pgedge_vectorizer.h
+++ b/src/pgedge_vectorizer.h
@@ -56,6 +56,7 @@ extern char *pgedge_vectorizer_model;
 extern char *pgedge_vectorizer_extra_headers;
 extern char *pgedge_vectorizer_databases;
 extern int pgedge_vectorizer_num_workers;
+extern int pgedge_vectorizer_worker_service_quantum;
 extern int pgedge_vectorizer_batch_size;
 extern int pgedge_vectorizer_max_retries;
 extern int pgedge_vectorizer_worker_poll_interval;
@@ -189,8 +190,16 @@ List *parse_markdown_structure(const char *content);
 void free_markdown_elements(List *elements);
 
 /* worker.c */
+extern PGDLLEXPORT PGEDGE_NORETURN void pgedge_vectorizer_launcher_main(Datum main_arg) PGEDGE_NORETURN_SUFFIX;
 extern PGDLLEXPORT PGEDGE_NORETURN void pgedge_vectorizer_worker_main(Datum main_arg) PGEDGE_NORETURN_SUFFIX;
 void register_background_workers(void);
+
+/*
+ * Upper bound on concurrent workers. Shared between the num_workers GUC
+ * maximum and the launcher's fixed slot array, so that the two cannot drift
+ * apart.
+ */
+#define PGEDGE_VECTORIZER_MAX_WORKERS	32
 
 /* queue.c */
 Datum pgedge_vectorizer_queue_status(PG_FUNCTION_ARGS);

--- a/src/worker.c
+++ b/src/worker.c
@@ -17,11 +17,13 @@
 
 #include "commands/dbcommands.h"
 #include "pgstat.h"
+#include "postmaster/bgworker.h"
 #include "postmaster/interrupt.h"
 #include "storage/proc.h"
 #include "tcop/tcopprot.h"
 #include "utils/memutils.h"
 #include "utils/ps_status.h"
+#include "utils/timestamp.h"
 
 /* Signal flags */
 static volatile sig_atomic_t got_sigterm = false;
@@ -30,13 +32,59 @@ static volatile sig_atomic_t got_sighup = false;
 /* Last cleanup timestamp */
 static time_t last_cleanup_time = 0;
 
+/*
+ * Launcher state
+ *
+ * All of this is process-local: there is deliberately no shared memory
+ * segment, which avoids RequestAddinShmemSpace() and the shmem_request_hook
+ * that does not exist before PostgreSQL 15.
+ *
+ * The cost is that a restarted launcher cannot rediscover workers started by
+ * its predecessor, so a launcher crash may briefly leave two workers on one
+ * database. That is harmless: queue rows are claimed with FOR UPDATE SKIP
+ * LOCKED, so concurrent workers simply take disjoint rows.
+ */
+typedef struct LauncherSlot
+{
+	char		dbname[NAMEDATALEN];
+	BackgroundWorkerHandle *handle;
+	bool		terminating;	/* asked to stop; awaiting confirmation */
+} LauncherSlot;
+
+static LauncherSlot launcher_slots[PGEDGE_VECTORIZER_MAX_WORKERS];
+static int	launcher_nslots = 0;
+static int	launcher_cursor = 0;	/* round-robin position in the database list */
+
+/*
+ * Sweep intervals.
+ *
+ * Workers are registered with bgw_notify_pid set to the launcher, but that
+ * notification was observed not to wake a launcher holding no database
+ * connection, so the sweep interval rather than the notification is what
+ * bounds how quickly a freed slot is refilled. Do not rely on the latch being
+ * set when a worker exits.
+ *
+ * When there are more databases than slots, databases are queued waiting for a
+ * turn and refill latency directly limits throughput, so sweep briskly. When
+ * every database has its own worker there is nothing to refill and the sweep
+ * only needs to notice configuration changes, so sweep rarely.
+ */
+#define LAUNCHER_SWEEP_INTERVAL_ROTATING_MS		1000
+#define LAUNCHER_SWEEP_INTERVAL_IDLE_MS			60000
+
 /* Forward declarations */
 static void worker_sigterm(SIGNAL_ARGS);
 static void worker_sighup(SIGNAL_ARGS);
-static void process_queue_batch(int worker_id);
-static void cleanup_completed_items(int worker_id);
+static void process_queue_batch(const char *dbname);
+static void cleanup_completed_items(const char *dbname);
 static void update_embedding(int64 chunk_id, const char *chunk_table,
 							 const float *embedding, int dim);
+static int	parse_database_list(char ***names);
+static BackgroundWorkerHandle *launch_worker_for_database(const char *dbname,
+														  int quantum_secs);
+static void launcher_reap_workers(void);
+static bool database_has_worker(const char *dbname);
+static void launcher_sweep(char **db_names, int db_count);
 
 /*
  * Signal handler for SIGTERM
@@ -72,26 +120,402 @@ register_background_workers(void)
 {
 	BackgroundWorker worker;
 
-	for (int i = 0; i < pgedge_vectorizer_num_workers; i++)
+	memset(&worker, 0, sizeof(BackgroundWorker));
+
+	/*
+	 * The launcher needs shared memory access so that it can register dynamic
+	 * workers, but deliberately takes no database connection: the database
+	 * list comes from a GUC rather than the catalogue, so it needs neither SPI
+	 * nor a backend. That keeps its crash surface very small.
+	 */
+	worker.bgw_flags = BGWORKER_SHMEM_ACCESS;
+	worker.bgw_start_time = BgWorkerStart_RecoveryFinished;
+	worker.bgw_restart_time = 10;  /* Restart after 10 seconds if it crashes */
+
+	snprintf(worker.bgw_library_name, BGW_MAXLEN, "pgedge_vectorizer");
+	snprintf(worker.bgw_function_name, BGW_MAXLEN,
+			 "pgedge_vectorizer_launcher_main");
+	snprintf(worker.bgw_name, BGW_MAXLEN, "pgedge_vectorizer launcher");
+	snprintf(worker.bgw_type, BGW_MAXLEN, "pgedge_vectorizer");
+
+	worker.bgw_main_arg = (Datum) 0;
+	worker.bgw_notify_pid = 0;
+
+	RegisterBackgroundWorker(&worker);
+}
+
+/*
+ * Parse pgedge_vectorizer.databases into a palloc'd array of trimmed names.
+ *
+ * Returns the number of names found, with *names set to a palloc'd array of
+ * palloc'd strings. Returns 0 with *names set to NULL when nothing is
+ * configured. Empty entries produced by stray commas are skipped.
+ */
+static int
+parse_database_list(char ***names)
+{
+	char	   *list;
+	char	   *tok;
+	char	   *saveptr = NULL;
+	char	  **result;
+	int			count = 0;
+	int			capacity = 8;
+
+	if (pgedge_vectorizer_databases == NULL ||
+		pgedge_vectorizer_databases[0] == '\0')
 	{
-		memset(&worker, 0, sizeof(BackgroundWorker));
-
-		/* Set worker properties */
-		worker.bgw_flags = BGWORKER_SHMEM_ACCESS |
-						   BGWORKER_BACKEND_DATABASE_CONNECTION;
-		worker.bgw_start_time = BgWorkerStart_RecoveryFinished;
-		worker.bgw_restart_time = 10;  /* Restart after 10 seconds if crashes */
-
-		snprintf(worker.bgw_library_name, BGW_MAXLEN, "pgedge_vectorizer");
-		snprintf(worker.bgw_function_name, BGW_MAXLEN, "pgedge_vectorizer_worker_main");
-		snprintf(worker.bgw_name, BGW_MAXLEN, "pgedge_vectorizer worker %d", i + 1);
-		snprintf(worker.bgw_type, BGW_MAXLEN, "pgedge_vectorizer");
-
-		worker.bgw_main_arg = Int32GetDatum(i);
-		worker.bgw_notify_pid = 0;
-
-		RegisterBackgroundWorker(&worker);
+		*names = NULL;
+		return 0;
 	}
+
+	result = palloc(capacity * sizeof(char *));
+	list = pstrdup(pgedge_vectorizer_databases);
+
+	/*
+	 * Use strtok_r() rather than strtok(): the latter keeps its parsing
+	 * position in a single process-wide static, so any other strtok() caller
+	 * reached from this loop would silently corrupt it.
+	 */
+	for (tok = strtok_r(list, ",", &saveptr); tok != NULL;
+		 tok = strtok_r(NULL, ",", &saveptr))
+	{
+		char	   *name = tok;
+		int			len;
+
+		/* Trim leading whitespace */
+		while (*name == ' ' || *name == '\t')
+			name++;
+
+		/* Trim trailing whitespace */
+		len = strlen(name);
+		while (len > 0 && (name[len - 1] == ' ' || name[len - 1] == '\t'))
+			name[--len] = '\0';
+
+		if (len == 0)
+			continue;
+
+		if (count == capacity)
+		{
+			capacity *= 2;
+			result = repalloc(result, capacity * sizeof(char *));
+		}
+
+		result[count++] = pstrdup(name);
+	}
+
+	pfree(list);
+	*names = result;
+	return count;
+}
+
+/*
+ * Spawn a worker for one database.
+ *
+ * Returns the handle, or NULL when no worker slot could be obtained, which
+ * normally means max_worker_processes is exhausted.
+ */
+static BackgroundWorkerHandle *
+launch_worker_for_database(const char *dbname, int quantum_secs)
+{
+	BackgroundWorker worker;
+	BackgroundWorkerHandle *handle;
+
+	memset(&worker, 0, sizeof(BackgroundWorker));
+
+	worker.bgw_flags = BGWORKER_SHMEM_ACCESS |
+					   BGWORKER_BACKEND_DATABASE_CONNECTION;
+	worker.bgw_start_time = BgWorkerStart_RecoveryFinished;
+
+	/*
+	 * The launcher owns respawn, so the postmaster must not resurrect a worker
+	 * for a database that has since been removed from the configuration.
+	 */
+	worker.bgw_restart_time = BGW_NEVER_RESTART;
+
+	snprintf(worker.bgw_library_name, BGW_MAXLEN, "pgedge_vectorizer");
+	snprintf(worker.bgw_function_name, BGW_MAXLEN,
+			 "pgedge_vectorizer_worker_main");
+	snprintf(worker.bgw_name, BGW_MAXLEN,
+			 "pgedge_vectorizer worker (%s)", dbname);
+	snprintf(worker.bgw_type, BGW_MAXLEN, "pgedge_vectorizer");
+
+	/*
+	 * bgw_main_arg is a single Datum and cannot carry a string, so the target
+	 * database name travels in bgw_extra. That leaves the Datum free for the
+	 * service quantum, which only the launcher can compute because only it
+	 * knows whether we are oversubscribed.
+	 */
+	worker.bgw_main_arg = Int32GetDatum(quantum_secs);
+	strlcpy(worker.bgw_extra, dbname, NAMEDATALEN);
+
+	/* Be signalled when this worker starts or stops */
+	worker.bgw_notify_pid = MyProcPid;
+
+	if (!RegisterDynamicBackgroundWorker(&worker, &handle))
+		return NULL;
+
+	return handle;
+}
+
+/*
+ * Drop tracking entries for workers that have exited.
+ */
+static void
+launcher_reap_workers(void)
+{
+	int			i = 0;
+
+	while (i < launcher_nslots)
+	{
+		pid_t		pid;
+
+		if (GetBackgroundWorkerPid(launcher_slots[i].handle, &pid) == BGWH_STOPPED)
+		{
+			pfree(launcher_slots[i].handle);
+
+			/* Compact the array by moving the final entry into the hole */
+			launcher_slots[i] = launcher_slots[launcher_nslots - 1];
+			launcher_nslots--;
+		}
+		else
+			i++;
+	}
+}
+
+/*
+ * Is this database already covered?
+ *
+ * Workers that have been asked to stop still count, so that we do not spawn a
+ * replacement alongside one that is still shutting down.
+ */
+static bool
+database_has_worker(const char *dbname)
+{
+	for (int i = 0; i < launcher_nslots; i++)
+	{
+		if (strcmp(launcher_slots[i].dbname, dbname) == 0)
+			return true;
+	}
+
+	return false;
+}
+
+/*
+ * One pass over the database list, spawning workers where they are missing.
+ *
+ * Databases are visited from a persistent cursor rather than always from the
+ * head of the list. Combined with the service quantum that makes busy workers
+ * relinquish their slots, this is what guarantees that every database is
+ * eventually serviced when there are more databases than slots.
+ */
+static void
+launcher_sweep(char **db_names, int db_count)
+{
+	int			quantum;
+	int			visited;
+	int			live = 0;
+	bool		warned = false;
+
+	if (db_count == 0)
+		return;
+
+	/*
+	 * A quantum is only meaningful when we cannot give every database its own
+	 * worker. When we can, workers stay resident and there is no churn at all,
+	 * which keeps the common case behaving as it did before.
+	 */
+	quantum = (db_count > pgedge_vectorizer_num_workers)
+		? pgedge_vectorizer_worker_service_quantum
+		: 0;
+
+	/* If the cap was lowered at runtime, retire the surplus */
+	for (int i = 0; i < launcher_nslots; i++)
+	{
+		if (!launcher_slots[i].terminating)
+			live++;
+	}
+
+	for (int i = launcher_nslots - 1;
+		 i >= 0 && live > pgedge_vectorizer_num_workers; i--)
+	{
+		if (launcher_slots[i].terminating)
+			continue;
+
+		elog(LOG, "pgedge_vectorizer launcher: retiring worker for database "
+			 "\"%s\" after num_workers was lowered",
+			 launcher_slots[i].dbname);
+		TerminateBackgroundWorker(launcher_slots[i].handle);
+		launcher_slots[i].terminating = true;
+		live--;
+	}
+
+	for (visited = 0; visited < db_count; visited++)
+	{
+		int			idx = (launcher_cursor + visited) % db_count;
+		const char *dbname = db_names[idx];
+		BackgroundWorkerHandle *handle;
+
+		if (launcher_nslots >= pgedge_vectorizer_num_workers)
+			break;
+
+		if (database_has_worker(dbname))
+			continue;
+
+		handle = launch_worker_for_database(dbname, quantum);
+		if (handle == NULL)
+		{
+			if (!warned)
+			{
+				elog(LOG, "pgedge_vectorizer launcher: could not register a "
+					 "worker for database \"%s\"; max_worker_processes may be "
+					 "exhausted, will retry", dbname);
+				warned = true;
+			}
+			break;
+		}
+
+		strlcpy(launcher_slots[launcher_nslots].dbname, dbname, NAMEDATALEN);
+		launcher_slots[launcher_nslots].handle = handle;
+		launcher_slots[launcher_nslots].terminating = false;
+		launcher_nslots++;
+	}
+
+	/* Start the next sweep further along, so every database gets a turn */
+	launcher_cursor = (launcher_cursor + visited) % db_count;
+}
+
+/*
+ * Launcher main entry point
+ *
+ * Spawns one dynamic worker per configured database, up to num_workers at a
+ * time, and keeps doing so as workers exit and the configuration changes.
+ *
+ * Note: this process has no database connection and therefore no
+ * PgBackendStatus entry, because that is allocated by InitPostgres() via
+ * BackgroundWorkerInitializeConnection(). It must not call any pgstat_report_*
+ * function.
+ */
+PGDLLEXPORT void
+pgedge_vectorizer_launcher_main(Datum main_arg)
+{
+	char	  **db_names = NULL;
+	int			db_count = 0;
+	bool		reload_list = true;
+	bool		logged_empty = false;
+
+	/* Setup signal handlers */
+	pqsignal(SIGTERM, worker_sigterm);
+	pqsignal(SIGHUP, worker_sighup);
+
+	/* We're now ready to receive signals */
+	BackgroundWorkerUnblockSignals();
+
+	elog(LOG, "pgedge_vectorizer launcher started");
+
+	while (!got_sigterm)
+	{
+		int			rc;
+		long		sweep_interval;
+
+		/* Reload configuration if SIGHUP received */
+		if (got_sighup)
+		{
+			got_sighup = false;
+			ProcessConfigFile(PGC_SIGHUP);
+			reload_list = true;
+		}
+
+		if (reload_list)
+		{
+			if (db_names != NULL)
+			{
+				for (int i = 0; i < db_count; i++)
+					pfree(db_names[i]);
+				pfree(db_names);
+				db_names = NULL;
+			}
+
+			db_count = parse_database_list(&db_names);
+			reload_list = false;
+
+			if (db_count == 0)
+			{
+				if (!logged_empty)
+				{
+					elog(LOG, "pgedge_vectorizer launcher: no databases "
+						 "configured in pgedge_vectorizer.databases, waiting");
+					logged_empty = true;
+				}
+			}
+			else
+			{
+				logged_empty = false;
+
+				if (db_count > pgedge_vectorizer_num_workers)
+					elog(LOG, "pgedge_vectorizer launcher: %d databases "
+						 "configured with num_workers = %d, databases will be "
+						 "serviced in rotation",
+						 db_count, pgedge_vectorizer_num_workers);
+			}
+		}
+
+		/*
+		 * Retire workers whose database is no longer configured, so that
+		 * removing a database from the list actually releases it.
+		 */
+		for (int i = 0; i < launcher_nslots; i++)
+		{
+			bool		still_configured = false;
+
+			if (launcher_slots[i].terminating)
+				continue;
+
+			for (int j = 0; j < db_count; j++)
+			{
+				if (strcmp(launcher_slots[i].dbname, db_names[j]) == 0)
+				{
+					still_configured = true;
+					break;
+				}
+			}
+
+			if (!still_configured)
+			{
+				elog(LOG, "pgedge_vectorizer launcher: stopping worker for "
+					 "database \"%s\", no longer configured",
+					 launcher_slots[i].dbname);
+				TerminateBackgroundWorker(launcher_slots[i].handle);
+				launcher_slots[i].terminating = true;
+			}
+		}
+
+		launcher_reap_workers();
+		launcher_sweep(db_names, db_count);
+
+		/*
+		 * Sweep briskly whilst databases are queued waiting for a slot, and
+		 * rarely once every database has its own resident worker.
+		 */
+		sweep_interval = (db_count > pgedge_vectorizer_num_workers)
+			? LAUNCHER_SWEEP_INTERVAL_ROTATING_MS
+			: LAUNCHER_SWEEP_INTERVAL_IDLE_MS;
+
+		rc = WaitLatch(MyLatch,
+					   WL_LATCH_SET | WL_TIMEOUT | WL_POSTMASTER_DEATH,
+					   sweep_interval,
+					   PG_WAIT_EXTENSION);
+
+		ResetLatch(MyLatch);
+
+		/* Emergency bailout if postmaster has died */
+		if (rc & WL_POSTMASTER_DEATH)
+			proc_exit(1);
+	}
+
+	elog(LOG, "pgedge_vectorizer launcher shutting down");
+
+	/* Workers are BGW_NEVER_RESTART and exit with the postmaster */
+	proc_exit(0);
 }
 
 /*
@@ -127,13 +551,9 @@ extension_installed(void)
 PGDLLEXPORT void
 pgedge_vectorizer_worker_main(Datum main_arg)
 {
-	int worker_id = DatumGetInt32(main_arg);
+	int quantum_secs = DatumGetInt32(main_arg);
 	char dbname[NAMEDATALEN];
-	char *db_list;
-	char *db_name;
-	char *db_copy;
-	char *db_saveptr;
-	int db_count = 0;
+	TimestampTz start_time;
 	bool extension_exists = false;
 	int ext_retry_interval = 5000;	/* Start at 5s, doubles up to max */
 	bool first_ext_check = true;
@@ -146,101 +566,31 @@ pgedge_vectorizer_worker_main(Datum main_arg)
 	/* We're now ready to receive signals */
 	BackgroundWorkerUnblockSignals();
 
-	/* Check if databases are configured */
-	if (pgedge_vectorizer_databases == NULL || pgedge_vectorizer_databases[0] == '\0')
-	{
-		elog(LOG, "pgedge_vectorizer worker %d: no databases configured in pgedge_vectorizer.databases, sleeping",
-			 worker_id + 1);
-
-		/* Sleep indefinitely, checking periodically for config changes */
-		while (!got_sigterm)
-		{
-			int rc;
-
-			if (got_sighup)
-			{
-				got_sighup = false;
-				ProcessConfigFile(PGC_SIGHUP);
-
-				/* Check if databases were configured */
-				if (pgedge_vectorizer_databases != NULL && pgedge_vectorizer_databases[0] != '\0')
-					break;
-			}
-
-			rc = WaitLatch(MyLatch,
-						   WL_LATCH_SET | WL_TIMEOUT | WL_POSTMASTER_DEATH,
-						   60000L, /* Check every minute */
-						   PG_WAIT_EXTENSION);
-
-			ResetLatch(MyLatch);
-
-			if (rc & WL_POSTMASTER_DEATH)
-				proc_exit(1);
-		}
-
-		if (got_sigterm)
-			proc_exit(0);
-	}
-
-	/* Parse database list and select one for this worker */
-	db_list = pstrdup(pgedge_vectorizer_databases);
-	db_copy = db_list;
-
 	/*
-	 * Count databases.  Use strtok_r() rather than strtok(): the latter keeps
-	 * its parsing position in a single process-wide static, so any other
-	 * strtok() caller reached from this loop would silently corrupt it.
+	 * The launcher passes our target database in bgw_extra, because
+	 * bgw_main_arg is a single Datum and cannot carry a string. The Datum
+	 * carries our service quantum instead, where 0 means stay resident.
+	 *
+	 * Deciding which databases are covered is the launcher's job, so there is
+	 * no database list parsing here any more.
 	 */
-	while ((db_name = strtok_r(db_copy, ",", &db_saveptr)) != NULL)
-	{
-		db_copy = NULL;
-		db_count++;
-	}
+	strlcpy(dbname, MyBgworkerEntry->bgw_extra, NAMEDATALEN);
 
-	if (db_count == 0)
+	if (dbname[0] == '\0')
 	{
-		elog(LOG, "pgedge_vectorizer worker %d: empty database list, exiting",
-			 worker_id + 1);
+		elog(LOG, "pgedge_vectorizer worker started without a database name, exiting");
 		proc_exit(0);
 	}
 
-	/* Select database for this worker (round-robin) */
-	pfree(db_list);
-	db_list = pstrdup(pgedge_vectorizer_databases);
-	db_copy = db_list;
+	start_time = GetCurrentTimestamp();
 
-	for (int i = 0; i <= (worker_id % db_count); i++)
-	{
-		db_name = strtok_r(db_copy, ",", &db_saveptr);
-		db_copy = NULL;
-	}
-
-	/*
-	 * The count pass found db_count tokens and worker_id % db_count is less
-	 * than that, so the loop above cannot have run off the end of the list.
-	 */
-	Assert(db_name != NULL);
-
-	/* Trim whitespace */
-	while (*db_name == ' ' || *db_name == '\t')
-		db_name++;
-
-	strlcpy(dbname, db_name, NAMEDATALEN);
-
-	/* Remove trailing whitespace */
-	for (int i = strlen(dbname) - 1; i >= 0 && (dbname[i] == ' ' || dbname[i] == '\t'); i--)
-		dbname[i] = '\0';
-
-	pfree(db_list);
-
-	/* Connect to the selected database */
+	/* Connect to the database the launcher assigned us */
 	BackgroundWorkerInitializeConnection(dbname, NULL, 0);
 
-	elog(LOG, "pgedge_vectorizer worker %d started (database: %s)",
-		 worker_id + 1, dbname);
+	elog(LOG, "pgedge_vectorizer worker started (database: %s)", dbname);
 
 	/* Set process display */
-	pgstat_report_appname(psprintf("pgedge_vectorizer worker %d", worker_id + 1));
+	pgstat_report_appname(psprintf("pgedge_vectorizer worker (%s)", dbname));
 
 	/* Main work loop */
 	while (!got_sigterm)
@@ -268,22 +618,22 @@ pgedge_vectorizer_worker_main(Datum main_arg)
 				{
 					if (first_ext_check)
 					{
-						elog(LOG, "pgedge_vectorizer worker %d: extension not installed in database '%s', "
+						elog(LOG, "pgedge_vectorizer worker: extension not installed in database '%s', "
 							 "will check again in %ds (hint: run CREATE EXTENSION pgedge_vectorizer)",
-							 worker_id + 1, dbname, ext_retry_interval / 1000);
+							 dbname, ext_retry_interval / 1000);
 						first_ext_check = false;
 					}
 					else if (ext_retry_interval >= EXT_RETRY_MAX)
 					{
-						elog(LOG, "pgedge_vectorizer worker %d: extension still not installed in database '%s', "
+						elog(LOG, "pgedge_vectorizer worker: extension still not installed in database '%s', "
 							 "next check in %ds",
-							 worker_id + 1, dbname, ext_retry_interval / 1000);
+							 dbname, ext_retry_interval / 1000);
 					}
 				}
 				else
 				{
-					elog(LOG, "pgedge_vectorizer worker %d: extension found in database '%s', starting to process queue",
-						 worker_id + 1, dbname);
+					elog(LOG, "pgedge_vectorizer worker: extension found in database '%s', starting to process queue",
+						 dbname);
 					ext_retry_interval = 5000;
 					first_ext_check = true;
 				}
@@ -316,6 +666,26 @@ pgedge_vectorizer_worker_main(Datum main_arg)
 		if (rc & WL_POSTMASTER_DEATH)
 			proc_exit(1);
 
+		/*
+		 * Yield our slot once the service quantum expires, so that the
+		 * launcher can hand it to the next database in the rotation. A worker
+		 * that always has work would otherwise keep its slot indefinitely and
+		 * starve the databases behind it.
+		 *
+		 * A quantum of zero means the launcher is not oversubscribed and every
+		 * configured database can have its own worker, so we stay resident.
+		 * That is the common case and involves no process churn at all.
+		 */
+		if (quantum_secs > 0 &&
+			TimestampDifferenceExceeds(start_time, GetCurrentTimestamp(),
+									   quantum_secs * 1000))
+		{
+			elog(LOG, "pgedge_vectorizer worker for database \"%s\" yielding its "
+				 "slot after %d seconds so that another database can be serviced",
+				 dbname, quantum_secs);
+			break;
+		}
+
 		/* Only process queue if extension is installed */
 		if (!extension_exists)
 		{
@@ -328,10 +698,10 @@ pgedge_vectorizer_worker_main(Datum main_arg)
 
 		PG_TRY();
 		{
-			process_queue_batch(worker_id);
+			process_queue_batch(dbname);
 
 			/* Perform automatic cleanup if enabled */
-			cleanup_completed_items(worker_id);
+			cleanup_completed_items(dbname);
 		}
 		PG_CATCH();
 		{
@@ -339,8 +709,8 @@ pgedge_vectorizer_worker_main(Datum main_arg)
 			FlushErrorState();
 
 			/* Don't exit on errors - log and continue */
-			elog(LOG, "pgedge_vectorizer worker %d: error in processing, continuing",
-				 worker_id + 1);
+			elog(LOG, "pgedge_vectorizer worker for database \"%s\": error in "
+				 "processing, continuing", dbname);
 
 			/* Abort any transaction */
 			AbortCurrentTransaction();
@@ -352,7 +722,7 @@ pgedge_vectorizer_worker_main(Datum main_arg)
 	}
 
 	/* Cleanup before exit */
-	elog(LOG, "pgedge_vectorizer worker %d shutting down", worker_id + 1);
+	elog(LOG, "pgedge_vectorizer worker for database \"%s\" shutting down", dbname);
 	proc_exit(0);
 }
 
@@ -360,7 +730,7 @@ pgedge_vectorizer_worker_main(Datum main_arg)
  * Process a batch of queue items
  */
 static void
-process_queue_batch(int worker_id)
+process_queue_batch(const char *dbname)
 {
 	int ret;
 	int batch_size = pgedge_vectorizer_batch_size;
@@ -403,7 +773,8 @@ process_queue_batch(int worker_id)
 		bool has_sparse_only = false;
 		int effective_batch_size = n_items;
 
-		elog(DEBUG1, "Worker %d processing %d queue items", worker_id + 1, n_items);
+		elog(DEBUG1, "Worker for database \"%s\" processing %d queue items",
+			 dbname, n_items);
 
 		/* Extract data from result */
 		for (int i = 0; i < n_items; i++)
@@ -465,12 +836,14 @@ process_queue_batch(int worker_id)
 		if (has_retries && n_items > 1)
 		{
 			effective_batch_size = 1;
-			elog(DEBUG1, "Worker %d: found retried items, processing individually", worker_id + 1);
+			elog(DEBUG1, "Worker for database \"%s\": found retried items, "
+				 "processing individually", dbname);
 		}
 		else if (has_sparse_only && n_items > 1)
 		{
 			effective_batch_size = 1;
-			elog(DEBUG1, "Worker %d: found sparse-only items, processing individually", worker_id + 1);
+			elog(DEBUG1, "Worker for database \"%s\": found sparse-only items, "
+				 "processing individually", dbname);
 		}
 
 		/* Mark all as processing */
@@ -881,7 +1254,7 @@ update_embedding(int64 chunk_id, const char *chunk_table, const float *embedding
  * Clean up completed queue items older than auto_cleanup_hours
  */
 static void
-cleanup_completed_items(int worker_id)
+cleanup_completed_items(const char *dbname)
 {
 	int ret;
 	int rows_deleted = 0;
@@ -916,8 +1289,9 @@ cleanup_completed_items(int worker_id)
 		rows_deleted = SPI_processed;
 		if (rows_deleted > 0)
 		{
-			elog(LOG, "pgedge_vectorizer worker %d: cleaned up %d completed queue items older than %d hours",
-				 worker_id + 1, rows_deleted, pgedge_vectorizer_auto_cleanup_hours);
+			elog(LOG, "pgedge_vectorizer worker for database \"%s\": cleaned up %d "
+				 "completed queue items older than %d hours",
+				 dbname, rows_deleted, pgedge_vectorizer_auto_cleanup_hours);
 		}
 	}
 

--- a/src/worker.c
+++ b/src/worker.c
@@ -80,8 +80,8 @@ static void cleanup_completed_items(const char *dbname);
 static void update_embedding(int64 chunk_id, const char *chunk_table,
 							 const float *embedding, int dim);
 static int	parse_database_list(char ***names);
-static BackgroundWorkerHandle *launch_worker_for_database(const char *dbname,
-														  int quantum_secs);
+static int	worker_quantum_secs(void);
+static BackgroundWorkerHandle *launch_worker_for_database(const char *dbname);
 static void launcher_reap_workers(void);
 static bool database_has_worker(const char *dbname);
 static void launcher_sweep(char **db_names, int db_count);
@@ -209,13 +209,47 @@ parse_database_list(char ***names)
 }
 
 /*
+ * How long may a worker hold its slot before yielding it?
+ *
+ * Zero means stay resident, which is correct whenever every configured database
+ * can have a worker of its own.
+ *
+ * Whether we are oversubscribed is a pure function of the database count and
+ * the concurrency cap, so a worker can evaluate this itself rather than being
+ * told at spawn time, and must re-evaluate it after every reload. A worker that
+ * latched the value at startup would stay resident forever after a reload that
+ * added databases, starving the additions exactly as the old static assignment
+ * starved anything beyond num_workers.
+ */
+static int
+worker_quantum_secs(void)
+{
+	char	  **db_names;
+	int			db_count;
+	int			quantum;
+
+	db_count = parse_database_list(&db_names);
+
+	quantum = (db_count > pgedge_vectorizer_num_workers)
+		? pgedge_vectorizer_worker_service_quantum
+		: 0;
+
+	for (int i = 0; i < db_count; i++)
+		pfree(db_names[i]);
+	if (db_names != NULL)
+		pfree(db_names);
+
+	return quantum;
+}
+
+/*
  * Spawn a worker for one database.
  *
  * Returns the handle, or NULL when no worker slot could be obtained, which
  * normally means max_worker_processes is exhausted.
  */
 static BackgroundWorkerHandle *
-launch_worker_for_database(const char *dbname, int quantum_secs)
+launch_worker_for_database(const char *dbname)
 {
 	BackgroundWorker worker;
 	BackgroundWorkerHandle *handle;
@@ -241,11 +275,11 @@ launch_worker_for_database(const char *dbname, int quantum_secs)
 
 	/*
 	 * bgw_main_arg is a single Datum and cannot carry a string, so the target
-	 * database name travels in bgw_extra. That leaves the Datum free for the
-	 * service quantum, which only the launcher can compute because only it
-	 * knows whether we are oversubscribed.
+	 * database name travels in bgw_extra. The worker works out its own service
+	 * quantum from the GUCs, so nothing else needs passing: were the launcher
+	 * to pass it at spawn time, the value would go stale on the next reload.
 	 */
-	worker.bgw_main_arg = Int32GetDatum(quantum_secs);
+	worker.bgw_main_arg = (Datum) 0;
 	strlcpy(worker.bgw_extra, dbname, NAMEDATALEN);
 
 	/* Be signalled when this worker starts or stops */
@@ -311,22 +345,12 @@ database_has_worker(const char *dbname)
 static void
 launcher_sweep(char **db_names, int db_count)
 {
-	int			quantum;
 	int			visited;
 	int			live = 0;
 	bool		warned = false;
 
 	if (db_count == 0)
 		return;
-
-	/*
-	 * A quantum is only meaningful when we cannot give every database its own
-	 * worker. When we can, workers stay resident and there is no churn at all,
-	 * which keeps the common case behaving as it did before.
-	 */
-	quantum = (db_count > pgedge_vectorizer_num_workers)
-		? pgedge_vectorizer_worker_service_quantum
-		: 0;
 
 	/* If the cap was lowered at runtime, retire the surplus */
 	for (int i = 0; i < launcher_nslots; i++)
@@ -361,7 +385,7 @@ launcher_sweep(char **db_names, int db_count)
 		if (database_has_worker(dbname))
 			continue;
 
-		handle = launch_worker_for_database(dbname, quantum);
+		handle = launch_worker_for_database(dbname);
 		if (handle == NULL)
 		{
 			if (!warned)
@@ -551,7 +575,7 @@ extension_installed(void)
 PGDLLEXPORT void
 pgedge_vectorizer_worker_main(Datum main_arg)
 {
-	int quantum_secs = DatumGetInt32(main_arg);
+	int quantum_secs;
 	char dbname[NAMEDATALEN];
 	TimestampTz start_time;
 	bool extension_exists = false;
@@ -568,11 +592,11 @@ pgedge_vectorizer_worker_main(Datum main_arg)
 
 	/*
 	 * The launcher passes our target database in bgw_extra, because
-	 * bgw_main_arg is a single Datum and cannot carry a string. The Datum
-	 * carries our service quantum instead, where 0 means stay resident.
+	 * bgw_main_arg is a single Datum and cannot carry a string.
 	 *
 	 * Deciding which databases are covered is the launcher's job, so there is
-	 * no database list parsing here any more.
+	 * no database list parsing here any more, beyond working out our own
+	 * service quantum below.
 	 */
 	strlcpy(dbname, MyBgworkerEntry->bgw_extra, NAMEDATALEN);
 
@@ -583,6 +607,7 @@ pgedge_vectorizer_worker_main(Datum main_arg)
 	}
 
 	start_time = GetCurrentTimestamp();
+	quantum_secs = worker_quantum_secs();
 
 	/* Connect to the database the launcher assigned us */
 	BackgroundWorkerInitializeConnection(dbname, NULL, 0);
@@ -606,6 +631,13 @@ pgedge_vectorizer_worker_main(Datum main_arg)
 			/* Recheck extension status after config reload */
 			extension_exists = false;
 			ext_retry_interval = 5000;
+
+			/*
+			 * Re-evaluate our quantum: a reload may have added databases or
+			 * lowered the cap, turning a resident worker into one that must
+			 * yield its slot so the additions get serviced.
+			 */
+			quantum_secs = worker_quantum_secs();
 		}
 
 		/* Check if extension is installed (periodically recheck) */

--- a/src/worker.c
+++ b/src/worker.c
@@ -79,8 +79,13 @@ static void process_queue_batch(const char *dbname);
 static void cleanup_completed_items(const char *dbname);
 static void update_embedding(int64 chunk_id, const char *chunk_table,
 							 const float *embedding, int dim);
+static char *trim_whitespace(char *str);
 static int	parse_database_list(char ***names);
 static int	worker_quantum_secs(void);
+static void launcher_retire_surplus(void);
+static void launcher_retire_unconfigured(char **db_names, int db_count);
+static int	launcher_reload_databases(char ***db_names, int old_count,
+									  bool *logged_empty);
 static BackgroundWorkerHandle *launch_worker_for_database(const char *dbname);
 static void launcher_reap_workers(void);
 static bool database_has_worker(const char *dbname);
@@ -145,6 +150,31 @@ register_background_workers(void)
 }
 
 /*
+ * Trim leading and trailing spaces and tabs from a token, returning a pointer
+ * into the original buffer.
+ *
+ * The length is measured with strnlen() bounded by NAMEDATALEN rather than with
+ * strlen(). A database name longer than that cannot be valid and would be
+ * truncated by strlcpy() when we come to use it, and the bound means we cannot
+ * over-read even if handed a buffer that is somehow not NUL-terminated
+ * (CWE-126).
+ */
+static char *
+trim_whitespace(char *str)
+{
+	size_t		len;
+
+	while (*str == ' ' || *str == '\t')
+		str++;
+
+	len = strnlen(str, NAMEDATALEN);
+	while (len > 0 && (str[len - 1] == ' ' || str[len - 1] == '\t'))
+		str[--len] = '\0';
+
+	return str;
+}
+
+/*
  * Parse pgedge_vectorizer.databases into a palloc'd array of trimmed names.
  *
  * Returns the number of names found, with *names set to a palloc'd array of
@@ -179,19 +209,9 @@ parse_database_list(char ***names)
 	for (tok = strtok_r(list, ",", &saveptr); tok != NULL;
 		 tok = strtok_r(NULL, ",", &saveptr))
 	{
-		char	   *name = tok;
-		int			len;
+		char	   *name = trim_whitespace(tok);
 
-		/* Trim leading whitespace */
-		while (*name == ' ' || *name == '\t')
-			name++;
-
-		/* Trim trailing whitespace */
-		len = strlen(name);
-		while (len > 0 && (name[len - 1] == ' ' || name[len - 1] == '\t'))
-			name[--len] = '\0';
-
-		if (len == 0)
+		if (name[0] == '\0')
 			continue;
 
 		if (count == capacity)
@@ -343,16 +363,10 @@ database_has_worker(const char *dbname)
  * eventually serviced when there are more databases than slots.
  */
 static void
-launcher_sweep(char **db_names, int db_count)
+launcher_retire_surplus(void)
 {
-	int			visited;
 	int			live = 0;
-	bool		warned = false;
 
-	if (db_count == 0)
-		return;
-
-	/* If the cap was lowered at runtime, retire the surplus */
 	for (int i = 0; i < launcher_nslots; i++)
 	{
 		if (!launcher_slots[i].terminating)
@@ -372,6 +386,54 @@ launcher_sweep(char **db_names, int db_count)
 		launcher_slots[i].terminating = true;
 		live--;
 	}
+}
+
+/*
+ * Stop workers whose database is no longer configured, so that removing a
+ * database from pgedge_vectorizer.databases actually releases it.
+ */
+static void
+launcher_retire_unconfigured(char **db_names, int db_count)
+{
+	for (int i = 0; i < launcher_nslots; i++)
+	{
+		bool		still_configured = false;
+
+		if (launcher_slots[i].terminating)
+			continue;
+
+		for (int j = 0; j < db_count; j++)
+		{
+			if (strcmp(launcher_slots[i].dbname, db_names[j]) == 0)
+			{
+				still_configured = true;
+				break;
+			}
+		}
+
+		if (still_configured)
+			continue;
+
+		elog(LOG, "pgedge_vectorizer launcher: stopping worker for database "
+			 "\"%s\", no longer configured", launcher_slots[i].dbname);
+		TerminateBackgroundWorker(launcher_slots[i].handle);
+		launcher_slots[i].terminating = true;
+	}
+}
+
+/*
+ * One pass over the database list, spawning workers where they are missing.
+ */
+static void
+launcher_sweep(char **db_names, int db_count)
+{
+	int			visited;
+	bool		warned = false;
+
+	if (db_count == 0)
+		return;
+
+	launcher_retire_surplus();
 
 	for (visited = 0; visited < db_count; visited++)
 	{
@@ -406,6 +468,50 @@ launcher_sweep(char **db_names, int db_count)
 
 	/* Start the next sweep further along, so every database gets a turn */
 	launcher_cursor = (launcher_cursor + visited) % db_count;
+}
+
+/*
+ * Re-read the configured database list, freeing the previous one.
+ *
+ * Returns the new count. *logged_empty tracks whether we have already
+ * complained about an empty list, so that the complaint appears once rather
+ * than on every sweep.
+ */
+static int
+launcher_reload_databases(char ***db_names, int old_count, bool *logged_empty)
+{
+	int			db_count;
+
+	if (*db_names != NULL)
+	{
+		for (int i = 0; i < old_count; i++)
+			pfree((*db_names)[i]);
+		pfree(*db_names);
+		*db_names = NULL;
+	}
+
+	db_count = parse_database_list(db_names);
+
+	if (db_count == 0)
+	{
+		if (!*logged_empty)
+		{
+			elog(LOG, "pgedge_vectorizer launcher: no databases configured in "
+				 "pgedge_vectorizer.databases, waiting");
+			*logged_empty = true;
+		}
+
+		return db_count;
+	}
+
+	*logged_empty = false;
+
+	if (db_count > pgedge_vectorizer_num_workers)
+		elog(LOG, "pgedge_vectorizer launcher: %d databases configured with "
+			 "num_workers = %d, databases will be serviced in rotation",
+			 db_count, pgedge_vectorizer_num_workers);
+
+	return db_count;
 }
 
 /*
@@ -451,68 +557,12 @@ pgedge_vectorizer_launcher_main(Datum main_arg)
 
 		if (reload_list)
 		{
-			if (db_names != NULL)
-			{
-				for (int i = 0; i < db_count; i++)
-					pfree(db_names[i]);
-				pfree(db_names);
-				db_names = NULL;
-			}
-
-			db_count = parse_database_list(&db_names);
+			db_count = launcher_reload_databases(&db_names, db_count,
+												 &logged_empty);
 			reload_list = false;
-
-			if (db_count == 0)
-			{
-				if (!logged_empty)
-				{
-					elog(LOG, "pgedge_vectorizer launcher: no databases "
-						 "configured in pgedge_vectorizer.databases, waiting");
-					logged_empty = true;
-				}
-			}
-			else
-			{
-				logged_empty = false;
-
-				if (db_count > pgedge_vectorizer_num_workers)
-					elog(LOG, "pgedge_vectorizer launcher: %d databases "
-						 "configured with num_workers = %d, databases will be "
-						 "serviced in rotation",
-						 db_count, pgedge_vectorizer_num_workers);
-			}
 		}
 
-		/*
-		 * Retire workers whose database is no longer configured, so that
-		 * removing a database from the list actually releases it.
-		 */
-		for (int i = 0; i < launcher_nslots; i++)
-		{
-			bool		still_configured = false;
-
-			if (launcher_slots[i].terminating)
-				continue;
-
-			for (int j = 0; j < db_count; j++)
-			{
-				if (strcmp(launcher_slots[i].dbname, db_names[j]) == 0)
-				{
-					still_configured = true;
-					break;
-				}
-			}
-
-			if (!still_configured)
-			{
-				elog(LOG, "pgedge_vectorizer launcher: stopping worker for "
-					 "database \"%s\", no longer configured",
-					 launcher_slots[i].dbname);
-				TerminateBackgroundWorker(launcher_slots[i].handle);
-				launcher_slots[i].terminating = true;
-			}
-		}
-
+		launcher_retire_unconfigured(db_names, db_count);
 		launcher_reap_workers();
 		launcher_sweep(db_names, db_count);
 

--- a/test/expected/worker.out
+++ b/test/expected/worker.out
@@ -26,3 +26,19 @@ SHOW pgedge_vectorizer.worker_poll_interval;
  1000
 (1 row)
 
+-- Service quantum bounds how long a worker holds its slot when there are more
+-- configured databases than num_workers allows to run concurrently
+SHOW pgedge_vectorizer.worker_service_quantum;
+ pgedge_vectorizer.worker_service_quantum 
+------------------------------------------
+ 1min
+(1 row)
+
+-- num_workers is a runtime-changeable concurrency cap rather than a fixed pool
+-- size, so it no longer requires a restart
+SELECT context FROM pg_settings WHERE name = 'pgedge_vectorizer.num_workers';
+ context 
+---------
+ sighup
+(1 row)
+

--- a/test/sql/worker.sql
+++ b/test/sql/worker.sql
@@ -8,3 +8,11 @@ SHOW pgedge_vectorizer.num_workers;
 SHOW pgedge_vectorizer.batch_size;
 SHOW pgedge_vectorizer.max_retries;
 SHOW pgedge_vectorizer.worker_poll_interval;
+
+-- Service quantum bounds how long a worker holds its slot when there are more
+-- configured databases than num_workers allows to run concurrently
+SHOW pgedge_vectorizer.worker_service_quantum;
+
+-- num_workers is a runtime-changeable concurrency cap rather than a fixed pool
+-- size, so it no longer requires a restart
+SELECT context FROM pg_settings WHERE name = 'pgedge_vectorizer.num_workers';

--- a/test/t/001_worker_coverage.pl
+++ b/test/t/001_worker_coverage.pl
@@ -99,6 +99,50 @@ my $shown = $node->safe_psql('postgres', 'SHOW pgedge_vectorizer.num_workers');
 is($shown, '4', 'num_workers can be changed by reload without a restart');
 
 $node->stop;
+
+# A worker that starts when the launcher is NOT oversubscribed must still begin
+# yielding if a later reload makes it oversubscribed. A worker that decided its
+# quantum once at startup would stay resident forever and starve the databases
+# added by the reload, which is issue #23 reappearing through a reload rather
+# than through the original static assignment.
+my @first  = qw(rotdb1 rotdb2);
+my @second = qw(rotdb3 rotdb4 rotdb5);
+
+my $rnode = PostgreSQL::Test::Cluster->new('vectorizer_reload');
+$rnode->init;
+$rnode->append_conf(
+	'postgresql.conf', qq(
+shared_preload_libraries = 'pgedge_vectorizer'
+pgedge_vectorizer.databases = '@{[ join ',', @first ]}'
+pgedge_vectorizer.num_workers = 2
+pgedge_vectorizer.worker_poll_interval = 200
+pgedge_vectorizer.worker_service_quantum = 5
+max_worker_processes = 16
+));
+$rnode->start;
+
+for my $db (@first, @second)
+{
+	$rnode->safe_psql('postgres', "CREATE DATABASE $db");
+	$rnode->safe_psql($db,        'CREATE EXTENSION pgedge_vectorizer CASCADE');
+}
+
+# Both of the first two databases can have their own worker, so both should be
+# resident with no quantum at all at this point.
+my @resident = wait_for_all_databases_serviced($rnode, \@first, 120);
+is_deeply(\@resident, [], 'both databases are serviced when not oversubscribed');
+
+# Now oversubscribe by reload alone, without restarting.
+$rnode->safe_psql('postgres',
+	"ALTER SYSTEM SET pgedge_vectorizer.databases = '"
+	  . join(',', @first, @second) . "'");
+$rnode->reload;
+
+my @after_reload = wait_for_all_databases_serviced($rnode, \@second, 120);
+is_deeply(\@after_reload, [],
+	'databases added by a reload that oversubscribes the launcher are serviced');
+
+$rnode->stop;
 done_testing();
 
 # Wait until every database in $dbs has announced a worker in the server log,

--- a/test/t/001_worker_coverage.pl
+++ b/test/t/001_worker_coverage.pl
@@ -32,6 +32,7 @@ shared_preload_libraries = 'pgedge_vectorizer'
 pgedge_vectorizer.databases = '@{[ join ',', @dbs ]}'
 pgedge_vectorizer.num_workers = 2
 pgedge_vectorizer.worker_poll_interval = 200
+pgedge_vectorizer.worker_service_quantum = 5
 max_worker_processes = 16
 ));
 $node->start;

--- a/test/t/001_worker_coverage.pl
+++ b/test/t/001_worker_coverage.pl
@@ -1,0 +1,82 @@
+# Copyright (c) 2025 - 2026, pgEdge, Inc.
+#
+# Verify that every database listed in pgedge_vectorizer.databases is serviced
+# by a background worker, regardless of how many workers the concurrency cap
+# allows to run at once.
+#
+# This cannot be expressed in pg_regress, which runs against a single database
+# and cannot manipulate shared_preload_libraries.
+
+use strict;
+use warnings;
+
+#
+# These modules must be loaded at compile time with use, rather than guarded
+# with a runtime require: PostgreSQL::Test::Utils contains an INIT block, and
+# requiring it at runtime fails with "Too late to run INIT block". Whether the
+# modules are available at all is decided in the Makefile, which only enables
+# TAP tests when it can see them.
+
+use PostgreSQL::Test::Cluster;
+use PostgreSQL::Test::Utils;
+use Test::More;
+
+# Deliberately more databases than num_workers allows to run concurrently.
+my @dbs = qw(vecdb1 vecdb2 vecdb3 vecdb4 vecdb5);
+
+my $node = PostgreSQL::Test::Cluster->new('vectorizer');
+$node->init;
+$node->append_conf(
+	'postgresql.conf', qq(
+shared_preload_libraries = 'pgedge_vectorizer'
+pgedge_vectorizer.databases = '@{[ join ',', @dbs ]}'
+pgedge_vectorizer.num_workers = 2
+pgedge_vectorizer.worker_poll_interval = 200
+max_worker_processes = 16
+));
+$node->start;
+
+# Create every database and install the extension in each one. A worker only
+# announces itself once it can see the extension.
+for my $db (@dbs)
+{
+	$node->safe_psql('postgres', "CREATE DATABASE $db");
+	$node->safe_psql($db,        'CREATE EXTENSION pgedge_vectorizer CASCADE');
+}
+
+# Reload so that databases created after startup are picked up, then wait for
+# each one to report a worker.
+$node->reload;
+
+my @unserviced = wait_for_all_databases_serviced($node, \@dbs, 120);
+
+is_deeply(\@unserviced, [],
+	'every configured database is serviced with num_workers below the database count');
+
+$node->stop;
+done_testing();
+
+# Wait until every database in $dbs has announced a worker in the server log,
+# or until $timeout seconds elapse. Returns the databases that never appeared.
+sub wait_for_all_databases_serviced
+{
+	my ($node, $dbs, $timeout) = @_;
+	my %seen;
+	my $deadline = time() + $timeout;
+
+	while (time() < $deadline)
+	{
+		my $log = slurp_file($node->logfile);
+
+		for my $db (@$dbs)
+		{
+			$seen{$db} = 1
+			  if $log =~ /extension found in database '\Q$db\E'/;
+		}
+
+		return () if keys(%seen) == scalar(@$dbs);
+		sleep 1;
+	}
+
+	return grep { !$seen{$_} } @$dbs;
+}

--- a/test/t/001_worker_coverage.pl
+++ b/test/t/001_worker_coverage.pl
@@ -54,6 +54,50 @@ my @unserviced = wait_for_all_databases_serviced($node, \@dbs, 120);
 is_deeply(\@unserviced, [],
 	'every configured database is serviced with num_workers below the database count');
 
+# Coverage alone is not enough: a worker that always has work must still give
+# up its slot, or the databases at the tail of the list would starve exactly as
+# they did before the launcher existed. Confirm each database is serviced more
+# than once, which can only happen if slots genuinely rotate.
+my %service_counts;
+my $rotate_deadline = time() + 120;
+
+while (time() < $rotate_deadline)
+{
+	my $log = slurp_file($node->logfile);
+
+	for my $db (@dbs)
+	{
+		my @hits = ($log =~ /worker started \(database: \Q$db\E\)/g);
+		$service_counts{$db} = scalar(@hits);
+	}
+
+	last if !grep { ($service_counts{$_} // 0) < 2 } @dbs;
+	sleep 1;
+}
+
+my @not_rotated = grep { ($service_counts{$_} // 0) < 2 } @dbs;
+
+is_deeply(\@not_rotated, [],
+	'every database is serviced repeatedly, so worker slots rotate');
+
+# A database added at runtime must be picked up on reload, without a restart.
+$node->safe_psql('postgres', 'CREATE DATABASE vecdb6');
+$node->safe_psql('vecdb6',   'CREATE EXTENSION pgedge_vectorizer CASCADE');
+$node->safe_psql('postgres',
+	"ALTER SYSTEM SET pgedge_vectorizer.databases = '"
+	  . join(',', @dbs, 'vecdb6') . "'");
+$node->reload;
+
+my @added = wait_for_all_databases_serviced($node, ['vecdb6'], 120);
+is_deeply(\@added, [], 'a database added by SIGHUP is picked up');
+
+# num_workers is PGC_SIGHUP now, so raising it must not need a restart.
+$node->safe_psql('postgres', 'ALTER SYSTEM SET pgedge_vectorizer.num_workers = 4');
+$node->reload;
+
+my $shown = $node->safe_psql('postgres', 'SHOW pgedge_vectorizer.num_workers');
+is($shown, '4', 'num_workers can be changed by reload without a restart');
+
 $node->stop;
 done_testing();
 


### PR DESCRIPTION
## Summary

Fixes the silent data staleness in #23, where any database listed beyond `pgedge_vectorizer.num_workers` was never processed at all.

The cause was that workers were statically registered at startup and each picked a database by `worker_id % db_count`, connecting to it for life. Because `worker_id` only ranged over `0 .. num_workers-1`, only those database indices were ever selected, and there was no mechanism by which a worker could later pick up a database at a later position. With the default `num_workers = 2` and five databases configured, three of them accumulated queue entries that were never handled, with nothing logged to indicate it.

This takes the third option from the issue, an autovacuum-style launcher, because it is the only one that guarantees coverage without either bounding the number of databases by the number of workers or relying on an operator noticing a warning.

### How it works

A single static launcher replaces the N static workers. It takes no database connection, reading the database list from the GUC rather than the catalogue, so it needs neither SPI nor a backend, which keeps its crash surface small. Each sweep it reaps exited workers and spawns dynamic per-database workers up to the cap, passing the target database in `bgw_extra` (`bgw_main_arg` is a single `Datum` and cannot carry a string) and a service quantum in `bgw_main_arg`.

Coverage alone is not sufficient: with a cap below the database count, slots must rotate or the design reproduces the original defect with extra machinery. Two mechanisms handle this. The launcher visits the list from a **round-robin cursor**, so the next spawn goes to the least recently serviced database rather than always the head. And workers have a **bounded service quantum**, yielding their slot once it elapses, because a permanently busy database would otherwise hold its slot forever and starve the rest.

The quantum is zero, meaning stay resident, whenever every configured database can have its own worker. **The common case therefore behaves exactly as before, with resident workers and no process churn**; rotation engages only when genuinely oversubscribed.

### Two findings worth flagging

**`bgw_notify_pid` does not wake a connection-less launcher.** The design initially assumed it would, giving prompt refill. Measured behaviour disagreed: after workers yielded at 17:41:02, replacements appeared only at 17:41:57, on the next timed sweep. The sweep interval, not the notification, therefore bounds refill latency, so it now adapts, sweeping once a second whilst databases are queued for a slot and once a minute when none are. This is documented in the code so nobody re-derives the wrong assumption.

**Relaxing `num_workers` to `PGC_SIGHUP` incidentally fixes on-demand loading.** `DefineCustomIntVariable` raises `FATAL` for a `PGC_POSTMASTER` variable created after startup, so any session loading the library without `shared_preload_libraries` was previously killed with `cannot create PGC_POSTMASTER variables after startup`. That no longer happens, although the launcher still requires preloading to be registered.

### Deliberately no shared memory

State is process-local, avoiding `RequestAddinShmemSpace` and the `shmem_request_hook` that does not exist before PostgreSQL 15, across the 14 to 19 range this extension supports. The trade-off is that a restarted launcher cannot rediscover its predecessor's workers, so a crash may briefly leave two workers on one database. That is harmless, because queue rows are claimed with `FOR UPDATE SKIP LOCKED`, so concurrent workers take disjoint rows.

## Behaviour change

`pgedge_vectorizer.num_workers` changes meaning from a fixed pool size to a **maximum concurrent worker count**, and becomes `PGC_SIGHUP`. Anyone who set it equal to their database count sees no difference. Anyone who inflated it purely to obtain coverage will find it now caps concurrency instead, which is strictly better than the silent staleness it replaces, but it is a change in meaning and is called out in the changelog.

## Test plan

Multi-database coverage cannot be expressed in pg_regress, which runs against a single database and cannot set `shared_preload_libraries`, so this adds a TAP suite. PGXS wires it into `installcheck` automatically, so no CI workflow change was needed. TAP is enabled only where the PostgreSQL Perl test modules are present, because Homebrew builds on macOS do not ship them and the matrix includes macOS.

- [x] The first commit's TAP test **fails against `main`**, reporting `vecdb3` onwards as unserviced: the issue reproduced before any fix
- [x] Five databases with `num_workers = 2` are all serviced after the fix
- [x] Slots demonstrably rotate, each database serviced repeatedly rather than once
- [x] A database added by SIGHUP is picked up without a restart
- [x] `num_workers` can be changed by reload
- [x] All 15 existing regression tests pass
- [x] Clean `make clean && make` with no new warnings

Verified locally against PostgreSQL 18.4; CI covers 14 through 19.

Closes #23