### PR TITLE
Fix RECORD field type caching across differently-keyed tables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ DATA = sql/$(EXTENSION)--$(EXTVERSION).sql \
        sql/$(EXTENSION)--1.0-beta3--1.0.sql
 
 # Test configuration for pg_regress
-REGRESS = setup chunking hybrid_chunking queue delete_truncate delete_truncate_pk vectorization multi_column maintenance edge_cases providers worker cleanup embedding pk_types stale_embeddings hybrid_test
+REGRESS = setup chunking hybrid_chunking queue delete_truncate delete_truncate_pk pk_type_session vectorization multi_column maintenance edge_cases providers worker cleanup embedding pk_types stale_embeddings hybrid_test
 REGRESS_OPTS = --inputdir=test --outputdir=test
 
 # Documentation files (if any)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -81,6 +81,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   a transition table, so a bulk delete stays set-based rather than doing per-row
   work. **Upgrading also repairs tables that were already vectorized**, which
   otherwise would have kept leaking silently.
+- Fixed `enable_vectorization()` and `recreate_chunks()` failing with `type of
+  parameter N does not match that when preparing the plan` when called for a
+  table with one primary key type and then, in the same session, a table with a
+  different primary key type
+  ([#39](https://github.com/pgEdge/pgedge-vectorizer/issues/39)). Both functions
+  loop over existing source rows into a `RECORD` variable and pass one of its
+  fields to a dynamic query; PL/pgSQL fixes that field's parameter type the
+  first time the statement runs, and the type mismatch broke any second
+  vectorized table whose primary key differed. The failure aborted partway
+  through, after the chunk table and trigger had already been created, leaving
+  the vectorizer for that column half set up.
 
 ## [1.0] - 2026-03-13
 

--- a/sql/pgedge_vectorizer--1.0--1.1.sql
+++ b/sql/pgedge_vectorizer--1.0--1.1.sql
@@ -386,7 +386,17 @@ BEGIN
     BEGIN
         RAISE NOTICE 'Processing existing rows...';
 
-        FOR row_record IN EXECUTE format('SELECT %I as pk_val, %I as content FROM %s WHERE %I IS NOT NULL AND %I != ''''',
+        -- pk_val is cast to text here so that row_record.pk_val is always the
+        -- same type across every call to this function within a session,
+        -- regardless of the source table's actual primary key type. PL/pgSQL
+        -- fixes the parameter type of a RECORD field the first time a dynamic
+        -- EXECUTE ... USING statement evaluates it, and reusing that same
+        -- statement later with a differently-typed record field fails with
+        -- "type of parameter N does not match that when preparing the plan"
+        -- (issue #39). Casting at the source, rather than at each USING site,
+        -- is required: PostgreSQL still binds the RECORD field's own runtime
+        -- type before any cast written into the later query text is applied.
+        FOR row_record IN EXECUTE format('SELECT %I::text as pk_val, %I as content FROM %s WHERE %I IS NOT NULL AND %I != ''''',
             source_pk, source_column, source_table, source_column, source_column)
         LOOP
             doc_content := row_record.content;
@@ -398,10 +408,14 @@ BEGIN
             FOR i IN 1..array_length(chunks, 1) LOOP
                 chunk_text := chunks[i];
 
-                -- Insert or update chunk (only clear embedding if content changed)
+                -- Insert or update chunk (only clear embedding if content changed).
+                -- pk_col_type uses %s: value from format_type() is system-controlled
+                -- (see the comment where the chunk table is created, above).
+                -- $1::%s casts pk_val, now always text, back to the source
+                -- table's actual primary key type.
                 EXECUTE format('
                     INSERT INTO %I (source_id, chunk_index, content, token_count)
-                    VALUES ($1, $2, $3, $4)
+                    VALUES ($1::%s, $2, $3, $4)
                     ON CONFLICT (source_id, chunk_index)
                     DO UPDATE SET content = EXCLUDED.content,
                                   token_count = EXCLUDED.token_count,
@@ -417,7 +431,7 @@ BEGIN
                     RETURNING id,
                               (embedding IS NULL) AS needs_embedding,
                               (sparse_embedding IS NULL) AS needs_sparse',
-                    chunk_table, chunk_table, chunk_table, chunk_table, chunk_table)
+                    chunk_table, pk_col_type, chunk_table, chunk_table, chunk_table, chunk_table)
                 USING row_record.pk_val, i, chunk_text,
                       length(chunk_text) / 4  -- Approximate token count
                 INTO chunk_id, needs_embedding, needs_sparse;
@@ -1240,8 +1254,16 @@ BEGIN
         RAISE NOTICE 'Re-chunking with strategy=%, size=%, overlap=%',
             actual_strategy, actual_chunk_size, actual_chunk_overlap;
 
+        -- pk_val is cast to text so that row_record.pk_val is always the same
+        -- type across calls in a session, whatever the source table's actual
+        -- primary key type. See the identical comment in enable_vectorization()
+        -- for why: PL/pgSQL fixes a RECORD field's parameter type the first
+        -- time a dynamic EXECUTE ... USING statement evaluates it, and this
+        -- statement's own "$1::%s" cast below does not protect it, because
+        -- that cast is applied after PostgreSQL has already bound the record
+        -- field's raw runtime type (issue #39).
         FOR row_record IN EXECUTE format(
-            'SELECT %I as pk_val, %I as content FROM %s WHERE %I IS NOT NULL AND %I != ''''',
+            'SELECT %I::text as pk_val, %I as content FROM %s WHERE %I IS NOT NULL AND %I != ''''',
             pk_col, source_column_name, source_table_name, source_column_name, source_column_name
         )
         LOOP

--- a/sql/pgedge_vectorizer--1.1.sql
+++ b/sql/pgedge_vectorizer--1.1.sql
@@ -378,7 +378,17 @@ BEGIN
     BEGIN
         RAISE NOTICE 'Processing existing rows...';
 
-        FOR row_record IN EXECUTE format('SELECT %I as pk_val, %I as content FROM %s WHERE %I IS NOT NULL AND %I != ''''',
+        -- pk_val is cast to text here so that row_record.pk_val is always the
+        -- same type across every call to this function within a session,
+        -- regardless of the source table's actual primary key type. PL/pgSQL
+        -- fixes the parameter type of a RECORD field the first time a dynamic
+        -- EXECUTE ... USING statement evaluates it, and reusing that same
+        -- statement later with a differently-typed record field fails with
+        -- "type of parameter N does not match that when preparing the plan"
+        -- (issue #39). Casting at the source, rather than at each USING site,
+        -- is required: PostgreSQL still binds the RECORD field's own runtime
+        -- type before any cast written into the later query text is applied.
+        FOR row_record IN EXECUTE format('SELECT %I::text as pk_val, %I as content FROM %s WHERE %I IS NOT NULL AND %I != ''''',
             source_pk, source_column, source_table, source_column, source_column)
         LOOP
             doc_content := row_record.content;
@@ -390,10 +400,14 @@ BEGIN
             FOR i IN 1..array_length(chunks, 1) LOOP
                 chunk_text := chunks[i];
 
-                -- Insert or update chunk (only clear embedding if content changed)
+                -- Insert or update chunk (only clear embedding if content changed).
+                -- pk_col_type uses %s: value from format_type() is system-controlled
+                -- (see the comment where the chunk table is created, above).
+                -- $1::%s casts pk_val, now always text, back to the source
+                -- table's actual primary key type.
                 EXECUTE format('
                     INSERT INTO %I (source_id, chunk_index, content, token_count)
-                    VALUES ($1, $2, $3, $4)
+                    VALUES ($1::%s, $2, $3, $4)
                     ON CONFLICT (source_id, chunk_index)
                     DO UPDATE SET content = EXCLUDED.content,
                                   token_count = EXCLUDED.token_count,
@@ -409,7 +423,7 @@ BEGIN
                     RETURNING id,
                               (embedding IS NULL) AS needs_embedding,
                               (sparse_embedding IS NULL) AS needs_sparse',
-                    chunk_table, chunk_table, chunk_table, chunk_table, chunk_table)
+                    chunk_table, pk_col_type, chunk_table, chunk_table, chunk_table, chunk_table)
                 USING row_record.pk_val, i, chunk_text,
                       length(chunk_text) / 4  -- Approximate token count
                 INTO chunk_id, needs_embedding, needs_sparse;
@@ -1232,8 +1246,16 @@ BEGIN
         RAISE NOTICE 'Re-chunking with strategy=%, size=%, overlap=%',
             actual_strategy, actual_chunk_size, actual_chunk_overlap;
 
+        -- pk_val is cast to text so that row_record.pk_val is always the same
+        -- type across calls in a session, whatever the source table's actual
+        -- primary key type. See the identical comment in enable_vectorization()
+        -- for why: PL/pgSQL fixes a RECORD field's parameter type the first
+        -- time a dynamic EXECUTE ... USING statement evaluates it, and this
+        -- statement's own "$1::%s" cast below does not protect it, because
+        -- that cast is applied after PostgreSQL has already bound the record
+        -- field's raw runtime type (issue #39).
         FOR row_record IN EXECUTE format(
-            'SELECT %I as pk_val, %I as content FROM %s WHERE %I IS NOT NULL AND %I != ''''',
+            'SELECT %I::text as pk_val, %I as content FROM %s WHERE %I IS NOT NULL AND %I != ''''',
             pk_col, source_column_name, source_table_name, source_column_name, source_column_name
         )
         LOOP

--- a/test/expected/pk_type_session.out
+++ b/test/expected/pk_type_session.out
@@ -1,0 +1,113 @@
+-- Cross-session primary-key-type test (issue #39)
+--
+-- enable_vectorization() and recreate_chunks() both loop over source rows with
+-- FOR row_record IN EXECUTE ... LOOP, where row_record is declared RECORD and
+-- its pk_val field is later used as a dynamic EXECUTE ... USING parameter.
+-- PL/pgSQL fixes a RECORD field's parameter type the first time that callsite
+-- is evaluated in a session, and reusing the same callsite with a different
+-- underlying type raises "type of parameter N (T2) does not match that when
+-- preparing the plan (T1)". This can only be exercised with two calls sharing
+-- one session, which is why it lives in its own test file rather than being
+-- split across several, unlike the non-default-key coverage added for #24.
+-- A bigint primary key first, to seed the callsite's cached parameter type.
+CREATE TABLE pk_docs_bigint (id BIGSERIAL PRIMARY KEY, body TEXT);
+INSERT INTO pk_docs_bigint (body) VALUES (repeat('alpha beta gamma ', 20));
+SELECT pgedge_vectorizer.enable_vectorization('pk_docs_bigint', 'body',
+                                              embedding_dimension => 3);
+NOTICE:  Using primary key column: id (bigint)
+NOTICE:  column "sparse_embedding" of relation "pk_docs_bigint_body_chunks" already exists, skipping
+NOTICE:  Vectorization enabled: pk_docs_bigint -> pk_docs_bigint_body_chunks
+NOTICE:  Strategy: token_based, chunk_size: 400, overlap: 50
+NOTICE:  Processing existing rows...
+NOTICE:  Processed 1 existing rows
+ enable_vectorization 
+----------------------
+ 
+(1 row)
+
+SELECT count(*) > 0 AS bigint_pk_has_chunks FROM pk_docs_bigint_body_chunks;
+ bigint_pk_has_chunks 
+----------------------
+ t
+(1 row)
+
+-- A text primary key second, in the same session. This is what fails on
+-- unmodified main: it aborts partway through "Processing existing rows...",
+-- after the chunk table, indexes and trigger already exist.
+CREATE TABLE pk_docs_text (doc_key TEXT PRIMARY KEY, body TEXT);
+INSERT INTO pk_docs_text VALUES ('k1', repeat('delta epsilon zeta ', 20));
+SELECT pgedge_vectorizer.enable_vectorization('pk_docs_text', 'body',
+                                              source_pk => 'doc_key',
+                                              embedding_dimension => 3);
+NOTICE:  Using primary key column: doc_key (text)
+NOTICE:  column "sparse_embedding" of relation "pk_docs_text_body_chunks" already exists, skipping
+NOTICE:  Vectorization enabled: pk_docs_text -> pk_docs_text_body_chunks
+NOTICE:  Strategy: token_based, chunk_size: 400, overlap: 50
+NOTICE:  Processing existing rows...
+NOTICE:  Processed 1 existing rows
+ enable_vectorization 
+----------------------
+ 
+(1 row)
+
+SELECT count(*) > 0 AS text_pk_has_chunks FROM pk_docs_text_body_chunks;
+ text_pk_has_chunks 
+--------------------
+ t
+(1 row)
+
+-- recreate_chunks() has the identical bug through the same mechanism, and its
+-- existing "$1::%s" cast at the INSERT does not protect it: the cache trips on
+-- the raw type PostgreSQL binds for the parameter, before any cast in the SQL
+-- text is applied. Exercise it back-to-back across the two PK types too.
+SELECT pgedge_vectorizer.recreate_chunks('pk_docs_bigint', 'body');
+NOTICE:  Recreating chunks for pk_docs_bigint.body -> pk_docs_bigint_body_chunks
+NOTICE:  Deleted 0 existing chunks
+NOTICE:  Cleared queue for pk_docs_bigint_body_chunks
+NOTICE:  Re-chunking with strategy=token_based, size=400, overlap=50
+NOTICE:  Processed 1 rows
+ recreate_chunks 
+-----------------
+               1
+(1 row)
+
+SELECT count(*) > 0 AS bigint_pk_chunks_after_recreate FROM pk_docs_bigint_body_chunks;
+ bigint_pk_chunks_after_recreate 
+---------------------------------
+ t
+(1 row)
+
+SELECT pgedge_vectorizer.recreate_chunks('pk_docs_text', 'body');
+NOTICE:  Recreating chunks for pk_docs_text.body -> pk_docs_text_body_chunks
+NOTICE:  Deleted 0 existing chunks
+NOTICE:  Cleared queue for pk_docs_text_body_chunks
+NOTICE:  Re-chunking with strategy=token_based, size=400, overlap=50
+NOTICE:  Processed 1 rows
+ recreate_chunks 
+-----------------
+               1
+(1 row)
+
+SELECT count(*) > 0 AS text_pk_chunks_after_recreate FROM pk_docs_text_body_chunks;
+ text_pk_chunks_after_recreate 
+-------------------------------
+ t
+(1 row)
+
+-- Clean up
+SELECT pgedge_vectorizer.disable_vectorization('pk_docs_bigint', 'body', true);
+NOTICE:  Vectorization disabled and chunk table dropped: pk_docs_bigint_body_chunks
+ disable_vectorization 
+-----------------------
+ 
+(1 row)
+
+SELECT pgedge_vectorizer.disable_vectorization('pk_docs_text', 'body', true);
+NOTICE:  Vectorization disabled and chunk table dropped: pk_docs_text_body_chunks
+ disable_vectorization 
+-----------------------
+ 
+(1 row)
+
+DROP TABLE pk_docs_bigint;
+DROP TABLE pk_docs_text;

--- a/test/expected/pk_type_session.out
+++ b/test/expected/pk_type_session.out
@@ -94,6 +94,87 @@ SELECT count(*) > 0 AS text_pk_chunks_after_recreate FROM pk_docs_text_body_chun
  t
 (1 row)
 
+-- The fix casts the RECORD field to text unconditionally, so it must not
+-- depend on which order the types are seen in. Repeat with a fresh pair of
+-- tables in the opposite order: text first this time, to seed the callsite's
+-- cached parameter type with text instead of bigint, then bigint second.
+CREATE TABLE pk_docs_text_first (doc_key TEXT PRIMARY KEY, body TEXT);
+INSERT INTO pk_docs_text_first VALUES ('k1', repeat('eta theta iota ', 20));
+SELECT pgedge_vectorizer.enable_vectorization('pk_docs_text_first', 'body',
+                                              source_pk => 'doc_key',
+                                              embedding_dimension => 3);
+NOTICE:  Using primary key column: doc_key (text)
+NOTICE:  column "sparse_embedding" of relation "pk_docs_text_first_body_chunks" already exists, skipping
+NOTICE:  Vectorization enabled: pk_docs_text_first -> pk_docs_text_first_body_chunks
+NOTICE:  Strategy: token_based, chunk_size: 400, overlap: 50
+NOTICE:  Processing existing rows...
+NOTICE:  Processed 1 existing rows
+ enable_vectorization 
+----------------------
+ 
+(1 row)
+
+SELECT count(*) > 0 AS text_first_has_chunks FROM pk_docs_text_first_body_chunks;
+ text_first_has_chunks 
+-----------------------
+ t
+(1 row)
+
+CREATE TABLE pk_docs_bigint_second (id BIGSERIAL PRIMARY KEY, body TEXT);
+INSERT INTO pk_docs_bigint_second (body) VALUES (repeat('kappa lambda mu ', 20));
+SELECT pgedge_vectorizer.enable_vectorization('pk_docs_bigint_second', 'body',
+                                              embedding_dimension => 3);
+NOTICE:  Using primary key column: id (bigint)
+NOTICE:  column "sparse_embedding" of relation "pk_docs_bigint_second_body_chunks" already exists, skipping
+NOTICE:  Vectorization enabled: pk_docs_bigint_second -> pk_docs_bigint_second_body_chunks
+NOTICE:  Strategy: token_based, chunk_size: 400, overlap: 50
+NOTICE:  Processing existing rows...
+NOTICE:  Processed 1 existing rows
+ enable_vectorization 
+----------------------
+ 
+(1 row)
+
+SELECT count(*) > 0 AS bigint_second_has_chunks FROM pk_docs_bigint_second_body_chunks;
+ bigint_second_has_chunks 
+--------------------------
+ t
+(1 row)
+
+SELECT pgedge_vectorizer.recreate_chunks('pk_docs_text_first', 'body');
+NOTICE:  Recreating chunks for pk_docs_text_first.body -> pk_docs_text_first_body_chunks
+NOTICE:  Deleted 0 existing chunks
+NOTICE:  Cleared queue for pk_docs_text_first_body_chunks
+NOTICE:  Re-chunking with strategy=token_based, size=400, overlap=50
+NOTICE:  Processed 1 rows
+ recreate_chunks 
+-----------------
+               1
+(1 row)
+
+SELECT count(*) > 0 AS text_first_chunks_after_recreate FROM pk_docs_text_first_body_chunks;
+ text_first_chunks_after_recreate 
+----------------------------------
+ t
+(1 row)
+
+SELECT pgedge_vectorizer.recreate_chunks('pk_docs_bigint_second', 'body');
+NOTICE:  Recreating chunks for pk_docs_bigint_second.body -> pk_docs_bigint_second_body_chunks
+NOTICE:  Deleted 0 existing chunks
+NOTICE:  Cleared queue for pk_docs_bigint_second_body_chunks
+NOTICE:  Re-chunking with strategy=token_based, size=400, overlap=50
+NOTICE:  Processed 1 rows
+ recreate_chunks 
+-----------------
+               1
+(1 row)
+
+SELECT count(*) > 0 AS bigint_second_chunks_after_recreate FROM pk_docs_bigint_second_body_chunks;
+ bigint_second_chunks_after_recreate 
+-------------------------------------
+ t
+(1 row)
+
 -- Clean up
 SELECT pgedge_vectorizer.disable_vectorization('pk_docs_bigint', 'body', true);
 NOTICE:  Vectorization disabled and chunk table dropped: pk_docs_bigint_body_chunks
@@ -109,5 +190,21 @@ NOTICE:  Vectorization disabled and chunk table dropped: pk_docs_text_body_chunk
  
 (1 row)
 
+SELECT pgedge_vectorizer.disable_vectorization('pk_docs_text_first', 'body', true);
+NOTICE:  Vectorization disabled and chunk table dropped: pk_docs_text_first_body_chunks
+ disable_vectorization 
+-----------------------
+ 
+(1 row)
+
+SELECT pgedge_vectorizer.disable_vectorization('pk_docs_bigint_second', 'body', true);
+NOTICE:  Vectorization disabled and chunk table dropped: pk_docs_bigint_second_body_chunks
+ disable_vectorization 
+-----------------------
+ 
+(1 row)
+
 DROP TABLE pk_docs_bigint;
 DROP TABLE pk_docs_text;
+DROP TABLE pk_docs_text_first;
+DROP TABLE pk_docs_bigint_second;

--- a/test/sql/pk_type_session.sql
+++ b/test/sql/pk_type_session.sql
@@ -37,8 +37,35 @@ SELECT count(*) > 0 AS bigint_pk_chunks_after_recreate FROM pk_docs_bigint_body_
 SELECT pgedge_vectorizer.recreate_chunks('pk_docs_text', 'body');
 SELECT count(*) > 0 AS text_pk_chunks_after_recreate FROM pk_docs_text_body_chunks;
 
+-- The fix casts the RECORD field to text unconditionally, so it must not
+-- depend on which order the types are seen in. Repeat with a fresh pair of
+-- tables in the opposite order: text first this time, to seed the callsite's
+-- cached parameter type with text instead of bigint, then bigint second.
+CREATE TABLE pk_docs_text_first (doc_key TEXT PRIMARY KEY, body TEXT);
+INSERT INTO pk_docs_text_first VALUES ('k1', repeat('eta theta iota ', 20));
+SELECT pgedge_vectorizer.enable_vectorization('pk_docs_text_first', 'body',
+                                              source_pk => 'doc_key',
+                                              embedding_dimension => 3);
+SELECT count(*) > 0 AS text_first_has_chunks FROM pk_docs_text_first_body_chunks;
+
+CREATE TABLE pk_docs_bigint_second (id BIGSERIAL PRIMARY KEY, body TEXT);
+INSERT INTO pk_docs_bigint_second (body) VALUES (repeat('kappa lambda mu ', 20));
+SELECT pgedge_vectorizer.enable_vectorization('pk_docs_bigint_second', 'body',
+                                              embedding_dimension => 3);
+SELECT count(*) > 0 AS bigint_second_has_chunks FROM pk_docs_bigint_second_body_chunks;
+
+SELECT pgedge_vectorizer.recreate_chunks('pk_docs_text_first', 'body');
+SELECT count(*) > 0 AS text_first_chunks_after_recreate FROM pk_docs_text_first_body_chunks;
+
+SELECT pgedge_vectorizer.recreate_chunks('pk_docs_bigint_second', 'body');
+SELECT count(*) > 0 AS bigint_second_chunks_after_recreate FROM pk_docs_bigint_second_body_chunks;
+
 -- Clean up
 SELECT pgedge_vectorizer.disable_vectorization('pk_docs_bigint', 'body', true);
 SELECT pgedge_vectorizer.disable_vectorization('pk_docs_text', 'body', true);
+SELECT pgedge_vectorizer.disable_vectorization('pk_docs_text_first', 'body', true);
+SELECT pgedge_vectorizer.disable_vectorization('pk_docs_bigint_second', 'body', true);
 DROP TABLE pk_docs_bigint;
 DROP TABLE pk_docs_text;
+DROP TABLE pk_docs_text_first;
+DROP TABLE pk_docs_bigint_second;

--- a/test/sql/pk_type_session.sql
+++ b/test/sql/pk_type_session.sql
@@ -1,0 +1,44 @@
+-- Cross-session primary-key-type test (issue #39)
+--
+-- enable_vectorization() and recreate_chunks() both loop over source rows with
+-- FOR row_record IN EXECUTE ... LOOP, where row_record is declared RECORD and
+-- its pk_val field is later used as a dynamic EXECUTE ... USING parameter.
+-- PL/pgSQL fixes a RECORD field's parameter type the first time that callsite
+-- is evaluated in a session, and reusing the same callsite with a different
+-- underlying type raises "type of parameter N (T2) does not match that when
+-- preparing the plan (T1)". This can only be exercised with two calls sharing
+-- one session, which is why it lives in its own test file rather than being
+-- split across several, unlike the non-default-key coverage added for #24.
+
+-- A bigint primary key first, to seed the callsite's cached parameter type.
+CREATE TABLE pk_docs_bigint (id BIGSERIAL PRIMARY KEY, body TEXT);
+INSERT INTO pk_docs_bigint (body) VALUES (repeat('alpha beta gamma ', 20));
+SELECT pgedge_vectorizer.enable_vectorization('pk_docs_bigint', 'body',
+                                              embedding_dimension => 3);
+SELECT count(*) > 0 AS bigint_pk_has_chunks FROM pk_docs_bigint_body_chunks;
+
+-- A text primary key second, in the same session. This is what fails on
+-- unmodified main: it aborts partway through "Processing existing rows...",
+-- after the chunk table, indexes and trigger already exist.
+CREATE TABLE pk_docs_text (doc_key TEXT PRIMARY KEY, body TEXT);
+INSERT INTO pk_docs_text VALUES ('k1', repeat('delta epsilon zeta ', 20));
+SELECT pgedge_vectorizer.enable_vectorization('pk_docs_text', 'body',
+                                              source_pk => 'doc_key',
+                                              embedding_dimension => 3);
+SELECT count(*) > 0 AS text_pk_has_chunks FROM pk_docs_text_body_chunks;
+
+-- recreate_chunks() has the identical bug through the same mechanism, and its
+-- existing "$1::%s" cast at the INSERT does not protect it: the cache trips on
+-- the raw type PostgreSQL binds for the parameter, before any cast in the SQL
+-- text is applied. Exercise it back-to-back across the two PK types too.
+SELECT pgedge_vectorizer.recreate_chunks('pk_docs_bigint', 'body');
+SELECT count(*) > 0 AS bigint_pk_chunks_after_recreate FROM pk_docs_bigint_body_chunks;
+
+SELECT pgedge_vectorizer.recreate_chunks('pk_docs_text', 'body');
+SELECT count(*) > 0 AS text_pk_chunks_after_recreate FROM pk_docs_text_body_chunks;
+
+-- Clean up
+SELECT pgedge_vectorizer.disable_vectorization('pk_docs_bigint', 'body', true);
+SELECT pgedge_vectorizer.disable_vectorization('pk_docs_text', 'body', true);
+DROP TABLE pk_docs_bigint;
+DROP TABLE pk_docs_text;


### PR DESCRIPTION
## Summary

Fixes #39. Calling `enable_vectorization()` for a table with one primary key type and then, in the same session, a table with a different primary key type failed with `type of parameter N (T2) does not match that when preparing the plan (T1)`, aborting after the chunk table and trigger had already been created and leaving the second column's vectorizer half set up. `recreate_chunks()` had the identical bug.

## Root cause

Both functions loop over existing source rows into a variable declared `RECORD`, then pass one of its fields (the primary key value) to a dynamic `EXECUTE ... USING` statement. PL/pgSQL fixes the parameter type of a RECORD field the first time that statement runs, and reuses it on every later call within the same session. The first table's PK type (say `bigint`) gets locked in, and a later table whose PK is `text` fails.

Confirmed with a minimal repro that has nothing to do with this extension's code, `LOCATION: plpgsql_param_eval_recfield, pl_exec.c:6798`:

```sql
FOR row_record IN EXECUTE format('SELECT %s AS pk_val', id_expr) LOOP
    EXECUTE format('SELECT $1::text', tbl) USING row_record.pk_val INTO out_val;
END LOOP;
```

Two calls with different underlying types for `id_expr` reproduce the exact error, with no reference to the extension at all.

I also tested, and disproved, the tempting fix of casting at the *USING call site* (`row_record.pk_val::text`) — it still fails, because PostgreSQL binds the RECORD field's raw runtime type before any cast written into the later query text is applied. The only fix that holds is casting at the *source*, in the SELECT that populates the RECORD variable, so the field is a fixed type across every future call regardless of the actual source table.

`recreate_chunks()` is a good illustration of why this matters: its INSERT already does `$1::%s` to cast the parameter to the real PK type, and it was **still broken**, because that cast happens after the type has already been bound.

## Why the existing test suite never caught this

`test/sql/pk_types.sql` exercises many PK types (`UUID`, `SERIAL`, `TEXT`, `VARCHAR`, composite, etc.) in one session, which looks like it should have hit this. It doesn't, because every one of its `enable_vectorization()` calls runs against an **empty** table — rows are inserted afterwards. The "processing existing rows" loop body, where the bug lives, therefore has zero iterations and the vulnerable statement is never evaluated for any of the tested types. The new test inserts a row first, specifically to exercise that path, and reproducibly fails against unmodified `main` before this fix.

## Fix

Cast the primary key value to `text` in the `SELECT` that populates the loop's `RECORD` variable, in both `enable_vectorization()` and `recreate_chunks()`, so the field's type never varies. Add an explicit `$1::%s` cast back to the real PK type at the one site that needed it (`enable_vectorization()`'s chunk INSERT); `recreate_chunks()` and the two DELETE statements in `enable_vectorization()` already had that cast.

Both `sql/pgedge_vectorizer--1.1.sql` and `sql/pgedge_vectorizer--1.0--1.1.sql` are changed identically, keeping the fresh install and the 1.0 upgrade path in step.

## Test plan

- [x] New regression test fails against unmodified `main` with exactly the reported error, and passes after the fix
- [x] `recreate_chunks()` exercised back-to-back across both PK types too, since it shares the root cause
- [x] Verified through a real `ALTER EXTENSION ... UPDATE TO '1.1'`: vectorize a bigint-keyed table on 1.0, upgrade, vectorize a text-keyed table, no error
- [x] All 16 regression tests pass from a clean build with no new warnings

Closes #39