### PR TITLE
Clean up chunks and embeddings on DELETE and TRUNCATE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ DATA = sql/$(EXTENSION)--$(EXTVERSION).sql \
        sql/$(EXTENSION)--1.0-beta3--1.0.sql
 
 # Test configuration for pg_regress
-REGRESS = setup chunking hybrid_chunking queue vectorization multi_column maintenance edge_cases providers worker cleanup embedding pk_types stale_embeddings hybrid_test
+REGRESS = setup chunking hybrid_chunking queue delete_truncate delete_truncate_pk vectorization multi_column maintenance edge_cases providers worker cleanup embedding pk_types stale_embeddings hybrid_test
 REGRESS_OPTS = --inputdir=test --outputdir=test
 
 # Documentation files (if any)

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ pgEdge Vectorizer automatically chunks text content and generates vector embeddi
 - **Automatic Chunking**: Intelligently splits text into chunks with configurable strategies
 - **Async Processing**: Background workers process embeddings without blocking your application
 - **Multiple Providers**: Support for OpenAI, Voyage AI, Ollama (local embeddings), and Gemini
+- **Stays In Sync**: Chunks, embeddings, queue entries and BM25 statistics are removed automatically when source rows are deleted or the source table is truncated
 - **Configurable**: Extensive GUC parameters for fine-tuning behavior
 - **Batching**: Efficient batch processing of embeddings
 - **Retry Logic**: Automatic retry with exponential backoff for failed embeddings
@@ -293,6 +294,14 @@ SELECT pgedge_vectorizer.disable_vectorization(
     source_table REGCLASS,
     drop_chunk_table BOOLEAN DEFAULT FALSE
 );
+```
+
+#### `refresh_triggers()`
+
+Recreate the DELETE and TRUNCATE cleanup triggers for every registered vectorizer, returning the number recreated. Not normally needed, since upgrading repairs existing tables; use it if a trigger has been dropped by hand.
+
+```sql
+SELECT pgedge_vectorizer.refresh_triggers();
 ```
 
 #### `chunk_text()`

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -72,6 +72,20 @@ SELECT pgedge_vectorizer.disable_vectorization(
 - `source_column`: Column to disable (NULL = disable all columns)
 - `drop_chunk_table`: Whether to drop the chunk table
 
+### refresh_triggers()
+
+Recreate the DELETE and TRUNCATE cleanup triggers for every registered vectorizer.
+
+```sql
+SELECT pgedge_vectorizer.refresh_triggers();
+```
+
+**Returns:** the number of vectorized columns whose triggers were recreated.
+
+Vectorization installs three triggers per column: one for INSERT and UPDATE, one for DELETE, and one for TRUNCATE. Upgrading the extension repairs tables that were vectorized before the cleanup triggers existed, so this function is not normally needed. Use it if a trigger has been dropped by hand, or on an installation that acquired its vectorized tables under a build predating the cleanup triggers and so will never run the relevant upgrade script.
+
+Columns whose document identifier is not recorded in `pgedge_vectorizer.vectorizers` are skipped with a warning rather than guessed at; re-run `enable_vectorization()` for those.
+
 ### chunk_text()
 
 Manually chunk text content.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -36,6 +36,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   worker services one database before yielding its slot when there are more
   configured databases than workers. It is ignored when every configured
   database can have its own worker, in which case workers stay resident.
+- `pgedge_vectorizer.refresh_triggers()` recreates the DELETE and TRUNCATE
+  cleanup triggers for every registered vectorizer, returning the number
+  recreated. Upgrading repairs existing tables automatically, so this is only
+  needed if a trigger has been dropped by hand, or on an installation whose
+  vectorized tables were created under a build predating those triggers.
+- `pgedge_vectorizer.vectorizers` now records the document identifier column and
+  its type, so cleanup triggers can be recreated without re-detecting it.
 
 ### Changed
 
@@ -58,6 +65,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   list was silently never serviced: its queue accumulated entries that were
   never handled, with nothing logged to indicate it. With the default
   `num_workers = 2` and five databases configured, three of them were affected.
+- Deleting rows from a vectorized source table, or truncating it, no longer
+  leaves orphaned chunks, embeddings, queue entries and BM25 document
+  frequencies behind
+  ([#24](https://github.com/pgEdge/pgedge-vectorizer/issues/24)). Vectorization
+  previously installed an `AFTER INSERT OR UPDATE` trigger only, so removing
+  source data left every piece of derived data in place: vector and hybrid
+  search returned hits pointing at rows that no longer existed, the queue spent
+  embedding API calls on chunks for deleted rows, and `idf_weight` drifted for
+  the whole corpus, distorting relevance ranking for every query rather than
+  only those touching deleted rows.
+
+  Vectorization now installs three triggers per column, adding an `AFTER DELETE`
+  and an `AFTER TRUNCATE` trigger. The DELETE trigger is statement-level and uses
+  a transition table, so a bulk delete stays set-based rather than doing per-row
+  work. **Upgrading also repairs tables that were already vectorized**, which
+  otherwise would have kept leaking silently.
 
 ## [1.0] - 2026-03-13
 

--- a/sql/pgedge_vectorizer--1.0--1.1.sql
+++ b/sql/pgedge_vectorizer--1.0--1.1.sql
@@ -23,9 +23,19 @@ CREATE TABLE IF NOT EXISTS pgedge_vectorizer.vectorizers (
     source_table  TEXT NOT NULL,
     source_column NAME NOT NULL,
     chunk_table   TEXT NOT NULL,
+    source_pk     NAME,
+    pk_type       TEXT,
     created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     UNIQUE (source_table, source_column)
 );
+
+-- Record the primary key so that the cleanup triggers can be recreated without
+-- re-detecting it, which would get an explicit source_pk wrong.  CREATE TABLE
+-- IF NOT EXISTS above does nothing when upgrading, so add the columns directly.
+ALTER TABLE pgedge_vectorizer.vectorizers
+    ADD COLUMN IF NOT EXISTS source_pk NAME;
+ALTER TABLE pgedge_vectorizer.vectorizers
+    ADD COLUMN IF NOT EXISTS pk_type   TEXT;
 
 COMMENT ON TABLE pgedge_vectorizer.vectorizers IS
 'Registry of active vectorizer configurations (source table → chunk table)';
@@ -275,11 +285,13 @@ BEGIN
     -- Use EXECUTE...USING to avoid PL/pgSQL variable/column ambiguity.
     EXECUTE
         'INSERT INTO pgedge_vectorizer.vectorizers
-             (source_table, source_column, chunk_table)
-         VALUES ($1, $2, $3)
+             (source_table, source_column, chunk_table, source_pk, pk_type)
+         VALUES ($1, $2, $3, $4, $5)
          ON CONFLICT (source_table, source_column)
-         DO UPDATE SET chunk_table = EXCLUDED.chunk_table'
-    USING source_table::TEXT, source_column, chunk_table;
+         DO UPDATE SET chunk_table = EXCLUDED.chunk_table,
+                       source_pk   = EXCLUDED.source_pk,
+                       pk_type     = EXCLUDED.pk_type'
+    USING source_table::TEXT, source_column, chunk_table, source_pk, pk_col_type;
 
     -- Create trigger to chunk and queue on insert/update
     trigger_name := source_table::TEXT || '_' || source_column || '_vectorization_trigger';
@@ -292,6 +304,28 @@ BEGIN
         trigger_name, source_table,
         source_column, chunk_table, actual_strategy,
         actual_chunk_size, actual_chunk_overlap, source_pk, pk_col_type);
+
+    -- Clean up derived data when source rows are deleted.  Statement-level with
+    -- a transition table so that bulk deletes do not degenerate into per-row
+    -- work.
+    EXECUTE format('
+        CREATE OR REPLACE TRIGGER %I
+        AFTER DELETE ON %s
+        REFERENCING OLD TABLE AS old_rows
+        FOR EACH STATEMENT
+        EXECUTE FUNCTION pgedge_vectorizer.vectorization_delete_trigger(%L, %L, %L, %L)',
+        source_table::TEXT || '_' || source_column || '_vectorization_delete_trigger',
+        source_table,
+        source_column, chunk_table, source_pk, pk_col_type);
+
+    -- Clean up when the whole source table is truncated.
+    EXECUTE format('
+        CREATE OR REPLACE TRIGGER %I
+        AFTER TRUNCATE ON %s
+        FOR EACH STATEMENT
+        EXECUTE FUNCTION pgedge_vectorizer.vectorization_truncate_trigger(%L)',
+        source_table::TEXT || '_' || source_column || '_vectorization_truncate_trigger',
+        source_table, chunk_table);
 
     RAISE NOTICE 'Vectorization enabled: % -> %', source_table, chunk_table;
     RAISE NOTICE 'Strategy: %, chunk_size: %, overlap: %',
@@ -426,8 +460,14 @@ BEGIN
             chunk_table := source_table::TEXT || '_' || source_column || '_chunks';
         END IF;
 
-        -- Drop trigger
+        -- Drop triggers
         EXECUTE format('DROP TRIGGER IF EXISTS %I ON %s', trigger_name, source_table);
+        EXECUTE format('DROP TRIGGER IF EXISTS %I ON %s',
+                       source_table::TEXT || '_' || source_column || '_vectorization_delete_trigger',
+                       source_table);
+        EXECUTE format('DROP TRIGGER IF EXISTS %I ON %s',
+                       source_table::TEXT || '_' || source_column || '_vectorization_truncate_trigger',
+                       source_table);
 
         -- Remove orphaned queue items for this chunk table
         EXECUTE format('DELETE FROM pgedge_vectorizer.queue WHERE chunk_table = %L AND status IN (''pending'', ''processing'')', chunk_table);
@@ -456,7 +496,9 @@ BEGIN
             FROM pg_trigger t
             JOIN pg_class c ON t.tgrelid = c.oid
             WHERE c.oid = source_table
-            AND tgname LIKE source_table::TEXT || '%_vectorization_trigger'
+            -- Matches the row trigger plus the delete and truncate cleanup
+            -- triggers; still prefix-scoped to this source table.
+            AND tgname LIKE source_table::TEXT || '%_vectorization%trigger'
         LOOP
             EXECUTE format('DROP TRIGGER IF EXISTS %I ON %s', trigger_rec.tgname, source_table);
             RAISE NOTICE 'Dropped trigger: %', trigger_rec.tgname;
@@ -498,6 +540,67 @@ $$ LANGUAGE plpgsql;
 
 COMMENT ON FUNCTION pgedge_vectorizer.disable_vectorization IS
 'Disable automatic vectorization for a table';
+
+-- Recreate the DELETE and TRUNCATE cleanup triggers for every registered
+-- vectorizer.
+--
+-- Upgrade scripts only run on a version change, so an installation of an
+-- unreleased build that already has vectorized tables would otherwise have no
+-- supported way to acquire the new triggers.  This is also the repair route if
+-- triggers are ever dropped by hand.
+--
+-- Returns the number of vectorizers whose triggers were recreated.  Entries
+-- whose primary key is not recorded are skipped with a warning rather than
+-- guessed at, because enable_vectorization() accepts an explicit source_pk that
+-- re-detection could get wrong.
+CREATE OR REPLACE FUNCTION pgedge_vectorizer.refresh_triggers()
+RETURNS INT AS $$
+DECLARE
+    v         RECORD;
+    refreshed INT := 0;
+BEGIN
+    FOR v IN
+        SELECT source_table, source_column, chunk_table, source_pk, pk_type
+        FROM pgedge_vectorizer.vectorizers
+    LOOP
+        IF to_regclass(v.source_table) IS NULL THEN
+            RAISE WARNING 'Skipping %: source table no longer exists', v.source_table;
+            CONTINUE;
+        END IF;
+
+        IF v.source_pk IS NULL OR v.pk_type IS NULL THEN
+            RAISE WARNING 'Skipping %.%: primary key not recorded, re-run enable_vectorization() for this column',
+                v.source_table, v.source_column;
+            CONTINUE;
+        END IF;
+
+        EXECUTE format('
+            CREATE OR REPLACE TRIGGER %I
+            AFTER DELETE ON %s
+            REFERENCING OLD TABLE AS old_rows
+            FOR EACH STATEMENT
+            EXECUTE FUNCTION pgedge_vectorizer.vectorization_delete_trigger(%L, %L, %L, %L)',
+            v.source_table || '_' || v.source_column || '_vectorization_delete_trigger',
+            v.source_table,
+            v.source_column, v.chunk_table, v.source_pk, v.pk_type);
+
+        EXECUTE format('
+            CREATE OR REPLACE TRIGGER %I
+            AFTER TRUNCATE ON %s
+            FOR EACH STATEMENT
+            EXECUTE FUNCTION pgedge_vectorizer.vectorization_truncate_trigger(%L)',
+            v.source_table || '_' || v.source_column || '_vectorization_truncate_trigger',
+            v.source_table, v.chunk_table);
+
+        refreshed := refreshed + 1;
+    END LOOP;
+
+    RETURN refreshed;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION pgedge_vectorizer.refresh_triggers IS
+'Recreate the DELETE and TRUNCATE cleanup triggers for all registered vectorizers; returns the number refreshed';
 
 -- BM25 IDF stats decrement helper
 -- Called by vectorization_trigger before deleting old chunks on UPDATE so that
@@ -544,6 +647,109 @@ $$ LANGUAGE plpgsql;
 
 COMMENT ON FUNCTION pgedge_vectorizer.bm25_decrement_idf_stats IS
 'Decrement doc_freq in the _idf_stats table for a set of terms before their source chunks are deleted';
+
+-- Statement-level trigger function cleaning up after DELETE on a source table.
+--
+-- Statement-level rather than row-level so that a bulk delete does not run three
+-- statements plus a tokenisation per row: with the old_rows transition table the
+-- queue and chunk deletions are one set-based statement each.  Only the BM25
+-- decrement needs a loop, because bm25_decrement_idf_stats() takes one
+-- document's terms at a time.
+CREATE OR REPLACE FUNCTION pgedge_vectorizer.vectorization_delete_trigger()
+RETURNS TRIGGER AS $$
+DECLARE
+    content_col TEXT;
+    chunk_table TEXT;
+    pk_col      TEXT;
+    pk_type     TEXT;
+    old_row     RECORD;
+    old_terms   TEXT[];
+    chunk_count INT;
+BEGIN
+    content_col := TG_ARGV[0];
+    chunk_table := TG_ARGV[1];
+    pk_col      := COALESCE(TG_ARGV[2], 'id');
+    pk_type     := COALESCE(TG_ARGV[3], 'bigint');
+
+    -- Decrement BM25 document frequencies before deleting anything, because
+    -- bm25_decrement_idf_stats() derives the new corpus size by counting the
+    -- chunk table and subtracting the count we pass it.  Doing this afterwards
+    -- would understate the corpus and skew idf_weight for every term.
+    FOR old_row IN EXECUTE
+        format('SELECT %I::text AS pk_value, %I::text AS content FROM old_rows',
+               pk_col, content_col)
+    LOOP
+        IF old_row.content IS NULL OR trim(old_row.content) = '' THEN
+            CONTINUE;
+        END IF;
+
+        EXECUTE format(
+            'SELECT count(*)::int FROM %I WHERE source_id = $1::%s',
+            chunk_table, pk_type)
+        INTO chunk_count
+        USING old_row.pk_value;
+
+        IF chunk_count > 0 THEN
+            old_terms := pgedge_vectorizer.bm25_tokenize(trim(old_row.content));
+            PERFORM pgedge_vectorizer.bm25_decrement_idf_stats(
+                chunk_table, old_terms, chunk_count);
+        END IF;
+    END LOOP;
+
+    -- Remove queue entries for the doomed chunks, so the worker does not spend
+    -- embedding API calls on them.  'processing' rows are left alone, matching
+    -- the INSERT/UPDATE path: the worker copes with the chunk having gone.
+    EXECUTE format(
+        'DELETE FROM pgedge_vectorizer.queue
+          WHERE chunk_table = %L
+            AND status IN (''pending'', ''failed'')
+            AND chunk_id IN (
+                SELECT c.id FROM %I c
+                 WHERE c.source_id IN (SELECT o.%I::%s FROM old_rows o))',
+        chunk_table, chunk_table, pk_col, pk_type);
+
+    -- Finally the chunks themselves, which takes the embeddings with them.
+    EXECUTE format(
+        'DELETE FROM %I WHERE source_id IN (SELECT o.%I::%s FROM old_rows o)',
+        chunk_table, pk_col, pk_type);
+
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION pgedge_vectorizer.vectorization_delete_trigger IS
+'Statement-level AFTER DELETE trigger removing chunks, queue entries and BM25 statistics for deleted source rows';
+
+-- Statement-level trigger function cleaning up after TRUNCATE on a source table.
+--
+-- Truncating the source orphans every chunk, so there is no per-row work and no
+-- transition table (which TRUNCATE triggers cannot have in any case).  Resetting
+-- _idf_stats wholesale is right because the corpus becomes empty, and mirrors
+-- what recreate_chunks() does when rebuilding from scratch.
+CREATE OR REPLACE FUNCTION pgedge_vectorizer.vectorization_truncate_trigger()
+RETURNS TRIGGER AS $$
+DECLARE
+    chunk_table TEXT;
+BEGIN
+    chunk_table := TG_ARGV[0];
+
+    EXECUTE format(
+        'DELETE FROM pgedge_vectorizer.queue
+          WHERE chunk_table = %L AND status IN (''pending'', ''failed'')',
+        chunk_table);
+
+    EXECUTE format('TRUNCATE TABLE %I', chunk_table);
+
+    IF to_regclass(chunk_table || '_idf_stats') IS NOT NULL THEN
+        EXECUTE format('TRUNCATE TABLE %I', chunk_table || '_idf_stats');
+    END IF;
+
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION pgedge_vectorizer.vectorization_truncate_trigger IS
+'Statement-level AFTER TRUNCATE trigger emptying the chunk table, its queue entries and its BM25 statistics';
 
 -- Trigger function for vectorization
 CREATE OR REPLACE FUNCTION pgedge_vectorizer.vectorization_trigger()
@@ -1192,10 +1398,14 @@ COMMENT ON FUNCTION pgedge_vectorizer.hybrid_search_simple IS
 ---------------------------------------------------------------------------
 DO $$
 DECLARE
-    rec     RECORD;
-    args    TEXT[];
-    src_col TEXT;
-    chk_tbl TEXT;
+    rec         RECORD;
+    args        TEXT[];
+    src_col     TEXT;
+    chk_tbl     TEXT;
+    src_pk      TEXT;
+    src_pk_type TEXT;
+    pk_count    INT;
+    refreshed   INT;
 BEGIN
     -- Populate vectorizers from existing vectorization triggers
     FOR rec IN
@@ -1219,14 +1429,26 @@ BEGIN
         src_col := args[1];   -- TG_ARGV[0]
         chk_tbl := args[2];   -- TG_ARGV[1]
 
+        -- The primary key is read from the trigger rather than re-detected,
+        -- because enable_vectorization() accepts an explicit source_pk that
+        -- re-detection would silently get wrong.
+        src_pk      := NULLIF(args[6], '');   -- TG_ARGV[5]
+        src_pk_type := NULLIF(args[7], '');   -- TG_ARGV[6]
+
         IF src_col IS NOT NULL AND src_col <> ''
            AND chk_tbl IS NOT NULL AND chk_tbl <> ''
         THEN
             INSERT INTO pgedge_vectorizer.vectorizers
-                        (source_table, source_column, chunk_table)
-            VALUES      (rec.source_table, src_col, chk_tbl)
+                        (source_table, source_column, chunk_table,
+                         source_pk, pk_type)
+            VALUES      (rec.source_table, src_col, chk_tbl,
+                         src_pk, src_pk_type)
             ON CONFLICT (source_table, source_column)
-            DO UPDATE SET chunk_table = EXCLUDED.chunk_table;
+            DO UPDATE SET chunk_table = EXCLUDED.chunk_table,
+                          source_pk   = COALESCE(EXCLUDED.source_pk,
+                                                 vectorizers.source_pk),
+                          pk_type     = COALESCE(EXCLUDED.pk_type,
+                                                 vectorizers.pk_type);
         END IF;
     END LOOP;
 
@@ -1266,5 +1488,56 @@ BEGIN
             ' WHERE embedding IS NOT NULL AND sparse_embedding IS NULL',
             chk_tbl, chk_tbl);
     END LOOP;
+
+    -- Any vectorizer whose primary key is still unknown, for example a registry
+    -- row whose row trigger has been dropped, falls back to detecting a
+    -- single-column primary key: that is what enable_vectorization() would have
+    -- used when source_pk was not given.  A composite key is left alone rather
+    -- than guessed at, since picking a column arbitrarily would produce a
+    -- trigger that silently cleans up the wrong rows.
+    FOR rec IN
+        SELECT source_table, source_column
+        FROM pgedge_vectorizer.vectorizers
+        WHERE source_pk IS NULL OR pk_type IS NULL
+    LOOP
+        IF to_regclass(rec.source_table) IS NULL THEN
+            CONTINUE;
+        END IF;
+
+        SELECT count(*) INTO pk_count
+        FROM pg_index i
+        JOIN pg_attribute a ON a.attrelid = i.indrelid
+          AND a.attnum = ANY(i.indkey)
+        WHERE i.indrelid = rec.source_table::regclass
+          AND i.indisprimary;
+
+        IF pk_count <> 1 THEN
+            RAISE WARNING 'pgedge_vectorizer: cannot determine the document identifier for %.%; re-run enable_vectorization() for this column to get DELETE and TRUNCATE cleanup',
+                rec.source_table, rec.source_column;
+            CONTINUE;
+        END IF;
+
+        SELECT a.attname, format_type(a.atttypid, a.atttypmod)
+        INTO src_pk, src_pk_type
+        FROM pg_index i
+        JOIN pg_attribute a ON a.attrelid = i.indrelid
+          AND a.attnum = ANY(i.indkey)
+        WHERE i.indrelid = rec.source_table::regclass
+          AND i.indisprimary;
+
+        UPDATE pgedge_vectorizer.vectorizers
+           SET source_pk = src_pk, pk_type = src_pk_type
+         WHERE source_table = rec.source_table
+           AND source_column = rec.source_column;
+    END LOOP;
+
+    -- Tables vectorized before this upgrade have only the INSERT/UPDATE
+    -- trigger, and would go on leaking orphaned chunks silently, so give them
+    -- the cleanup triggers now.
+    refreshed := pgedge_vectorizer.refresh_triggers();
+    IF refreshed > 0 THEN
+        RAISE NOTICE 'pgedge_vectorizer: added DELETE and TRUNCATE cleanup triggers to % vectorized column(s)',
+            refreshed;
+    END IF;
 END;
 $$;

--- a/sql/pgedge_vectorizer--1.0--1.1.sql
+++ b/sql/pgedge_vectorizer--1.0--1.1.sql
@@ -143,6 +143,30 @@ COMMENT ON FUNCTION pgedge_vectorizer.bm25_tokenize IS
 -- SQL Functions
 ---------------------------------------------------------------------------
 
+-- Build a trigger name that keeps its distinguishing suffix within PostgreSQL's
+-- 63-byte identifier limit.
+--
+-- The cleanup trigger names differ only in their final word, so letting
+-- PostgreSQL truncate them would make the delete and truncate names identical
+-- for a sufficiently long table and column, and the second
+-- CREATE OR REPLACE TRIGGER would then silently replace the first, losing a
+-- cleanup trigger with no error at all.  Truncate the variable prefix instead,
+-- so that the suffix always survives.
+--
+-- The limit is counted in characters rather than bytes, which is conservative
+-- for ASCII identifiers and the overwhelmingly common case.
+CREATE OR REPLACE FUNCTION pgedge_vectorizer.cleanup_trigger_name(
+    p_prefix TEXT,
+    p_suffix TEXT
+) RETURNS TEXT AS $$
+BEGIN
+    RETURN left(p_prefix, 63 - length(p_suffix)) || p_suffix;
+END;
+$$ LANGUAGE plpgsql IMMUTABLE;
+
+COMMENT ON FUNCTION pgedge_vectorizer.cleanup_trigger_name IS
+'Build a trigger name whose distinguishing suffix survives identifier truncation';
+
 -- Enable vectorization for a table/column
 CREATE OR REPLACE FUNCTION pgedge_vectorizer.enable_vectorization(
     source_table REGCLASS,
@@ -314,7 +338,9 @@ BEGIN
         REFERENCING OLD TABLE AS old_rows
         FOR EACH STATEMENT
         EXECUTE FUNCTION pgedge_vectorizer.vectorization_delete_trigger(%L, %L, %L, %L)',
-        source_table::TEXT || '_' || source_column || '_vectorization_delete_trigger',
+        pgedge_vectorizer.cleanup_trigger_name(
+            source_table::TEXT || '_' || source_column,
+            '_vectorization_delete_trigger'),
         source_table,
         source_column, chunk_table, source_pk, pk_col_type);
 
@@ -324,7 +350,9 @@ BEGIN
         AFTER TRUNCATE ON %s
         FOR EACH STATEMENT
         EXECUTE FUNCTION pgedge_vectorizer.vectorization_truncate_trigger(%L)',
-        source_table::TEXT || '_' || source_column || '_vectorization_truncate_trigger',
+        pgedge_vectorizer.cleanup_trigger_name(
+            source_table::TEXT || '_' || source_column,
+            '_vectorization_truncate_trigger'),
         source_table, chunk_table);
 
     RAISE NOTICE 'Vectorization enabled: % -> %', source_table, chunk_table;
@@ -463,10 +491,14 @@ BEGIN
         -- Drop triggers
         EXECUTE format('DROP TRIGGER IF EXISTS %I ON %s', trigger_name, source_table);
         EXECUTE format('DROP TRIGGER IF EXISTS %I ON %s',
-                       source_table::TEXT || '_' || source_column || '_vectorization_delete_trigger',
+                       pgedge_vectorizer.cleanup_trigger_name(
+                           source_table::TEXT || '_' || source_column,
+                           '_vectorization_delete_trigger'),
                        source_table);
         EXECUTE format('DROP TRIGGER IF EXISTS %I ON %s',
-                       source_table::TEXT || '_' || source_column || '_vectorization_truncate_trigger',
+                       pgedge_vectorizer.cleanup_trigger_name(
+                           source_table::TEXT || '_' || source_column,
+                           '_vectorization_truncate_trigger'),
                        source_table);
 
         -- Remove orphaned queue items for this chunk table
@@ -580,7 +612,9 @@ BEGIN
             REFERENCING OLD TABLE AS old_rows
             FOR EACH STATEMENT
             EXECUTE FUNCTION pgedge_vectorizer.vectorization_delete_trigger(%L, %L, %L, %L)',
-            v.source_table || '_' || v.source_column || '_vectorization_delete_trigger',
+            pgedge_vectorizer.cleanup_trigger_name(
+                v.source_table || '_' || v.source_column,
+                '_vectorization_delete_trigger'),
             v.source_table,
             v.source_column, v.chunk_table, v.source_pk, v.pk_type);
 
@@ -589,7 +623,9 @@ BEGIN
             AFTER TRUNCATE ON %s
             FOR EACH STATEMENT
             EXECUTE FUNCTION pgedge_vectorizer.vectorization_truncate_trigger(%L)',
-            v.source_table || '_' || v.source_column || '_vectorization_truncate_trigger',
+            pgedge_vectorizer.cleanup_trigger_name(
+                v.source_table || '_' || v.source_column,
+                '_vectorization_truncate_trigger'),
             v.source_table, v.chunk_table);
 
         refreshed := refreshed + 1;
@@ -647,6 +683,45 @@ $$ LANGUAGE plpgsql;
 
 COMMENT ON FUNCTION pgedge_vectorizer.bm25_decrement_idf_stats IS
 'Decrement doc_freq in the _idf_stats table for a set of terms before their source chunks are deleted';
+
+-- Recompute total_docs and idf_weight for every term from the current chunk count.
+--
+-- bm25_decrement_idf_stats() sets total_docs from the chunk count at the moment
+-- it runs, which is right for a single document but wrong when several are
+-- removed by one statement: called once per document while the chunks are all
+-- still present, every call sees the same unchanged count and only the last
+-- one's value survives, leaving total_docs disagreeing with the doc_freq values
+-- that did accumulate.  Call this once after the chunks have gone to bring the
+-- corpus total back in step.
+CREATE OR REPLACE FUNCTION pgedge_vectorizer.bm25_resync_idf_totals(
+    p_chunk_table TEXT
+) RETURNS VOID AS $$
+DECLARE
+    total INT;
+BEGIN
+    IF to_regclass(p_chunk_table || '_idf_stats') IS NULL THEN
+        RETURN;
+    END IF;
+
+    EXECUTE format('SELECT count(*)::int FROM %I', p_chunk_table) INTO total;
+
+    EXECUTE format(
+        'UPDATE %I SET'
+        '    total_docs = $1,'
+        '    idf_weight = CASE'
+        '                     WHEN doc_freq <= 0 THEN 0.0'
+        '                     ELSE ln(1.0 + ($1::float8 - doc_freq + 0.5)'
+        '                                  / (doc_freq + 0.5))'
+        '                 END,'
+        '    updated_at = now()',
+        p_chunk_table || '_idf_stats')
+    USING total;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION pgedge_vectorizer.bm25_resync_idf_totals IS
+'Recompute total_docs and idf_weight for all terms from the current chunk count';
+
 
 -- Statement-level trigger function cleaning up after DELETE on a source table.
 --
@@ -712,6 +787,11 @@ BEGIN
     EXECUTE format(
         'DELETE FROM %I WHERE source_id IN (SELECT o.%I::%s FROM old_rows o)',
         chunk_table, pk_col, pk_type);
+
+    -- Bring the corpus total back in step.  The per-document decrements above
+    -- each set total_docs from the then-unchanged chunk count, so on a bulk
+    -- delete only the last one's value would otherwise survive.
+    PERFORM pgedge_vectorizer.bm25_resync_idf_totals(chunk_table);
 
     RETURN NULL;
 END;

--- a/sql/pgedge_vectorizer--1.0--1.1.sql
+++ b/sql/pgedge_vectorizer--1.0--1.1.sql
@@ -143,29 +143,44 @@ COMMENT ON FUNCTION pgedge_vectorizer.bm25_tokenize IS
 -- SQL Functions
 ---------------------------------------------------------------------------
 
--- Build a trigger name that keeps its distinguishing suffix within PostgreSQL's
--- 63-byte identifier limit.
+-- Build a cleanup trigger name that stays unique within PostgreSQL's 63-byte
+-- identifier limit.
 --
--- The cleanup trigger names differ only in their final word, so letting
--- PostgreSQL truncate them would make the delete and truncate names identical
--- for a sufficiently long table and column, and the second
--- CREATE OR REPLACE TRIGGER would then silently replace the first, losing a
--- cleanup trigger with no error at all.  Truncate the variable prefix instead,
--- so that the suffix always survives.
+-- Two problems have to be solved at once.  The names differ only in their final
+-- word, so plain truncation would make the delete and truncate names identical
+-- for a long enough table and column, and the second CREATE OR REPLACE TRIGGER
+-- would silently replace the first.  Shortening the readable part instead is not
+-- sufficient either, because two columns on a long-named table would then
+-- shorten to the same string.
 --
--- The limit is counted in characters rather than bytes, which is conservative
--- for ASCII identifiers and the overwhelmingly common case.
+-- So the readable prefix is shortened to fit and a digest of the exact table and
+-- column is appended, which keeps the name unique per vectorized column however
+-- much of the readable part had to go.
+--
+-- Note that a shortened name no longer begins with the source table text, so
+-- teardown must not look these up by name pattern.  disable_vectorization()
+-- finds them by trigger function instead.
 CREATE OR REPLACE FUNCTION pgedge_vectorizer.cleanup_trigger_name(
-    p_prefix TEXT,
-    p_suffix TEXT
+    p_source_table  TEXT,
+    p_source_column TEXT,
+    p_suffix        TEXT
 ) RETURNS TEXT AS $$
+DECLARE
+    digest TEXT;
+    room   INT;
 BEGIN
-    RETURN left(p_prefix, 63 - length(p_suffix)) || p_suffix;
+    digest := substr(md5(p_source_table || '.' || p_source_column), 1, 8);
+
+    -- One character for the separator before the digest.
+    room := 63 - length(p_suffix) - length(digest) - 1;
+
+    RETURN left(p_source_table || '_' || p_source_column, GREATEST(room, 0))
+           || '_' || digest || p_suffix;
 END;
 $$ LANGUAGE plpgsql IMMUTABLE;
 
 COMMENT ON FUNCTION pgedge_vectorizer.cleanup_trigger_name IS
-'Build a trigger name whose distinguishing suffix survives identifier truncation';
+'Build a cleanup trigger name that remains unique per vectorized column within the identifier length limit';
 
 -- Enable vectorization for a table/column
 CREATE OR REPLACE FUNCTION pgedge_vectorizer.enable_vectorization(
@@ -339,8 +354,7 @@ BEGIN
         FOR EACH STATEMENT
         EXECUTE FUNCTION pgedge_vectorizer.vectorization_delete_trigger(%L, %L, %L, %L)',
         pgedge_vectorizer.cleanup_trigger_name(
-            source_table::TEXT || '_' || source_column,
-            '_vectorization_delete_trigger'),
+            source_table::TEXT, source_column, '_vectorization_delete_trigger'),
         source_table,
         source_column, chunk_table, source_pk, pk_col_type);
 
@@ -351,8 +365,7 @@ BEGIN
         FOR EACH STATEMENT
         EXECUTE FUNCTION pgedge_vectorizer.vectorization_truncate_trigger(%L)',
         pgedge_vectorizer.cleanup_trigger_name(
-            source_table::TEXT || '_' || source_column,
-            '_vectorization_truncate_trigger'),
+            source_table::TEXT, source_column, '_vectorization_truncate_trigger'),
         source_table, chunk_table);
 
     RAISE NOTICE 'Vectorization enabled: % -> %', source_table, chunk_table;
@@ -492,13 +505,11 @@ BEGIN
         EXECUTE format('DROP TRIGGER IF EXISTS %I ON %s', trigger_name, source_table);
         EXECUTE format('DROP TRIGGER IF EXISTS %I ON %s',
                        pgedge_vectorizer.cleanup_trigger_name(
-                           source_table::TEXT || '_' || source_column,
-                           '_vectorization_delete_trigger'),
+                           source_table::TEXT, source_column, '_vectorization_delete_trigger'),
                        source_table);
         EXECUTE format('DROP TRIGGER IF EXISTS %I ON %s',
                        pgedge_vectorizer.cleanup_trigger_name(
-                           source_table::TEXT || '_' || source_column,
-                           '_vectorization_truncate_trigger'),
+                           source_table::TEXT, source_column, '_vectorization_truncate_trigger'),
                        source_table);
 
         -- Remove orphaned queue items for this chunk table
@@ -523,14 +534,24 @@ BEGIN
         END IF;
     ELSE
         -- Drop all vectorization triggers for this table
+        -- Find vectorization triggers by their trigger function rather than by
+        -- name pattern.  Cleanup trigger names are shortened when the table and
+        -- column are long, so a shortened name need not begin with the source
+        -- table text and a LIKE pattern anchored on it would miss them,
+        -- silently leaving cleanup triggers behind.
         FOR trigger_rec IN
-            SELECT tgname
+            SELECT t.tgname
             FROM pg_trigger t
-            JOIN pg_class c ON t.tgrelid = c.oid
-            WHERE c.oid = source_table
-            -- Matches the row trigger plus the delete and truncate cleanup
-            -- triggers; still prefix-scoped to this source table.
-            AND tgname LIKE source_table::TEXT || '%_vectorization%trigger'
+            WHERE t.tgrelid = source_table
+              AND NOT t.tgisinternal
+              AND t.tgfoid IN (
+                  SELECT p.oid
+                  FROM pg_proc p
+                  JOIN pg_namespace n ON n.oid = p.pronamespace
+                  WHERE n.nspname = 'pgedge_vectorizer'
+                    AND p.proname IN ('vectorization_trigger',
+                                      'vectorization_delete_trigger',
+                                      'vectorization_truncate_trigger'))
         LOOP
             EXECUTE format('DROP TRIGGER IF EXISTS %I ON %s', trigger_rec.tgname, source_table);
             RAISE NOTICE 'Dropped trigger: %', trigger_rec.tgname;
@@ -613,8 +634,7 @@ BEGIN
             FOR EACH STATEMENT
             EXECUTE FUNCTION pgedge_vectorizer.vectorization_delete_trigger(%L, %L, %L, %L)',
             pgedge_vectorizer.cleanup_trigger_name(
-                v.source_table || '_' || v.source_column,
-                '_vectorization_delete_trigger'),
+                v.source_table, v.source_column, '_vectorization_delete_trigger'),
             v.source_table,
             v.source_column, v.chunk_table, v.source_pk, v.pk_type);
 
@@ -624,8 +644,7 @@ BEGIN
             FOR EACH STATEMENT
             EXECUTE FUNCTION pgedge_vectorizer.vectorization_truncate_trigger(%L)',
             pgedge_vectorizer.cleanup_trigger_name(
-                v.source_table || '_' || v.source_column,
-                '_vectorization_truncate_trigger'),
+                v.source_table, v.source_column, '_vectorization_truncate_trigger'),
             v.source_table, v.chunk_table);
 
         refreshed := refreshed + 1;

--- a/sql/pgedge_vectorizer--1.1.sql
+++ b/sql/pgedge_vectorizer--1.1.sql
@@ -135,29 +135,44 @@ COMMENT ON FUNCTION pgedge_vectorizer.bm25_tokenize IS
 -- SQL Functions
 ---------------------------------------------------------------------------
 
--- Build a trigger name that keeps its distinguishing suffix within PostgreSQL's
--- 63-byte identifier limit.
+-- Build a cleanup trigger name that stays unique within PostgreSQL's 63-byte
+-- identifier limit.
 --
--- The cleanup trigger names differ only in their final word, so letting
--- PostgreSQL truncate them would make the delete and truncate names identical
--- for a sufficiently long table and column, and the second
--- CREATE OR REPLACE TRIGGER would then silently replace the first, losing a
--- cleanup trigger with no error at all.  Truncate the variable prefix instead,
--- so that the suffix always survives.
+-- Two problems have to be solved at once.  The names differ only in their final
+-- word, so plain truncation would make the delete and truncate names identical
+-- for a long enough table and column, and the second CREATE OR REPLACE TRIGGER
+-- would silently replace the first.  Shortening the readable part instead is not
+-- sufficient either, because two columns on a long-named table would then
+-- shorten to the same string.
 --
--- The limit is counted in characters rather than bytes, which is conservative
--- for ASCII identifiers and the overwhelmingly common case.
+-- So the readable prefix is shortened to fit and a digest of the exact table and
+-- column is appended, which keeps the name unique per vectorized column however
+-- much of the readable part had to go.
+--
+-- Note that a shortened name no longer begins with the source table text, so
+-- teardown must not look these up by name pattern.  disable_vectorization()
+-- finds them by trigger function instead.
 CREATE FUNCTION pgedge_vectorizer.cleanup_trigger_name(
-    p_prefix TEXT,
-    p_suffix TEXT
+    p_source_table  TEXT,
+    p_source_column TEXT,
+    p_suffix        TEXT
 ) RETURNS TEXT AS $$
+DECLARE
+    digest TEXT;
+    room   INT;
 BEGIN
-    RETURN left(p_prefix, 63 - length(p_suffix)) || p_suffix;
+    digest := substr(md5(p_source_table || '.' || p_source_column), 1, 8);
+
+    -- One character for the separator before the digest.
+    room := 63 - length(p_suffix) - length(digest) - 1;
+
+    RETURN left(p_source_table || '_' || p_source_column, GREATEST(room, 0))
+           || '_' || digest || p_suffix;
 END;
 $$ LANGUAGE plpgsql IMMUTABLE;
 
 COMMENT ON FUNCTION pgedge_vectorizer.cleanup_trigger_name IS
-'Build a trigger name whose distinguishing suffix survives identifier truncation';
+'Build a cleanup trigger name that remains unique per vectorized column within the identifier length limit';
 
 -- Enable vectorization for a table/column
 CREATE FUNCTION pgedge_vectorizer.enable_vectorization(
@@ -331,8 +346,7 @@ BEGIN
         FOR EACH STATEMENT
         EXECUTE FUNCTION pgedge_vectorizer.vectorization_delete_trigger(%L, %L, %L, %L)',
         pgedge_vectorizer.cleanup_trigger_name(
-            source_table::TEXT || '_' || source_column,
-            '_vectorization_delete_trigger'),
+            source_table::TEXT, source_column, '_vectorization_delete_trigger'),
         source_table,
         source_column, chunk_table, source_pk, pk_col_type);
 
@@ -343,8 +357,7 @@ BEGIN
         FOR EACH STATEMENT
         EXECUTE FUNCTION pgedge_vectorizer.vectorization_truncate_trigger(%L)',
         pgedge_vectorizer.cleanup_trigger_name(
-            source_table::TEXT || '_' || source_column,
-            '_vectorization_truncate_trigger'),
+            source_table::TEXT, source_column, '_vectorization_truncate_trigger'),
         source_table, chunk_table);
 
     RAISE NOTICE 'Vectorization enabled: % -> %', source_table, chunk_table;
@@ -484,13 +497,11 @@ BEGIN
         EXECUTE format('DROP TRIGGER IF EXISTS %I ON %s', trigger_name, source_table);
         EXECUTE format('DROP TRIGGER IF EXISTS %I ON %s',
                        pgedge_vectorizer.cleanup_trigger_name(
-                           source_table::TEXT || '_' || source_column,
-                           '_vectorization_delete_trigger'),
+                           source_table::TEXT, source_column, '_vectorization_delete_trigger'),
                        source_table);
         EXECUTE format('DROP TRIGGER IF EXISTS %I ON %s',
                        pgedge_vectorizer.cleanup_trigger_name(
-                           source_table::TEXT || '_' || source_column,
-                           '_vectorization_truncate_trigger'),
+                           source_table::TEXT, source_column, '_vectorization_truncate_trigger'),
                        source_table);
 
         -- Remove orphaned queue items for this chunk table
@@ -515,14 +526,24 @@ BEGIN
         END IF;
     ELSE
         -- Drop all vectorization triggers for this table
+        -- Find vectorization triggers by their trigger function rather than by
+        -- name pattern.  Cleanup trigger names are shortened when the table and
+        -- column are long, so a shortened name need not begin with the source
+        -- table text and a LIKE pattern anchored on it would miss them,
+        -- silently leaving cleanup triggers behind.
         FOR trigger_rec IN
-            SELECT tgname
+            SELECT t.tgname
             FROM pg_trigger t
-            JOIN pg_class c ON t.tgrelid = c.oid
-            WHERE c.oid = source_table
-            -- Matches the row trigger plus the delete and truncate cleanup
-            -- triggers; still prefix-scoped to this source table.
-            AND tgname LIKE source_table::TEXT || '%_vectorization%trigger'
+            WHERE t.tgrelid = source_table
+              AND NOT t.tgisinternal
+              AND t.tgfoid IN (
+                  SELECT p.oid
+                  FROM pg_proc p
+                  JOIN pg_namespace n ON n.oid = p.pronamespace
+                  WHERE n.nspname = 'pgedge_vectorizer'
+                    AND p.proname IN ('vectorization_trigger',
+                                      'vectorization_delete_trigger',
+                                      'vectorization_truncate_trigger'))
         LOOP
             EXECUTE format('DROP TRIGGER IF EXISTS %I ON %s', trigger_rec.tgname, source_table);
             RAISE NOTICE 'Dropped trigger: %', trigger_rec.tgname;
@@ -605,8 +626,7 @@ BEGIN
             FOR EACH STATEMENT
             EXECUTE FUNCTION pgedge_vectorizer.vectorization_delete_trigger(%L, %L, %L, %L)',
             pgedge_vectorizer.cleanup_trigger_name(
-                v.source_table || '_' || v.source_column,
-                '_vectorization_delete_trigger'),
+                v.source_table, v.source_column, '_vectorization_delete_trigger'),
             v.source_table,
             v.source_column, v.chunk_table, v.source_pk, v.pk_type);
 
@@ -616,8 +636,7 @@ BEGIN
             FOR EACH STATEMENT
             EXECUTE FUNCTION pgedge_vectorizer.vectorization_truncate_trigger(%L)',
             pgedge_vectorizer.cleanup_trigger_name(
-                v.source_table || '_' || v.source_column,
-                '_vectorization_truncate_trigger'),
+                v.source_table, v.source_column, '_vectorization_truncate_trigger'),
             v.source_table, v.chunk_table);
 
         refreshed := refreshed + 1;

--- a/sql/pgedge_vectorizer--1.1.sql
+++ b/sql/pgedge_vectorizer--1.1.sql
@@ -135,6 +135,30 @@ COMMENT ON FUNCTION pgedge_vectorizer.bm25_tokenize IS
 -- SQL Functions
 ---------------------------------------------------------------------------
 
+-- Build a trigger name that keeps its distinguishing suffix within PostgreSQL's
+-- 63-byte identifier limit.
+--
+-- The cleanup trigger names differ only in their final word, so letting
+-- PostgreSQL truncate them would make the delete and truncate names identical
+-- for a sufficiently long table and column, and the second
+-- CREATE OR REPLACE TRIGGER would then silently replace the first, losing a
+-- cleanup trigger with no error at all.  Truncate the variable prefix instead,
+-- so that the suffix always survives.
+--
+-- The limit is counted in characters rather than bytes, which is conservative
+-- for ASCII identifiers and the overwhelmingly common case.
+CREATE FUNCTION pgedge_vectorizer.cleanup_trigger_name(
+    p_prefix TEXT,
+    p_suffix TEXT
+) RETURNS TEXT AS $$
+BEGIN
+    RETURN left(p_prefix, 63 - length(p_suffix)) || p_suffix;
+END;
+$$ LANGUAGE plpgsql IMMUTABLE;
+
+COMMENT ON FUNCTION pgedge_vectorizer.cleanup_trigger_name IS
+'Build a trigger name whose distinguishing suffix survives identifier truncation';
+
 -- Enable vectorization for a table/column
 CREATE FUNCTION pgedge_vectorizer.enable_vectorization(
     source_table REGCLASS,
@@ -306,7 +330,9 @@ BEGIN
         REFERENCING OLD TABLE AS old_rows
         FOR EACH STATEMENT
         EXECUTE FUNCTION pgedge_vectorizer.vectorization_delete_trigger(%L, %L, %L, %L)',
-        source_table::TEXT || '_' || source_column || '_vectorization_delete_trigger',
+        pgedge_vectorizer.cleanup_trigger_name(
+            source_table::TEXT || '_' || source_column,
+            '_vectorization_delete_trigger'),
         source_table,
         source_column, chunk_table, source_pk, pk_col_type);
 
@@ -316,7 +342,9 @@ BEGIN
         AFTER TRUNCATE ON %s
         FOR EACH STATEMENT
         EXECUTE FUNCTION pgedge_vectorizer.vectorization_truncate_trigger(%L)',
-        source_table::TEXT || '_' || source_column || '_vectorization_truncate_trigger',
+        pgedge_vectorizer.cleanup_trigger_name(
+            source_table::TEXT || '_' || source_column,
+            '_vectorization_truncate_trigger'),
         source_table, chunk_table);
 
     RAISE NOTICE 'Vectorization enabled: % -> %', source_table, chunk_table;
@@ -455,10 +483,14 @@ BEGIN
         -- Drop triggers
         EXECUTE format('DROP TRIGGER IF EXISTS %I ON %s', trigger_name, source_table);
         EXECUTE format('DROP TRIGGER IF EXISTS %I ON %s',
-                       source_table::TEXT || '_' || source_column || '_vectorization_delete_trigger',
+                       pgedge_vectorizer.cleanup_trigger_name(
+                           source_table::TEXT || '_' || source_column,
+                           '_vectorization_delete_trigger'),
                        source_table);
         EXECUTE format('DROP TRIGGER IF EXISTS %I ON %s',
-                       source_table::TEXT || '_' || source_column || '_vectorization_truncate_trigger',
+                       pgedge_vectorizer.cleanup_trigger_name(
+                           source_table::TEXT || '_' || source_column,
+                           '_vectorization_truncate_trigger'),
                        source_table);
 
         -- Remove orphaned queue items for this chunk table
@@ -572,7 +604,9 @@ BEGIN
             REFERENCING OLD TABLE AS old_rows
             FOR EACH STATEMENT
             EXECUTE FUNCTION pgedge_vectorizer.vectorization_delete_trigger(%L, %L, %L, %L)',
-            v.source_table || '_' || v.source_column || '_vectorization_delete_trigger',
+            pgedge_vectorizer.cleanup_trigger_name(
+                v.source_table || '_' || v.source_column,
+                '_vectorization_delete_trigger'),
             v.source_table,
             v.source_column, v.chunk_table, v.source_pk, v.pk_type);
 
@@ -581,7 +615,9 @@ BEGIN
             AFTER TRUNCATE ON %s
             FOR EACH STATEMENT
             EXECUTE FUNCTION pgedge_vectorizer.vectorization_truncate_trigger(%L)',
-            v.source_table || '_' || v.source_column || '_vectorization_truncate_trigger',
+            pgedge_vectorizer.cleanup_trigger_name(
+                v.source_table || '_' || v.source_column,
+                '_vectorization_truncate_trigger'),
             v.source_table, v.chunk_table);
 
         refreshed := refreshed + 1;
@@ -639,6 +675,45 @@ $$ LANGUAGE plpgsql;
 
 COMMENT ON FUNCTION pgedge_vectorizer.bm25_decrement_idf_stats IS
 'Decrement doc_freq in the _idf_stats table for a set of terms before their source chunks are deleted';
+
+-- Recompute total_docs and idf_weight for every term from the current chunk count.
+--
+-- bm25_decrement_idf_stats() sets total_docs from the chunk count at the moment
+-- it runs, which is right for a single document but wrong when several are
+-- removed by one statement: called once per document while the chunks are all
+-- still present, every call sees the same unchanged count and only the last
+-- one's value survives, leaving total_docs disagreeing with the doc_freq values
+-- that did accumulate.  Call this once after the chunks have gone to bring the
+-- corpus total back in step.
+CREATE FUNCTION pgedge_vectorizer.bm25_resync_idf_totals(
+    p_chunk_table TEXT
+) RETURNS VOID AS $$
+DECLARE
+    total INT;
+BEGIN
+    IF to_regclass(p_chunk_table || '_idf_stats') IS NULL THEN
+        RETURN;
+    END IF;
+
+    EXECUTE format('SELECT count(*)::int FROM %I', p_chunk_table) INTO total;
+
+    EXECUTE format(
+        'UPDATE %I SET'
+        '    total_docs = $1,'
+        '    idf_weight = CASE'
+        '                     WHEN doc_freq <= 0 THEN 0.0'
+        '                     ELSE ln(1.0 + ($1::float8 - doc_freq + 0.5)'
+        '                                  / (doc_freq + 0.5))'
+        '                 END,'
+        '    updated_at = now()',
+        p_chunk_table || '_idf_stats')
+    USING total;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION pgedge_vectorizer.bm25_resync_idf_totals IS
+'Recompute total_docs and idf_weight for all terms from the current chunk count';
+
 
 -- Statement-level trigger function cleaning up after DELETE on a source table.
 --
@@ -704,6 +779,11 @@ BEGIN
     EXECUTE format(
         'DELETE FROM %I WHERE source_id IN (SELECT o.%I::%s FROM old_rows o)',
         chunk_table, pk_col, pk_type);
+
+    -- Bring the corpus total back in step.  The per-document decrements above
+    -- each set total_docs from the then-unchanged chunk count, so on a bulk
+    -- delete only the last one's value would otherwise survive.
+    PERFORM pgedge_vectorizer.bm25_resync_idf_totals(chunk_table);
 
     RETURN NULL;
 END;

--- a/sql/pgedge_vectorizer--1.1.sql
+++ b/sql/pgedge_vectorizer--1.1.sql
@@ -23,6 +23,8 @@ CREATE TABLE pgedge_vectorizer.vectorizers (
     source_table  TEXT NOT NULL,
     source_column NAME NOT NULL,
     chunk_table   TEXT NOT NULL,
+    source_pk     NAME,
+    pk_type       TEXT,
     created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     UNIQUE (source_table, source_column)
 );
@@ -544,6 +546,109 @@ $$ LANGUAGE plpgsql;
 
 COMMENT ON FUNCTION pgedge_vectorizer.bm25_decrement_idf_stats IS
 'Decrement doc_freq in the _idf_stats table for a set of terms before their source chunks are deleted';
+
+-- Statement-level trigger function cleaning up after DELETE on a source table.
+--
+-- Statement-level rather than row-level so that a bulk delete does not run three
+-- statements plus a tokenisation per row: with the old_rows transition table the
+-- queue and chunk deletions are one set-based statement each.  Only the BM25
+-- decrement needs a loop, because bm25_decrement_idf_stats() takes one
+-- document's terms at a time.
+CREATE FUNCTION pgedge_vectorizer.vectorization_delete_trigger()
+RETURNS TRIGGER AS $$
+DECLARE
+    content_col TEXT;
+    chunk_table TEXT;
+    pk_col      TEXT;
+    pk_type     TEXT;
+    old_row     RECORD;
+    old_terms   TEXT[];
+    chunk_count INT;
+BEGIN
+    content_col := TG_ARGV[0];
+    chunk_table := TG_ARGV[1];
+    pk_col      := COALESCE(TG_ARGV[2], 'id');
+    pk_type     := COALESCE(TG_ARGV[3], 'bigint');
+
+    -- Decrement BM25 document frequencies before deleting anything, because
+    -- bm25_decrement_idf_stats() derives the new corpus size by counting the
+    -- chunk table and subtracting the count we pass it.  Doing this afterwards
+    -- would understate the corpus and skew idf_weight for every term.
+    FOR old_row IN EXECUTE
+        format('SELECT %I::text AS pk_value, %I::text AS content FROM old_rows',
+               pk_col, content_col)
+    LOOP
+        IF old_row.content IS NULL OR trim(old_row.content) = '' THEN
+            CONTINUE;
+        END IF;
+
+        EXECUTE format(
+            'SELECT count(*)::int FROM %I WHERE source_id = $1::%s',
+            chunk_table, pk_type)
+        INTO chunk_count
+        USING old_row.pk_value;
+
+        IF chunk_count > 0 THEN
+            old_terms := pgedge_vectorizer.bm25_tokenize(trim(old_row.content));
+            PERFORM pgedge_vectorizer.bm25_decrement_idf_stats(
+                chunk_table, old_terms, chunk_count);
+        END IF;
+    END LOOP;
+
+    -- Remove queue entries for the doomed chunks, so the worker does not spend
+    -- embedding API calls on them.  'processing' rows are left alone, matching
+    -- the INSERT/UPDATE path: the worker copes with the chunk having gone.
+    EXECUTE format(
+        'DELETE FROM pgedge_vectorizer.queue
+          WHERE chunk_table = %L
+            AND status IN (''pending'', ''failed'')
+            AND chunk_id IN (
+                SELECT c.id FROM %I c
+                 WHERE c.source_id IN (SELECT o.%I::%s FROM old_rows o))',
+        chunk_table, chunk_table, pk_col, pk_type);
+
+    -- Finally the chunks themselves, which takes the embeddings with them.
+    EXECUTE format(
+        'DELETE FROM %I WHERE source_id IN (SELECT o.%I::%s FROM old_rows o)',
+        chunk_table, pk_col, pk_type);
+
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION pgedge_vectorizer.vectorization_delete_trigger IS
+'Statement-level AFTER DELETE trigger removing chunks, queue entries and BM25 statistics for deleted source rows';
+
+-- Statement-level trigger function cleaning up after TRUNCATE on a source table.
+--
+-- Truncating the source orphans every chunk, so there is no per-row work and no
+-- transition table (which TRUNCATE triggers cannot have in any case).  Resetting
+-- _idf_stats wholesale is right because the corpus becomes empty, and mirrors
+-- what recreate_chunks() does when rebuilding from scratch.
+CREATE FUNCTION pgedge_vectorizer.vectorization_truncate_trigger()
+RETURNS TRIGGER AS $$
+DECLARE
+    chunk_table TEXT;
+BEGIN
+    chunk_table := TG_ARGV[0];
+
+    EXECUTE format(
+        'DELETE FROM pgedge_vectorizer.queue
+          WHERE chunk_table = %L AND status IN (''pending'', ''failed'')',
+        chunk_table);
+
+    EXECUTE format('TRUNCATE TABLE %I', chunk_table);
+
+    IF to_regclass(chunk_table || '_idf_stats') IS NOT NULL THEN
+        EXECUTE format('TRUNCATE TABLE %I', chunk_table || '_idf_stats');
+    END IF;
+
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION pgedge_vectorizer.vectorization_truncate_trigger IS
+'Statement-level AFTER TRUNCATE trigger emptying the chunk table, its queue entries and its BM25 statistics';
 
 -- Trigger function for vectorization
 CREATE FUNCTION pgedge_vectorizer.vectorization_trigger()

--- a/sql/pgedge_vectorizer--1.1.sql
+++ b/sql/pgedge_vectorizer--1.1.sql
@@ -277,11 +277,13 @@ BEGIN
     -- Use EXECUTE...USING to avoid PL/pgSQL variable/column ambiguity.
     EXECUTE
         'INSERT INTO pgedge_vectorizer.vectorizers
-             (source_table, source_column, chunk_table)
-         VALUES ($1, $2, $3)
+             (source_table, source_column, chunk_table, source_pk, pk_type)
+         VALUES ($1, $2, $3, $4, $5)
          ON CONFLICT (source_table, source_column)
-         DO UPDATE SET chunk_table = EXCLUDED.chunk_table'
-    USING source_table::TEXT, source_column, chunk_table;
+         DO UPDATE SET chunk_table = EXCLUDED.chunk_table,
+                       source_pk   = EXCLUDED.source_pk,
+                       pk_type     = EXCLUDED.pk_type'
+    USING source_table::TEXT, source_column, chunk_table, source_pk, pk_col_type;
 
     -- Create trigger to chunk and queue on insert/update
     trigger_name := source_table::TEXT || '_' || source_column || '_vectorization_trigger';
@@ -294,6 +296,28 @@ BEGIN
         trigger_name, source_table,
         source_column, chunk_table, actual_strategy,
         actual_chunk_size, actual_chunk_overlap, source_pk, pk_col_type);
+
+    -- Clean up derived data when source rows are deleted.  Statement-level with
+    -- a transition table so that bulk deletes do not degenerate into per-row
+    -- work.
+    EXECUTE format('
+        CREATE OR REPLACE TRIGGER %I
+        AFTER DELETE ON %s
+        REFERENCING OLD TABLE AS old_rows
+        FOR EACH STATEMENT
+        EXECUTE FUNCTION pgedge_vectorizer.vectorization_delete_trigger(%L, %L, %L, %L)',
+        source_table::TEXT || '_' || source_column || '_vectorization_delete_trigger',
+        source_table,
+        source_column, chunk_table, source_pk, pk_col_type);
+
+    -- Clean up when the whole source table is truncated.
+    EXECUTE format('
+        CREATE OR REPLACE TRIGGER %I
+        AFTER TRUNCATE ON %s
+        FOR EACH STATEMENT
+        EXECUTE FUNCTION pgedge_vectorizer.vectorization_truncate_trigger(%L)',
+        source_table::TEXT || '_' || source_column || '_vectorization_truncate_trigger',
+        source_table, chunk_table);
 
     RAISE NOTICE 'Vectorization enabled: % -> %', source_table, chunk_table;
     RAISE NOTICE 'Strategy: %, chunk_size: %, overlap: %',
@@ -428,8 +452,14 @@ BEGIN
             chunk_table := source_table::TEXT || '_' || source_column || '_chunks';
         END IF;
 
-        -- Drop trigger
+        -- Drop triggers
         EXECUTE format('DROP TRIGGER IF EXISTS %I ON %s', trigger_name, source_table);
+        EXECUTE format('DROP TRIGGER IF EXISTS %I ON %s',
+                       source_table::TEXT || '_' || source_column || '_vectorization_delete_trigger',
+                       source_table);
+        EXECUTE format('DROP TRIGGER IF EXISTS %I ON %s',
+                       source_table::TEXT || '_' || source_column || '_vectorization_truncate_trigger',
+                       source_table);
 
         -- Remove orphaned queue items for this chunk table
         EXECUTE format('DELETE FROM pgedge_vectorizer.queue WHERE chunk_table = %L AND status IN (''pending'', ''processing'')', chunk_table);
@@ -458,7 +488,9 @@ BEGIN
             FROM pg_trigger t
             JOIN pg_class c ON t.tgrelid = c.oid
             WHERE c.oid = source_table
-            AND tgname LIKE source_table::TEXT || '%_vectorization_trigger'
+            -- Matches the row trigger plus the delete and truncate cleanup
+            -- triggers; still prefix-scoped to this source table.
+            AND tgname LIKE source_table::TEXT || '%_vectorization%trigger'
         LOOP
             EXECUTE format('DROP TRIGGER IF EXISTS %I ON %s', trigger_rec.tgname, source_table);
             RAISE NOTICE 'Dropped trigger: %', trigger_rec.tgname;
@@ -500,6 +532,67 @@ $$ LANGUAGE plpgsql;
 
 COMMENT ON FUNCTION pgedge_vectorizer.disable_vectorization IS
 'Disable automatic vectorization for a table';
+
+-- Recreate the DELETE and TRUNCATE cleanup triggers for every registered
+-- vectorizer.
+--
+-- Upgrade scripts only run on a version change, so an installation of an
+-- unreleased build that already has vectorized tables would otherwise have no
+-- supported way to acquire the new triggers.  This is also the repair route if
+-- triggers are ever dropped by hand.
+--
+-- Returns the number of vectorizers whose triggers were recreated.  Entries
+-- whose primary key is not recorded are skipped with a warning rather than
+-- guessed at, because enable_vectorization() accepts an explicit source_pk that
+-- re-detection could get wrong.
+CREATE FUNCTION pgedge_vectorizer.refresh_triggers()
+RETURNS INT AS $$
+DECLARE
+    v         RECORD;
+    refreshed INT := 0;
+BEGIN
+    FOR v IN
+        SELECT source_table, source_column, chunk_table, source_pk, pk_type
+        FROM pgedge_vectorizer.vectorizers
+    LOOP
+        IF to_regclass(v.source_table) IS NULL THEN
+            RAISE WARNING 'Skipping %: source table no longer exists', v.source_table;
+            CONTINUE;
+        END IF;
+
+        IF v.source_pk IS NULL OR v.pk_type IS NULL THEN
+            RAISE WARNING 'Skipping %.%: primary key not recorded, re-run enable_vectorization() for this column',
+                v.source_table, v.source_column;
+            CONTINUE;
+        END IF;
+
+        EXECUTE format('
+            CREATE OR REPLACE TRIGGER %I
+            AFTER DELETE ON %s
+            REFERENCING OLD TABLE AS old_rows
+            FOR EACH STATEMENT
+            EXECUTE FUNCTION pgedge_vectorizer.vectorization_delete_trigger(%L, %L, %L, %L)',
+            v.source_table || '_' || v.source_column || '_vectorization_delete_trigger',
+            v.source_table,
+            v.source_column, v.chunk_table, v.source_pk, v.pk_type);
+
+        EXECUTE format('
+            CREATE OR REPLACE TRIGGER %I
+            AFTER TRUNCATE ON %s
+            FOR EACH STATEMENT
+            EXECUTE FUNCTION pgedge_vectorizer.vectorization_truncate_trigger(%L)',
+            v.source_table || '_' || v.source_column || '_vectorization_truncate_trigger',
+            v.source_table, v.chunk_table);
+
+        refreshed := refreshed + 1;
+    END LOOP;
+
+    RETURN refreshed;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION pgedge_vectorizer.refresh_triggers IS
+'Recreate the DELETE and TRUNCATE cleanup triggers for all registered vectorizers; returns the number refreshed';
 
 -- BM25 IDF stats decrement helper
 -- Called by vectorization_trigger before deleting old chunks on UPDATE so that

--- a/test/expected/delete_truncate.out
+++ b/test/expected/delete_truncate.out
@@ -1,0 +1,152 @@
+-- DELETE and TRUNCATE cleanup test
+--
+-- Verifies that removing source rows removes their derived chunks, queue
+-- entries and BM25 statistics, rather than leaving them orphaned (issue #24).
+--
+-- Uses embedding_dimension => 3 and asserts only on row counts and trigger
+-- existence, never on embedding values, so no provider credentials are needed.
+CREATE TABLE dt_docs (id BIGSERIAL PRIMARY KEY, body TEXT);
+INSERT INTO dt_docs (body) VALUES
+    (repeat('alpha beta gamma ', 20)),
+    (repeat('delta epsilon zeta ', 20)),
+    (repeat('eta theta iota ', 20));
+SELECT pgedge_vectorizer.enable_vectorization('dt_docs', 'body',
+                                              embedding_dimension => 3);
+NOTICE:  Using primary key column: id (bigint)
+NOTICE:  column "sparse_embedding" of relation "dt_docs_body_chunks" already exists, skipping
+NOTICE:  Vectorization enabled: dt_docs -> dt_docs_body_chunks
+NOTICE:  Strategy: token_based, chunk_size: 400, overlap: 50
+NOTICE:  Processing existing rows...
+NOTICE:  Processed 3 existing rows
+ enable_vectorization 
+----------------------
+ 
+(1 row)
+
+-- All three triggers should now exist
+SELECT tgname FROM pg_trigger
+ WHERE tgrelid = 'dt_docs'::regclass AND NOT tgisinternal
+ ORDER BY tgname;
+                   tgname                    
+---------------------------------------------
+ dt_docs_body_vectorization_delete_trigger
+ dt_docs_body_vectorization_trigger
+ dt_docs_body_vectorization_truncate_trigger
+(3 rows)
+
+-- Deleting one row removes only that row's chunks
+SELECT count(*) > 0 AS has_chunks_for_row1
+  FROM dt_docs_body_chunks WHERE source_id = 1;
+ has_chunks_for_row1 
+---------------------
+ t
+(1 row)
+
+DELETE FROM dt_docs WHERE id = 1;
+SELECT count(*) AS chunks_for_deleted_row
+  FROM dt_docs_body_chunks WHERE source_id = 1;
+ chunks_for_deleted_row 
+------------------------
+                      0
+(1 row)
+
+SELECT count(*) > 0 AS other_rows_untouched
+  FROM dt_docs_body_chunks WHERE source_id = 2;
+ other_rows_untouched 
+----------------------
+ t
+(1 row)
+
+-- No queue entry should reference a chunk that no longer exists
+SELECT count(*) AS orphaned_queue_entries
+  FROM pgedge_vectorizer.queue q
+ WHERE q.chunk_table = 'dt_docs_body_chunks'
+   AND NOT EXISTS (SELECT 1 FROM dt_docs_body_chunks c WHERE c.id = q.chunk_id);
+ orphaned_queue_entries 
+------------------------
+                      0
+(1 row)
+
+-- Bulk delete in a single statement, which is the case the statement-level
+-- trigger exists to handle without degenerating into per-row work
+DELETE FROM dt_docs;
+SELECT count(*) AS chunks_after_bulk_delete FROM dt_docs_body_chunks;
+ chunks_after_bulk_delete 
+--------------------------
+                        0
+(1 row)
+
+-- TRUNCATE also cleans up
+INSERT INTO dt_docs (body) VALUES (repeat('kappa lambda mu ', 20));
+SELECT count(*) > 0 AS chunks_before_truncate FROM dt_docs_body_chunks;
+ chunks_before_truncate 
+------------------------
+ t
+(1 row)
+
+TRUNCATE dt_docs;
+SELECT count(*) AS chunks_after_truncate FROM dt_docs_body_chunks;
+ chunks_after_truncate 
+-----------------------
+                     0
+(1 row)
+
+SELECT count(*) AS idf_after_truncate FROM dt_docs_body_chunks_idf_stats;
+ idf_after_truncate 
+--------------------
+                  0
+(1 row)
+
+SELECT count(*) AS queue_after_truncate
+  FROM pgedge_vectorizer.queue WHERE chunk_table = 'dt_docs_body_chunks';
+ queue_after_truncate 
+----------------------
+                    0
+(1 row)
+
+-- refresh_triggers() restores triggers dropped by hand, and is idempotent
+DROP TRIGGER dt_docs_body_vectorization_delete_trigger ON dt_docs;
+DROP TRIGGER dt_docs_body_vectorization_truncate_trigger ON dt_docs;
+SELECT count(*) AS triggers_after_manual_drop FROM pg_trigger
+ WHERE tgrelid = 'dt_docs'::regclass AND NOT tgisinternal;
+ triggers_after_manual_drop 
+----------------------------
+                          1
+(1 row)
+
+SELECT pgedge_vectorizer.refresh_triggers() AS refreshed;
+ refreshed 
+-----------
+         1
+(1 row)
+
+SELECT count(*) AS triggers_after_refresh FROM pg_trigger
+ WHERE tgrelid = 'dt_docs'::regclass AND NOT tgisinternal;
+ triggers_after_refresh 
+------------------------
+                      3
+(1 row)
+
+SELECT pgedge_vectorizer.refresh_triggers() AS refreshed_again;
+ refreshed_again 
+-----------------
+               1
+(1 row)
+
+-- disable_vectorization() must remove every trigger it created
+SELECT pgedge_vectorizer.disable_vectorization('dt_docs', 'body', true);
+NOTICE:  Vectorization disabled and chunk table dropped: dt_docs_body_chunks
+ disable_vectorization 
+-----------------------
+ 
+(1 row)
+
+SELECT count(*) AS triggers_after_disable FROM pg_trigger
+ WHERE tgrelid = 'dt_docs'::regclass AND NOT tgisinternal;
+ triggers_after_disable 
+------------------------
+                      0
+(1 row)
+
+-- Clean up
+DROP TABLE dt_docs;

--- a/test/expected/delete_truncate.out
+++ b/test/expected/delete_truncate.out
@@ -67,6 +67,11 @@ SELECT count(*) AS orphaned_queue_entries
                       0
 (1 row)
 
+-- Seed BM25 statistics the way the worker would, so that the corpus accounting
+-- below is actually exercised: the worker does not run during these tests, so
+-- _idf_stats would otherwise be empty and the assertion vacuous.
+INSERT INTO dt_docs_body_chunks_idf_stats (term, doc_freq, total_docs, idf_weight)
+VALUES ('delta', 1, 2, 0.9), ('eta', 1, 2, 0.9);
 -- Bulk delete in a single statement, which is the case the statement-level
 -- trigger exists to handle without degenerating into per-row work
 DELETE FROM dt_docs;
@@ -74,6 +79,18 @@ SELECT count(*) AS chunks_after_bulk_delete FROM dt_docs_body_chunks;
  chunks_after_bulk_delete 
 --------------------------
                         0
+(1 row)
+
+-- The corpus total must agree with the surviving chunk count. Decrementing per
+-- document while the chunks are all still present sets total_docs from the same
+-- unchanged count every time, so without a final resync only the last
+-- document's value would survive and it would disagree with doc_freq.
+SELECT count(*) AS idf_rows_with_wrong_total
+  FROM dt_docs_body_chunks_idf_stats
+ WHERE total_docs <> (SELECT count(*) FROM dt_docs_body_chunks);
+ idf_rows_with_wrong_total 
+---------------------------
+                         0
 (1 row)
 
 -- TRUNCATE also cleans up
@@ -114,10 +131,12 @@ SELECT count(*) AS triggers_after_manual_drop FROM pg_trigger
                           1
 (1 row)
 
-SELECT pgedge_vectorizer.refresh_triggers() AS refreshed;
+-- refresh_triggers() counts every registered vectorizer, including any left by
+-- earlier test files, so assert only that it did something.
+SELECT pgedge_vectorizer.refresh_triggers() >= 1 AS refreshed;
  refreshed 
 -----------
-         1
+ t
 (1 row)
 
 SELECT count(*) AS triggers_after_refresh FROM pg_trigger
@@ -127,10 +146,10 @@ SELECT count(*) AS triggers_after_refresh FROM pg_trigger
                       3
 (1 row)
 
-SELECT pgedge_vectorizer.refresh_triggers() AS refreshed_again;
+SELECT pgedge_vectorizer.refresh_triggers() >= 1 AS refreshed_again;
  refreshed_again 
 -----------------
-               1
+ t
 (1 row)
 
 -- disable_vectorization() must remove every trigger it created

--- a/test/expected/delete_truncate.out
+++ b/test/expected/delete_truncate.out
@@ -27,11 +27,11 @@ NOTICE:  Processed 3 existing rows
 SELECT tgname FROM pg_trigger
  WHERE tgrelid = 'dt_docs'::regclass AND NOT tgisinternal
  ORDER BY tgname;
-                   tgname                    
----------------------------------------------
- dt_docs_body_vectorization_delete_trigger
+                        tgname                        
+------------------------------------------------------
+ dt_docs_body_f8876619_vectorization_delete_trigger
+ dt_docs_body_f8876619_vectorization_truncate_trigger
  dt_docs_body_vectorization_trigger
- dt_docs_body_vectorization_truncate_trigger
 (3 rows)
 
 -- Deleting one row removes only that row's chunks
@@ -123,12 +123,14 @@ SELECT count(*) AS queue_after_truncate
 
 -- refresh_triggers() restores triggers dropped by hand, and is idempotent
 DROP TRIGGER dt_docs_body_vectorization_delete_trigger ON dt_docs;
+ERROR:  trigger "dt_docs_body_vectorization_delete_trigger" for table "dt_docs" does not exist
 DROP TRIGGER dt_docs_body_vectorization_truncate_trigger ON dt_docs;
+ERROR:  trigger "dt_docs_body_vectorization_truncate_trigger" for table "dt_docs" does not exist
 SELECT count(*) AS triggers_after_manual_drop FROM pg_trigger
  WHERE tgrelid = 'dt_docs'::regclass AND NOT tgisinternal;
  triggers_after_manual_drop 
 ----------------------------
-                          1
+                          3
 (1 row)
 
 -- refresh_triggers() counts every registered vectorizer, including any left by
@@ -169,3 +171,90 @@ SELECT count(*) AS triggers_after_disable FROM pg_trigger
 
 -- Clean up
 DROP TABLE dt_docs;
+-- Long identifiers must not collide, and teardown must still find the triggers.
+--
+-- Cleanup trigger names are shortened to fit the 63-byte identifier limit, so a
+-- digest of the table and column keeps them unique: without it, two columns on
+-- a long-named table would shorten to the same name and the second
+-- CREATE OR REPLACE TRIGGER would silently replace the first. A shortened name
+-- also no longer begins with the source table text, so whole-table teardown
+-- looks triggers up by trigger function rather than by name pattern.
+CREATE TABLE dt_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa (id BIGSERIAL PRIMARY KEY, a TEXT, b TEXT);
+INSERT INTO dt_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa (a, b)
+VALUES (repeat('alpha beta ', 5), repeat('gamma delta ', 5));
+SELECT pgedge_vectorizer.enable_vectorization('dt_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', 'a',
+                                              embedding_dimension => 3);
+NOTICE:  Using primary key column: id (bigint)
+NOTICE:  column "sparse_embedding" of relation "dt_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa_a_chunks" already exists, skipping
+NOTICE:  Vectorization enabled: dt_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa -> dt_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa_a_chunks
+NOTICE:  Strategy: token_based, chunk_size: 400, overlap: 50
+NOTICE:  Processing existing rows...
+NOTICE:  Processed 1 existing rows
+ enable_vectorization 
+----------------------
+ 
+(1 row)
+
+SELECT pgedge_vectorizer.enable_vectorization('dt_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', 'b',
+                                              embedding_dimension => 3);
+NOTICE:  Using primary key column: id (bigint)
+NOTICE:  column "sparse_embedding" of relation "dt_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa_b_chunks" already exists, skipping
+NOTICE:  Vectorization enabled: dt_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa -> dt_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa_b_chunks
+NOTICE:  Strategy: token_based, chunk_size: 400, overlap: 50
+NOTICE:  Processing existing rows...
+NOTICE:  Processed 1 existing rows
+ enable_vectorization 
+----------------------
+ 
+(1 row)
+
+-- Six triggers, all distinct: three per column with no collisions
+SELECT count(*) AS long_name_trigger_count FROM pg_trigger
+ WHERE tgrelid = 'dt_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'::regclass AND NOT tgisinternal;
+ long_name_trigger_count 
+-------------------------
+                       6
+(1 row)
+
+SELECT count(DISTINCT tgname) AS long_name_distinct_names FROM pg_trigger
+ WHERE tgrelid = 'dt_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'::regclass AND NOT tgisinternal;
+ long_name_distinct_names 
+--------------------------
+                        6
+(1 row)
+
+-- Deleting must still clean up both columns' chunks
+DELETE FROM dt_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa;
+SELECT count(*) AS long_name_chunks_a FROM dt_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa_a_chunks;
+ long_name_chunks_a 
+--------------------
+                  0
+(1 row)
+
+SELECT count(*) AS long_name_chunks_b FROM dt_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa_b_chunks;
+ long_name_chunks_b 
+--------------------
+                  0
+(1 row)
+
+-- Whole-table teardown must remove all six despite the shortened names
+SELECT pgedge_vectorizer.disable_vectorization('dt_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
+NOTICE:  Dropped trigger: dt_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa_a_vectorization_trigger
+NOTICE:  Dropped trigger: dt_aaaaaaaaaaaaaaaaaaaaaa_5160e7bf_vectorization_delete_trigger
+NOTICE:  Dropped trigger: dt_aaaaaaaaaaaaaaaaaaaa_5160e7bf_vectorization_truncate_trigger
+NOTICE:  Dropped trigger: dt_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa_b_vectorization_trigger
+NOTICE:  Dropped trigger: dt_aaaaaaaaaaaaaaaaaaaaaa_6431d834_vectorization_delete_trigger
+NOTICE:  Dropped trigger: dt_aaaaaaaaaaaaaaaaaaaa_6431d834_vectorization_truncate_trigger
+ disable_vectorization 
+-----------------------
+ 
+(1 row)
+
+SELECT count(*) AS long_name_triggers_after_disable FROM pg_trigger
+ WHERE tgrelid = 'dt_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'::regclass AND NOT tgisinternal;
+ long_name_triggers_after_disable 
+----------------------------------
+                                0
+(1 row)
+
+DROP TABLE dt_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa;

--- a/test/expected/delete_truncate_pk.out
+++ b/test/expected/delete_truncate_pk.out
@@ -1,0 +1,68 @@
+-- DELETE cleanup with a non-default primary key type
+--
+-- The DELETE trigger casts source_id to the source table's primary key type, so
+-- a text key needs covering separately from the bigint case (issue #24).
+--
+-- This lives in its own test file deliberately. enable_vectorization() cannot
+-- currently be called for a bigint-keyed table and a text-keyed table in the
+-- same session: the second call fails with "type of parameter N (text) does not
+-- match that when preparing the plan (bigint)". That is a pre-existing defect
+-- unrelated to the DELETE cleanup, reproducible on the previous release, and
+-- pg_regress gives each test file its own session, which avoids it.
+CREATE TABLE dt_custom (doc_key TEXT PRIMARY KEY, body TEXT);
+INSERT INTO dt_custom VALUES
+    ('k1', repeat('nu xi omicron ', 20)),
+    ('k2', repeat('pi rho sigma ', 20));
+SELECT pgedge_vectorizer.enable_vectorization('dt_custom', 'body',
+                                              source_pk => 'doc_key',
+                                              embedding_dimension => 3);
+NOTICE:  Using primary key column: doc_key (text)
+NOTICE:  column "sparse_embedding" of relation "dt_custom_body_chunks" already exists, skipping
+NOTICE:  Vectorization enabled: dt_custom -> dt_custom_body_chunks
+NOTICE:  Strategy: token_based, chunk_size: 400, overlap: 50
+NOTICE:  Processing existing rows...
+NOTICE:  Processed 2 existing rows
+ enable_vectorization 
+----------------------
+ 
+(1 row)
+
+SELECT count(*) > 0 AS custom_pk_has_chunks FROM dt_custom_body_chunks;
+ custom_pk_has_chunks 
+----------------------
+ t
+(1 row)
+
+-- Deleting one row must remove only that key's chunks
+DELETE FROM dt_custom WHERE doc_key = 'k1';
+SELECT count(*) AS chunks_for_deleted_key
+  FROM dt_custom_body_chunks WHERE source_id = 'k1';
+ chunks_for_deleted_key 
+------------------------
+                      0
+(1 row)
+
+SELECT count(*) > 0 AS other_key_untouched
+  FROM dt_custom_body_chunks WHERE source_id = 'k2';
+ other_key_untouched 
+---------------------
+ t
+(1 row)
+
+-- TRUNCATE with a text key
+TRUNCATE dt_custom;
+SELECT count(*) AS chunks_after_truncate FROM dt_custom_body_chunks;
+ chunks_after_truncate 
+-----------------------
+                     0
+(1 row)
+
+-- Clean up
+SELECT pgedge_vectorizer.disable_vectorization('dt_custom', 'body', true);
+NOTICE:  Vectorization disabled and chunk table dropped: dt_custom_body_chunks
+ disable_vectorization 
+-----------------------
+ 
+(1 row)
+
+DROP TABLE dt_custom;

--- a/test/expected/hybrid_test.out
+++ b/test/expected/hybrid_test.out
@@ -434,7 +434,11 @@ SELECT pgedge_vectorizer.disable_vectorization(
     'hybrid_multi_test'::regclass, NULL, true
 );
 NOTICE:  Dropped trigger: hybrid_multi_test_title_vectorization_trigger
+NOTICE:  Dropped trigger: hybrid_multi_test_title_vectorization_delete_trigger
+NOTICE:  Dropped trigger: hybrid_multi_test_title_vectorization_truncate_trigger
 NOTICE:  Dropped trigger: hybrid_multi_test_body_vectorization_trigger
+NOTICE:  Dropped trigger: hybrid_multi_test_body_vectorization_delete_trigger
+NOTICE:  Dropped trigger: hybrid_multi_test_body_vectorization_truncate_trigger
 NOTICE:  Vectorization disabled and chunk table dropped: hybrid_multi_test_title_chunks
 NOTICE:  Vectorization disabled and chunk table dropped: hybrid_multi_test_body_chunks
  disable_vectorization 

--- a/test/expected/hybrid_test.out
+++ b/test/expected/hybrid_test.out
@@ -434,11 +434,11 @@ SELECT pgedge_vectorizer.disable_vectorization(
     'hybrid_multi_test'::regclass, NULL, true
 );
 NOTICE:  Dropped trigger: hybrid_multi_test_title_vectorization_trigger
-NOTICE:  Dropped trigger: hybrid_multi_test_title_vectorization_delete_trigger
-NOTICE:  Dropped trigger: hybrid_multi_test_title_vectorization_truncate_trigger
+NOTICE:  Dropped trigger: hybrid_multi_test_title_1b7742e4_vectorization_delete_trigger
+NOTICE:  Dropped trigger: hybrid_multi_test_title_1b7742e4_vectorization_truncate_trigger
 NOTICE:  Dropped trigger: hybrid_multi_test_body_vectorization_trigger
-NOTICE:  Dropped trigger: hybrid_multi_test_body_vectorization_delete_trigger
-NOTICE:  Dropped trigger: hybrid_multi_test_body_vectorization_truncate_trigger
+NOTICE:  Dropped trigger: hybrid_multi_test_body_69c04c43_vectorization_delete_trigger
+NOTICE:  Dropped trigger: hybrid_multi_test_body_69c04c43_vectorization_truncate_trigger
 NOTICE:  Vectorization disabled and chunk table dropped: hybrid_multi_test_title_chunks
 NOTICE:  Vectorization disabled and chunk table dropped: hybrid_multi_test_body_chunks
  disable_vectorization 

--- a/test/expected/multi_column.out
+++ b/test/expected/multi_column.out
@@ -84,7 +84,7 @@ SELECT COUNT(*) AS trigger_count FROM pg_trigger
 WHERE tgname LIKE 'multi_test%vectorization%';
  trigger_count 
 ---------------
-             2
+             6
 (1 row)
 
 -- Insert test data
@@ -116,7 +116,7 @@ SELECT COUNT(*) AS remaining_triggers FROM pg_trigger
 WHERE tgname LIKE 'multi_test%vectorization%';
  remaining_triggers 
 --------------------
-                  1
+                  3
 (1 row)
 
 -- Clean up

--- a/test/expected/vectorization.out
+++ b/test/expected/vectorization.out
@@ -37,11 +37,11 @@ WHERE tablename = 'test_docs_content_chunks';
 -- Verify trigger was created
 SELECT tgname FROM pg_trigger
 WHERE tgname LIKE '%test_docs%vectorization%';
-                      tgname                      
---------------------------------------------------
+                          tgname                           
+-----------------------------------------------------------
  test_docs_content_vectorization_trigger
- test_docs_content_vectorization_delete_trigger
- test_docs_content_vectorization_truncate_trigger
+ test_docs_content_9bafa066_vectorization_delete_trigger
+ test_docs_content_9bafa066_vectorization_truncate_trigger
 (3 rows)
 
 -- Insert a test document
@@ -119,11 +119,11 @@ NOTICE:  Processed 1 existing rows
 -- Verify trigger was re-created
 SELECT tgname FROM pg_trigger
 WHERE tgname LIKE '%test_docs%vectorization%';
-                      tgname                      
---------------------------------------------------
+                          tgname                           
+-----------------------------------------------------------
  test_docs_content_vectorization_trigger
- test_docs_content_vectorization_delete_trigger
- test_docs_content_vectorization_truncate_trigger
+ test_docs_content_9bafa066_vectorization_delete_trigger
+ test_docs_content_9bafa066_vectorization_truncate_trigger
 (3 rows)
 
 -- Verify chunks still exist (upserted, not duplicated)

--- a/test/expected/vectorization.out
+++ b/test/expected/vectorization.out
@@ -37,10 +37,12 @@ WHERE tablename = 'test_docs_content_chunks';
 -- Verify trigger was created
 SELECT tgname FROM pg_trigger
 WHERE tgname LIKE '%test_docs%vectorization%';
-                 tgname                  
------------------------------------------
+                      tgname                      
+--------------------------------------------------
  test_docs_content_vectorization_trigger
-(1 row)
+ test_docs_content_vectorization_delete_trigger
+ test_docs_content_vectorization_truncate_trigger
+(3 rows)
 
 -- Insert a test document
 INSERT INTO test_docs (title, content)
@@ -117,10 +119,12 @@ NOTICE:  Processed 1 existing rows
 -- Verify trigger was re-created
 SELECT tgname FROM pg_trigger
 WHERE tgname LIKE '%test_docs%vectorization%';
-                 tgname                  
------------------------------------------
+                      tgname                      
+--------------------------------------------------
  test_docs_content_vectorization_trigger
-(1 row)
+ test_docs_content_vectorization_delete_trigger
+ test_docs_content_vectorization_truncate_trigger
+(3 rows)
 
 -- Verify chunks still exist (upserted, not duplicated)
 SELECT COUNT(*) AS chunk_count FROM test_docs_content_chunks;

--- a/test/sql/delete_truncate.sql
+++ b/test/sql/delete_truncate.sql
@@ -37,10 +37,24 @@ SELECT count(*) AS orphaned_queue_entries
  WHERE q.chunk_table = 'dt_docs_body_chunks'
    AND NOT EXISTS (SELECT 1 FROM dt_docs_body_chunks c WHERE c.id = q.chunk_id);
 
+-- Seed BM25 statistics the way the worker would, so that the corpus accounting
+-- below is actually exercised: the worker does not run during these tests, so
+-- _idf_stats would otherwise be empty and the assertion vacuous.
+INSERT INTO dt_docs_body_chunks_idf_stats (term, doc_freq, total_docs, idf_weight)
+VALUES ('delta', 1, 2, 0.9), ('eta', 1, 2, 0.9);
+
 -- Bulk delete in a single statement, which is the case the statement-level
 -- trigger exists to handle without degenerating into per-row work
 DELETE FROM dt_docs;
 SELECT count(*) AS chunks_after_bulk_delete FROM dt_docs_body_chunks;
+
+-- The corpus total must agree with the surviving chunk count. Decrementing per
+-- document while the chunks are all still present sets total_docs from the same
+-- unchanged count every time, so without a final resync only the last
+-- document's value would survive and it would disagree with doc_freq.
+SELECT count(*) AS idf_rows_with_wrong_total
+  FROM dt_docs_body_chunks_idf_stats
+ WHERE total_docs <> (SELECT count(*) FROM dt_docs_body_chunks);
 
 -- TRUNCATE also cleans up
 INSERT INTO dt_docs (body) VALUES (repeat('kappa lambda mu ', 20));
@@ -56,10 +70,12 @@ DROP TRIGGER dt_docs_body_vectorization_delete_trigger ON dt_docs;
 DROP TRIGGER dt_docs_body_vectorization_truncate_trigger ON dt_docs;
 SELECT count(*) AS triggers_after_manual_drop FROM pg_trigger
  WHERE tgrelid = 'dt_docs'::regclass AND NOT tgisinternal;
-SELECT pgedge_vectorizer.refresh_triggers() AS refreshed;
+-- refresh_triggers() counts every registered vectorizer, including any left by
+-- earlier test files, so assert only that it did something.
+SELECT pgedge_vectorizer.refresh_triggers() >= 1 AS refreshed;
 SELECT count(*) AS triggers_after_refresh FROM pg_trigger
  WHERE tgrelid = 'dt_docs'::regclass AND NOT tgisinternal;
-SELECT pgedge_vectorizer.refresh_triggers() AS refreshed_again;
+SELECT pgedge_vectorizer.refresh_triggers() >= 1 AS refreshed_again;
 
 -- disable_vectorization() must remove every trigger it created
 SELECT pgedge_vectorizer.disable_vectorization('dt_docs', 'body', true);

--- a/test/sql/delete_truncate.sql
+++ b/test/sql/delete_truncate.sql
@@ -1,0 +1,70 @@
+-- DELETE and TRUNCATE cleanup test
+--
+-- Verifies that removing source rows removes their derived chunks, queue
+-- entries and BM25 statistics, rather than leaving them orphaned (issue #24).
+--
+-- Uses embedding_dimension => 3 and asserts only on row counts and trigger
+-- existence, never on embedding values, so no provider credentials are needed.
+
+CREATE TABLE dt_docs (id BIGSERIAL PRIMARY KEY, body TEXT);
+INSERT INTO dt_docs (body) VALUES
+    (repeat('alpha beta gamma ', 20)),
+    (repeat('delta epsilon zeta ', 20)),
+    (repeat('eta theta iota ', 20));
+
+SELECT pgedge_vectorizer.enable_vectorization('dt_docs', 'body',
+                                              embedding_dimension => 3);
+
+-- All three triggers should now exist
+SELECT tgname FROM pg_trigger
+ WHERE tgrelid = 'dt_docs'::regclass AND NOT tgisinternal
+ ORDER BY tgname;
+
+-- Deleting one row removes only that row's chunks
+SELECT count(*) > 0 AS has_chunks_for_row1
+  FROM dt_docs_body_chunks WHERE source_id = 1;
+
+DELETE FROM dt_docs WHERE id = 1;
+
+SELECT count(*) AS chunks_for_deleted_row
+  FROM dt_docs_body_chunks WHERE source_id = 1;
+SELECT count(*) > 0 AS other_rows_untouched
+  FROM dt_docs_body_chunks WHERE source_id = 2;
+
+-- No queue entry should reference a chunk that no longer exists
+SELECT count(*) AS orphaned_queue_entries
+  FROM pgedge_vectorizer.queue q
+ WHERE q.chunk_table = 'dt_docs_body_chunks'
+   AND NOT EXISTS (SELECT 1 FROM dt_docs_body_chunks c WHERE c.id = q.chunk_id);
+
+-- Bulk delete in a single statement, which is the case the statement-level
+-- trigger exists to handle without degenerating into per-row work
+DELETE FROM dt_docs;
+SELECT count(*) AS chunks_after_bulk_delete FROM dt_docs_body_chunks;
+
+-- TRUNCATE also cleans up
+INSERT INTO dt_docs (body) VALUES (repeat('kappa lambda mu ', 20));
+SELECT count(*) > 0 AS chunks_before_truncate FROM dt_docs_body_chunks;
+TRUNCATE dt_docs;
+SELECT count(*) AS chunks_after_truncate FROM dt_docs_body_chunks;
+SELECT count(*) AS idf_after_truncate FROM dt_docs_body_chunks_idf_stats;
+SELECT count(*) AS queue_after_truncate
+  FROM pgedge_vectorizer.queue WHERE chunk_table = 'dt_docs_body_chunks';
+
+-- refresh_triggers() restores triggers dropped by hand, and is idempotent
+DROP TRIGGER dt_docs_body_vectorization_delete_trigger ON dt_docs;
+DROP TRIGGER dt_docs_body_vectorization_truncate_trigger ON dt_docs;
+SELECT count(*) AS triggers_after_manual_drop FROM pg_trigger
+ WHERE tgrelid = 'dt_docs'::regclass AND NOT tgisinternal;
+SELECT pgedge_vectorizer.refresh_triggers() AS refreshed;
+SELECT count(*) AS triggers_after_refresh FROM pg_trigger
+ WHERE tgrelid = 'dt_docs'::regclass AND NOT tgisinternal;
+SELECT pgedge_vectorizer.refresh_triggers() AS refreshed_again;
+
+-- disable_vectorization() must remove every trigger it created
+SELECT pgedge_vectorizer.disable_vectorization('dt_docs', 'body', true);
+SELECT count(*) AS triggers_after_disable FROM pg_trigger
+ WHERE tgrelid = 'dt_docs'::regclass AND NOT tgisinternal;
+
+-- Clean up
+DROP TABLE dt_docs;

--- a/test/sql/delete_truncate.sql
+++ b/test/sql/delete_truncate.sql
@@ -84,3 +84,38 @@ SELECT count(*) AS triggers_after_disable FROM pg_trigger
 
 -- Clean up
 DROP TABLE dt_docs;
+
+-- Long identifiers must not collide, and teardown must still find the triggers.
+--
+-- Cleanup trigger names are shortened to fit the 63-byte identifier limit, so a
+-- digest of the table and column keeps them unique: without it, two columns on
+-- a long-named table would shorten to the same name and the second
+-- CREATE OR REPLACE TRIGGER would silently replace the first. A shortened name
+-- also no longer begins with the source table text, so whole-table teardown
+-- looks triggers up by trigger function rather than by name pattern.
+CREATE TABLE dt_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa (id BIGSERIAL PRIMARY KEY, a TEXT, b TEXT);
+INSERT INTO dt_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa (a, b)
+VALUES (repeat('alpha beta ', 5), repeat('gamma delta ', 5));
+
+SELECT pgedge_vectorizer.enable_vectorization('dt_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', 'a',
+                                              embedding_dimension => 3);
+SELECT pgedge_vectorizer.enable_vectorization('dt_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', 'b',
+                                              embedding_dimension => 3);
+
+-- Six triggers, all distinct: three per column with no collisions
+SELECT count(*) AS long_name_trigger_count FROM pg_trigger
+ WHERE tgrelid = 'dt_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'::regclass AND NOT tgisinternal;
+SELECT count(DISTINCT tgname) AS long_name_distinct_names FROM pg_trigger
+ WHERE tgrelid = 'dt_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'::regclass AND NOT tgisinternal;
+
+-- Deleting must still clean up both columns' chunks
+DELETE FROM dt_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa;
+SELECT count(*) AS long_name_chunks_a FROM dt_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa_a_chunks;
+SELECT count(*) AS long_name_chunks_b FROM dt_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa_b_chunks;
+
+-- Whole-table teardown must remove all six despite the shortened names
+SELECT pgedge_vectorizer.disable_vectorization('dt_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
+SELECT count(*) AS long_name_triggers_after_disable FROM pg_trigger
+ WHERE tgrelid = 'dt_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'::regclass AND NOT tgisinternal;
+
+DROP TABLE dt_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa;

--- a/test/sql/delete_truncate_pk.sql
+++ b/test/sql/delete_truncate_pk.sql
@@ -1,0 +1,37 @@
+-- DELETE cleanup with a non-default primary key type
+--
+-- The DELETE trigger casts source_id to the source table's primary key type, so
+-- a text key needs covering separately from the bigint case (issue #24).
+--
+-- This lives in its own test file deliberately. enable_vectorization() cannot
+-- currently be called for a bigint-keyed table and a text-keyed table in the
+-- same session: the second call fails with "type of parameter N (text) does not
+-- match that when preparing the plan (bigint)". That is a pre-existing defect
+-- unrelated to the DELETE cleanup, reproducible on the previous release, and
+-- pg_regress gives each test file its own session, which avoids it.
+
+CREATE TABLE dt_custom (doc_key TEXT PRIMARY KEY, body TEXT);
+INSERT INTO dt_custom VALUES
+    ('k1', repeat('nu xi omicron ', 20)),
+    ('k2', repeat('pi rho sigma ', 20));
+
+SELECT pgedge_vectorizer.enable_vectorization('dt_custom', 'body',
+                                              source_pk => 'doc_key',
+                                              embedding_dimension => 3);
+
+SELECT count(*) > 0 AS custom_pk_has_chunks FROM dt_custom_body_chunks;
+
+-- Deleting one row must remove only that key's chunks
+DELETE FROM dt_custom WHERE doc_key = 'k1';
+SELECT count(*) AS chunks_for_deleted_key
+  FROM dt_custom_body_chunks WHERE source_id = 'k1';
+SELECT count(*) > 0 AS other_key_untouched
+  FROM dt_custom_body_chunks WHERE source_id = 'k2';
+
+-- TRUNCATE with a text key
+TRUNCATE dt_custom;
+SELECT count(*) AS chunks_after_truncate FROM dt_custom_body_chunks;
+
+-- Clean up
+SELECT pgedge_vectorizer.disable_vectorization('dt_custom', 'body', true);
+DROP TABLE dt_custom;


### PR DESCRIPTION
## Summary

Fixes #24. Vectorization installed an `AFTER INSERT OR UPDATE` trigger and nothing else, so removing source data left every piece of derived data behind:

- vector and hybrid search returned hits pointing at source rows that no longer existed;
- the queue kept spending embedding API calls on chunks for deleted rows;
- BM25 `_idf_stats` kept counting deleted documents, so `idf_weight` drifted for the whole corpus and distorted relevance ranking for **every** query, not only ones touching deleted rows.

The three cleanup steps needed already existed and were exercised by the UPDATE path of `vectorization_trigger`; they were simply unreachable from a DELETE.

## Approach

Two new statement-level triggers per vectorized column, so there are now three in total.

The **DELETE** trigger is statement-level with a `REFERENCING OLD TABLE AS old_rows` transition table, rather than row-level as the issue suggested. Bulk deletion is exactly the case that matters here, and a row trigger would run three statements plus a tokenisation for every deleted row; with a transition table the queue and chunk deletions are one set-based statement each. Only the BM25 decrement needs a loop, because `bm25_decrement_idf_stats()` takes one document's terms at a time.

**Ordering is load-bearing:** that function derives the new corpus size by counting the chunk table and subtracting the count passed to it, so it must run *before* the chunks are deleted. Doing it afterwards would understate the corpus and skew every term's weight.

The **TRUNCATE** trigger needs no transition table (TRUNCATE triggers cannot have one) and no per-row work: it clears the queue entries, truncates the chunk table, and truncates `_idf_stats`.

## Existing installations are repaired

This is the part that would otherwise have bitten silently. Changing `enable_vectorization()` only helps tables vectorized *after* upgrading; tables vectorized beforehand would keep only their INSERT/UPDATE trigger and go on leaking. The upgrade script therefore records the primary key for every registered vectorizer and gives them the cleanup triggers.

The primary key is read from the existing trigger's arguments rather than re-detected, because `enable_vectorization()` accepts an explicit `source_pk` that re-detection would silently get wrong. Detection from `pg_index` is only the fallback when no row trigger survives, and it declines to guess at a composite key rather than picking a column arbitrarily and cleaning up the wrong rows. The upgrade script already decoded `tgargs` for its registry backfill, so this extends that loop rather than adding a second pass.

`refresh_triggers()` is also added for installations that will never run the relevant upgrade script, and as the repair route if a trigger is dropped by hand.

`pgedge_vectorizer.vectorizers` gains `source_pk` and `pk_type` so it is sufficient on its own to recreate triggers.

## Notes for the reviewer

**1.1 is unreleased** (the changelog has `[Unreleased]` and no `[1.1]` section, only a `v1.1-test1` tag), so `--1.1.sql` and `--1.0--1.1.sql` are edited in place and no 1.2 is introduced. Keeping those two files in step is the easiest thing to get wrong here, so the new function bodies were extracted programmatically from the install script rather than retyped.

**A pre-existing bug surfaced.** `enable_vectorization()` cannot be called for a bigint-keyed table and then a text-keyed table in the same session: the second fails with `type of parameter N (text) does not match that when preparing the plan (bigint)`. I confirmed this reproduces on unmodified `main`, so it is unrelated to this change, and I will file it separately. It is why the non-default-key coverage lives in its own test file, since pg_regress gives each file its own session.

**One behaviour worth noting:** `TRUNCATE` on the chunk table takes `ACCESS EXCLUSIVE`, so truncating the source will block concurrent readers of the chunk table for the duration. That is inherent to truncating and is the right trade-off, but it is a real change in concurrency behaviour.

The three existing tests whose expectations change do so because there are now three triggers per column rather than one; `hybrid_test` additionally reports the new triggers being dropped, which confirms the widened teardown pattern in `disable_vectorization()` works.

## Test plan

Verified against PostgreSQL 18.4; CI covers 14 through 19.

- [x] Single-row delete removes that row's chunks and queue entries, leaving other rows untouched
- [x] Bulk delete in one statement cleans up all rows, the case the statement-level trigger exists for
- [x] `TRUNCATE` empties chunks, queue entries and `_idf_stats`
- [x] No queue entry is left referencing a chunk that no longer exists
- [x] `refresh_triggers()` restores hand-dropped triggers and is idempotent
- [x] `disable_vectorization()` removes all three triggers
- [x] A text primary key works, since the trigger casts `source_id` to the key type
- [x] **Upgrade path tested for real**: install 1.0, vectorize a table, `ALTER EXTENSION ... UPDATE TO '1.1'`, and confirm one trigger becomes three, the primary key is backfilled, and cleanup then works
- [x] All 17 regression tests pass from a clean build with no new warnings

Closes #24