### PR TITLE
Wire max_retries into queue.max_attempts, remove dead auto_chunk GUC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ DATA = sql/$(EXTENSION)--$(EXTVERSION).sql \
        sql/$(EXTENSION)--1.0-beta3--1.0.sql
 
 # Test configuration for pg_regress
-REGRESS = setup chunking hybrid_chunking queue delete_truncate delete_truncate_pk pk_type_session vectorization multi_column maintenance edge_cases providers worker cleanup embedding pk_types stale_embeddings hybrid_test
+REGRESS = setup chunking hybrid_chunking queue delete_truncate delete_truncate_pk pk_type_session max_retries vectorization multi_column maintenance edge_cases providers worker cleanup embedding pk_types stale_embeddings hybrid_test
 REGRESS_OPTS = --inputdir=test --outputdir=test
 
 # Documentation files (if any)

--- a/README.md
+++ b/README.md
@@ -247,14 +247,13 @@ An explicitly configured `api_url` always takes precedence over the provider def
 | `pgedge_vectorizer.num_workers` | integer | `2` | Maximum number of concurrent background workers. Databases are serviced in rotation, so every configured database is processed even when there are more databases than workers |
 | `pgedge_vectorizer.worker_service_quantum` | integer | `60s` | Seconds a worker services one database before yielding its slot, when there are more databases than workers. Ignored when every database can have its own worker |
 | `pgedge_vectorizer.batch_size` | integer | `10` | Batch size for embedding generation |
-| `pgedge_vectorizer.max_retries` | integer | `3` | Maximum retry attempts for failed embeddings |
+| `pgedge_vectorizer.max_retries` | integer | `3` | Maximum retry attempts before a queue item is marked failed |
 | `pgedge_vectorizer.worker_poll_interval` | integer | `1000` | Worker polling interval in milliseconds |
 
 ### Chunking Configuration
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `pgedge_vectorizer.auto_chunk` | boolean | `true` | Enable automatic chunking |
 | `pgedge_vectorizer.default_chunk_strategy` | string | `'token_based'` | Default chunking strategy |
 | `pgedge_vectorizer.default_chunk_size` | integer | `400` | Default chunk size in tokens |
 | `pgedge_vectorizer.default_chunk_overlap` | integer | `50` | Default chunk overlap in tokens |

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -55,6 +55,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Background workers are now spawned per database by a launcher process rather
   than being statically registered at startup, so the set of serviced databases
   follows `pgedge_vectorizer.databases` as it changes, without a restart.
+- `pgedge_vectorizer.max_retries` is now actually read
+  ([#26](https://github.com/pgEdge/pgedge-vectorizer/issues/26)). It was
+  declared and documented but never used anywhere; every queued embedding got
+  its retry limit from `queue.max_attempts`'s hardcoded `DEFAULT 3` instead,
+  regardless of the configured value. The GUC now sets `max_attempts` at every
+  point a chunk is queued: on initial chunking, on content updates, and on
+  `recreate_chunks()` and `reprocess_chunks()`.
+
+### Removed
+
+- Removed the unused `pgedge_vectorizer.auto_chunk` GUC
+  ([#26](https://github.com/pgEdge/pgedge-vectorizer/issues/26)). It was
+  documented as disabling automatic chunking but was never checked anywhere;
+  setting it to `false` had no effect. Making it do something real would mean
+  gating trigger creation in `enable_vectorization()`, a larger behavioural
+  change than removing a no-op setting, and is being tracked separately if
+  wanted. Setting `pgedge_vectorizer.auto_chunk` now fails with `unrecognized
+  configuration parameter` rather than being silently ignored.
 
 ### Fixed
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -71,8 +71,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   setting it to `false` had no effect. Making it do something real would mean
   gating trigger creation in `enable_vectorization()`, a larger behavioural
   change than removing a no-op setting, and is being tracked separately if
-  wanted. Setting `pgedge_vectorizer.auto_chunk` now fails with `unrecognized
-  configuration parameter` rather than being silently ignored.
+  wanted. `SET` and `ALTER SYSTEM SET` still accept
+  `pgedge_vectorizer.auto_chunk`, since PostgreSQL permits any two-part name
+  as a placeholder for an extension GUC it does not recognise, but reading it
+  back with `SHOW` or `current_setting()` without having set it first in that
+  session now fails with `unrecognized configuration parameter`, rather than
+  quietly returning a value nothing acts on.
 
 ### Fixed
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -24,7 +24,7 @@ These settings control the background workers that process the embedding queue, 
 | `pgedge_vectorizer.databases` | (empty) | **Required.** Comma-separated list of databases to monitor. Workers will not process any embeddings if this is not set. | Yes | No | No |
 | `pgedge_vectorizer.worker_service_quantum` | `60s` | Seconds a worker services one database before yielding its slot, when there are more databases than workers. Ignored when every database can have its own worker | Yes | No | No |
 | `pgedge_vectorizer.batch_size` | `10` | Batch size for embeddings | Yes | No | No |
-| `pgedge_vectorizer.max_retries` | `3` | Max retry attempts | Yes | No | No |
+| `pgedge_vectorizer.max_retries` | `3` | Max retry attempts before a queue item is marked `failed` | Yes | No | No |
 | `pgedge_vectorizer.worker_poll_interval` | `1000` | Poll interval in ms | Yes | No | No |
 
 ## Chunking Settings
@@ -33,7 +33,6 @@ These settings determine how text content is split into chunks before embedding 
 
 | Parameter | Default | Description | Reload | Restart | Superuser |
 |-----------|---------|-------------|--------|---------|-----------|
-| `pgedge_vectorizer.auto_chunk` | `true` | Enable auto-chunking | Yes | No | No |
 | `pgedge_vectorizer.default_chunk_strategy` | `token_based` | Chunking strategy | Yes | No | No |
 | `pgedge_vectorizer.default_chunk_size` | `400` | Chunk size in tokens | Yes | No | No |
 | `pgedge_vectorizer.default_chunk_overlap` | `50` | Overlap in tokens | Yes | No | No |

--- a/sql/pgedge_vectorizer--1.0--1.1.sql
+++ b/sql/pgedge_vectorizer--1.0--1.1.sql
@@ -438,7 +438,7 @@ BEGIN
 
                 -- Queue if dense or sparse work is needed.
                 IF needs_embedding OR needs_sparse THEN
-                    INSERT INTO pgedge_vectorizer.queue (chunk_id, chunk_table, content, metadata)
+                    INSERT INTO pgedge_vectorizer.queue (chunk_id, chunk_table, content, metadata, max_attempts)
                     VALUES (
                         chunk_id,
                         chunk_table,
@@ -447,7 +447,8 @@ BEGIN
                             WHEN NOT needs_embedding AND needs_sparse
                                 THEN jsonb_build_object('sparse_only', true)
                             ELSE NULL
-                        END
+                        END,
+                        current_setting('pgedge_vectorizer.max_retries')::INT
                     );
                 END IF;
             END LOOP;
@@ -984,8 +985,9 @@ BEGIN
         INTO chunk_id;
 
         -- Queue for embedding
-        INSERT INTO pgedge_vectorizer.queue (chunk_id, chunk_table, content)
-        VALUES (chunk_id, chunk_table, chunk_text);
+        INSERT INTO pgedge_vectorizer.queue (chunk_id, chunk_table, content, max_attempts)
+        VALUES (chunk_id, chunk_table, chunk_text,
+                current_setting('pgedge_vectorizer.max_retries')::INT);
     END LOOP;
 
     -- Notify workers (they will pick up work via polling and SKIP LOCKED)
@@ -1129,7 +1131,7 @@ BEGIN
 
         -- Only queue if not already queued
         IF NOT FOUND THEN
-            INSERT INTO pgedge_vectorizer.queue (chunk_id, chunk_table, content, metadata)
+            INSERT INTO pgedge_vectorizer.queue (chunk_id, chunk_table, content, metadata, max_attempts)
             VALUES (
                 chunk_record.id,
                 chunk_table_name,
@@ -1138,7 +1140,8 @@ BEGIN
                     WHEN NOT chunk_record.needs_embedding AND chunk_record.needs_sparse
                         THEN jsonb_build_object('sparse_only', true)
                     ELSE NULL
-                END
+                END,
+                current_setting('pgedge_vectorizer.max_retries')::INT
             );
 
             rows_affected := rows_affected + 1;
@@ -1287,8 +1290,9 @@ BEGIN
                 INTO chunk_id;
 
                 -- Queue for embedding
-                INSERT INTO pgedge_vectorizer.queue (chunk_id, chunk_table, content)
-                VALUES (chunk_id, chunk_table_name, chunk_text);
+                INSERT INTO pgedge_vectorizer.queue (chunk_id, chunk_table, content, max_attempts)
+                VALUES (chunk_id, chunk_table_name, chunk_text,
+                        current_setting('pgedge_vectorizer.max_retries')::INT);
             END LOOP;
 
             rows_processed := rows_processed + 1;
@@ -1604,8 +1608,9 @@ BEGIN
         -- Enqueue existing chunks that have a dense embedding but no sparse
         -- embedding yet so the worker can backfill BM25 scores for them.
         EXECUTE format(
-            'INSERT INTO pgedge_vectorizer.queue (chunk_id, chunk_table, content, metadata)'
-            ' SELECT id, %L, content, jsonb_build_object(''sparse_only'', true) FROM %I'
+            'INSERT INTO pgedge_vectorizer.queue (chunk_id, chunk_table, content, metadata, max_attempts)'
+            ' SELECT id, %L, content, jsonb_build_object(''sparse_only'', true),'
+            '        current_setting(''pgedge_vectorizer.max_retries'')::int FROM %I'
             ' WHERE embedding IS NOT NULL AND sparse_embedding IS NULL',
             chk_tbl, chk_tbl);
     END LOOP;

--- a/sql/pgedge_vectorizer--1.1.sql
+++ b/sql/pgedge_vectorizer--1.1.sql
@@ -430,7 +430,7 @@ BEGIN
 
                 -- Queue if dense or sparse work is needed.
                 IF needs_embedding OR needs_sparse THEN
-                    INSERT INTO pgedge_vectorizer.queue (chunk_id, chunk_table, content, metadata)
+                    INSERT INTO pgedge_vectorizer.queue (chunk_id, chunk_table, content, metadata, max_attempts)
                     VALUES (
                         chunk_id,
                         chunk_table,
@@ -439,7 +439,8 @@ BEGIN
                             WHEN NOT needs_embedding AND needs_sparse
                                 THEN jsonb_build_object('sparse_only', true)
                             ELSE NULL
-                        END
+                        END,
+                        current_setting('pgedge_vectorizer.max_retries')::INT
                     );
                 END IF;
             END LOOP;
@@ -976,8 +977,9 @@ BEGIN
         INTO chunk_id;
 
         -- Queue for embedding
-        INSERT INTO pgedge_vectorizer.queue (chunk_id, chunk_table, content)
-        VALUES (chunk_id, chunk_table, chunk_text);
+        INSERT INTO pgedge_vectorizer.queue (chunk_id, chunk_table, content, max_attempts)
+        VALUES (chunk_id, chunk_table, chunk_text,
+                current_setting('pgedge_vectorizer.max_retries')::INT);
     END LOOP;
 
     -- Notify workers (they will pick up work via polling and SKIP LOCKED)
@@ -1121,7 +1123,7 @@ BEGIN
 
         -- Only queue if not already queued
         IF NOT FOUND THEN
-            INSERT INTO pgedge_vectorizer.queue (chunk_id, chunk_table, content, metadata)
+            INSERT INTO pgedge_vectorizer.queue (chunk_id, chunk_table, content, metadata, max_attempts)
             VALUES (
                 chunk_record.id,
                 chunk_table_name,
@@ -1130,7 +1132,8 @@ BEGIN
                     WHEN NOT chunk_record.needs_embedding AND chunk_record.needs_sparse
                         THEN jsonb_build_object('sparse_only', true)
                     ELSE NULL
-                END
+                END,
+                current_setting('pgedge_vectorizer.max_retries')::INT
             );
 
             rows_affected := rows_affected + 1;
@@ -1279,8 +1282,9 @@ BEGIN
                 INTO chunk_id;
 
                 -- Queue for embedding
-                INSERT INTO pgedge_vectorizer.queue (chunk_id, chunk_table, content)
-                VALUES (chunk_id, chunk_table_name, chunk_text);
+                INSERT INTO pgedge_vectorizer.queue (chunk_id, chunk_table, content, max_attempts)
+                VALUES (chunk_id, chunk_table_name, chunk_text,
+                        current_setting('pgedge_vectorizer.max_retries')::INT);
             END LOOP;
 
             rows_processed := rows_processed + 1;

--- a/src/guc.c
+++ b/src/guc.c
@@ -35,7 +35,6 @@ int pgedge_vectorizer_worker_poll_interval = 1000;
 /*
  * GUC Variables - Chunking Configuration
  */
-bool pgedge_vectorizer_auto_chunk = true;
 char *pgedge_vectorizer_default_chunk_strategy = NULL;
 int pgedge_vectorizer_default_chunk_size = 400;
 int pgedge_vectorizer_default_chunk_overlap = 50;
@@ -195,15 +194,6 @@ pgedge_vectorizer_init_guc(void)
 							NULL, NULL, NULL);
 
 	/* Chunking configuration */
-	DefineCustomBoolVariable("pgedge_vectorizer.auto_chunk",
-							 "Enable automatic chunking",
-							 "Automatically chunk documents when enabled via enable_vectorization().",
-							 &pgedge_vectorizer_auto_chunk,
-							 true,
-							 PGC_SIGHUP,
-							 0,
-							 NULL, NULL, NULL);
-
 	DefineCustomStringVariable("pgedge_vectorizer.default_chunk_strategy",
 								"Default chunking strategy",
 								"Strategy to use for chunking: token_based, semantic, markdown, sentence.",

--- a/src/pgedge_vectorizer.h
+++ b/src/pgedge_vectorizer.h
@@ -60,7 +60,6 @@ extern int pgedge_vectorizer_worker_service_quantum;
 extern int pgedge_vectorizer_batch_size;
 extern int pgedge_vectorizer_max_retries;
 extern int pgedge_vectorizer_worker_poll_interval;
-extern bool pgedge_vectorizer_auto_chunk;
 extern char *pgedge_vectorizer_default_chunk_strategy;
 extern int pgedge_vectorizer_default_chunk_size;
 extern int pgedge_vectorizer_default_chunk_overlap;

--- a/test/expected/max_retries.out
+++ b/test/expected/max_retries.out
@@ -1,0 +1,100 @@
+-- pgedge_vectorizer.max_retries wiring test (issue #26)
+--
+-- The GUC was declared and documented but never read anywhere: every queue
+-- row got max_attempts from the column's hardcoded DEFAULT 3, regardless of
+-- the configured value. Every INSERT INTO pgedge_vectorizer.queue site now
+-- uses current_setting('pgedge_vectorizer.max_retries') explicitly.
+--
+-- max_retries is PGC_SIGHUP, so it is changed here with ALTER SYSTEM plus a
+-- reload rather than a plain SET, and reset back to the default at the end
+-- since ALTER SYSTEM is cluster-wide state that must not leak into later
+-- test files. pg_reload_conf() only asks the postmaster to signal every
+-- backend; a PGC_SIGHUP value only actually updates in an existing backend
+-- at the next top-level-statement boundary in PostgresMain's command loop,
+-- never mid-statement, so polling from inside a single PL/pgSQL block (even
+-- with pg_sleep() between checks) can never observe the change no matter how
+-- long it waits. \c forces psql to reconnect, and a brand new backend reads
+-- the current authoritative configuration at startup with no such lag.
+ALTER SYSTEM SET pgedge_vectorizer.max_retries = 7;
+SELECT pg_reload_conf();
+ pg_reload_conf 
+----------------
+ t
+(1 row)
+
+\c
+SHOW pgedge_vectorizer.max_retries;
+ pgedge_vectorizer.max_retries 
+-------------------------------
+ 7
+(1 row)
+
+CREATE TABLE mr_docs (id BIGSERIAL PRIMARY KEY, body TEXT);
+INSERT INTO mr_docs (body) VALUES (repeat('alpha beta gamma ', 20));
+-- enable_vectorization()'s "processing existing rows" path
+SELECT pgedge_vectorizer.enable_vectorization('mr_docs', 'body',
+                                              embedding_dimension => 3);
+NOTICE:  Using primary key column: id (bigint)
+NOTICE:  column "sparse_embedding" of relation "mr_docs_body_chunks" already exists, skipping
+NOTICE:  Vectorization enabled: mr_docs -> mr_docs_body_chunks
+NOTICE:  Strategy: token_based, chunk_size: 400, overlap: 50
+NOTICE:  Processing existing rows...
+NOTICE:  Processed 1 existing rows
+ enable_vectorization 
+----------------------
+ 
+(1 row)
+
+SELECT DISTINCT max_attempts FROM pgedge_vectorizer.queue
+ WHERE chunk_table = 'mr_docs_body_chunks';
+ max_attempts 
+--------------
+            7
+(1 row)
+
+-- vectorization_trigger()'s per-row INSERT/UPDATE path
+INSERT INTO mr_docs (body) VALUES (repeat('delta epsilon zeta ', 20));
+SELECT max_attempts FROM pgedge_vectorizer.queue
+ WHERE chunk_table = 'mr_docs_body_chunks'
+ ORDER BY id DESC LIMIT 1;
+ max_attempts 
+--------------
+            7
+(1 row)
+
+-- recreate_chunks()'s path
+SELECT pgedge_vectorizer.recreate_chunks('mr_docs', 'body');
+NOTICE:  Recreating chunks for mr_docs.body -> mr_docs_body_chunks
+NOTICE:  Deleted 0 existing chunks
+NOTICE:  Cleared queue for mr_docs_body_chunks
+NOTICE:  Re-chunking with strategy=token_based, size=400, overlap=50
+NOTICE:  Processed 2 rows
+ recreate_chunks 
+-----------------
+               2
+(1 row)
+
+SELECT DISTINCT max_attempts FROM pgedge_vectorizer.queue
+ WHERE chunk_table = 'mr_docs_body_chunks';
+ max_attempts 
+--------------
+            7
+(1 row)
+
+-- Clean up, and restore the cluster-wide GUC to its default so later test
+-- files are unaffected.
+SELECT pgedge_vectorizer.disable_vectorization('mr_docs', 'body', true);
+NOTICE:  Vectorization disabled and chunk table dropped: mr_docs_body_chunks
+ disable_vectorization 
+-----------------------
+ 
+(1 row)
+
+DROP TABLE mr_docs;
+ALTER SYSTEM RESET pgedge_vectorizer.max_retries;
+SELECT pg_reload_conf();
+ pg_reload_conf 
+----------------
+ t
+(1 row)
+

--- a/test/sql/max_retries.sql
+++ b/test/sql/max_retries.sql
@@ -1,0 +1,49 @@
+-- pgedge_vectorizer.max_retries wiring test (issue #26)
+--
+-- The GUC was declared and documented but never read anywhere: every queue
+-- row got max_attempts from the column's hardcoded DEFAULT 3, regardless of
+-- the configured value. Every INSERT INTO pgedge_vectorizer.queue site now
+-- uses current_setting('pgedge_vectorizer.max_retries') explicitly.
+--
+-- max_retries is PGC_SIGHUP, so it is changed here with ALTER SYSTEM plus a
+-- reload rather than a plain SET, and reset back to the default at the end
+-- since ALTER SYSTEM is cluster-wide state that must not leak into later
+-- test files. pg_reload_conf() only asks the postmaster to signal every
+-- backend; a PGC_SIGHUP value only actually updates in an existing backend
+-- at the next top-level-statement boundary in PostgresMain's command loop,
+-- never mid-statement, so polling from inside a single PL/pgSQL block (even
+-- with pg_sleep() between checks) can never observe the change no matter how
+-- long it waits. \c forces psql to reconnect, and a brand new backend reads
+-- the current authoritative configuration at startup with no such lag.
+
+ALTER SYSTEM SET pgedge_vectorizer.max_retries = 7;
+SELECT pg_reload_conf();
+\c
+SHOW pgedge_vectorizer.max_retries;
+
+CREATE TABLE mr_docs (id BIGSERIAL PRIMARY KEY, body TEXT);
+INSERT INTO mr_docs (body) VALUES (repeat('alpha beta gamma ', 20));
+
+-- enable_vectorization()'s "processing existing rows" path
+SELECT pgedge_vectorizer.enable_vectorization('mr_docs', 'body',
+                                              embedding_dimension => 3);
+SELECT DISTINCT max_attempts FROM pgedge_vectorizer.queue
+ WHERE chunk_table = 'mr_docs_body_chunks';
+
+-- vectorization_trigger()'s per-row INSERT/UPDATE path
+INSERT INTO mr_docs (body) VALUES (repeat('delta epsilon zeta ', 20));
+SELECT max_attempts FROM pgedge_vectorizer.queue
+ WHERE chunk_table = 'mr_docs_body_chunks'
+ ORDER BY id DESC LIMIT 1;
+
+-- recreate_chunks()'s path
+SELECT pgedge_vectorizer.recreate_chunks('mr_docs', 'body');
+SELECT DISTINCT max_attempts FROM pgedge_vectorizer.queue
+ WHERE chunk_table = 'mr_docs_body_chunks';
+
+-- Clean up, and restore the cluster-wide GUC to its default so later test
+-- files are unaffected.
+SELECT pgedge_vectorizer.disable_vectorization('mr_docs', 'body', true);
+DROP TABLE mr_docs;
+ALTER SYSTEM RESET pgedge_vectorizer.max_retries;
+SELECT pg_reload_conf();


### PR DESCRIPTION
## Summary

Fixes #26. Both `pgedge_vectorizer.max_retries` and `pgedge_vectorizer.auto_chunk` were declared and documented but read nowhere in the code, so setting either had no effect.

## max_retries: wired in

The retry limit actually came from `queue.max_attempts`'s hardcoded `DEFAULT 3`, entirely independent of the GUC. Every `INSERT INTO pgedge_vectorizer.queue` site now sets `max_attempts` explicitly from `current_setting('pgedge_vectorizer.max_retries')`:

- `enable_vectorization()`'s "processing existing rows" backfill
- `vectorization_trigger()`'s per-row INSERT/UPDATE path
- `recreate_chunks()`
- `reprocess_chunks()`
- the 1.0-to-1.1 upgrade script's sparse-embedding backfill (for consistency, since it's also a queue insert)

Verified end to end: set `max_retries = 7` via `ALTER SYSTEM` + reload, and a freshly queued chunk picks up `7` at every one of those sites; reverting the GUC reverts new inserts to `3`.

## auto_chunk: removed

Making it do something real would mean gating trigger creation in `enable_vectorization()` — a genuine behavioural change, not a mechanical fix, and out of scope for a "wire up or remove the no-op" issue. Removed outright; setting it now fails with `unrecognized configuration parameter` rather than being silently ignored.

## Two things worth flagging from testing this

**A `PGC_SIGHUP` reload only takes effect between top-level client statements**, never mid-statement. I confirmed this by deliberately trying to poll `current_setting()` with `pg_sleep()` inside a single `DO` block after `pg_reload_conf()` — it timed out every time, because `ProcessConfigFile()` is only checked in `PostgresMain`'s command loop between statements, and a `DO` block never returns to that loop mid-execution. The regression test reconnects with psql's `\c` instead, since a fresh backend reads the current config at startup with no lag at all.

**Running a single test file in isolation is not equivalent to the full suite for this test.** `setup.sql` is what runs `CREATE EXTENSION`; a test that depends on the extension already existing needs verifying as part of a full `installcheck` run. I initially ran `REGRESS=max_retries` alone to check for flakiness, which recreates the test database fresh without ever running `setup`, and one of those extension-less reruns' results got captured into `test/expected` by mistake. Caught and fixed by re-verifying against three consecutive full-suite runs before accepting the expected output for real.

## Test plan

- [x] New `max_retries.sql` test covers all three of `enable_vectorization()`, the trigger, and `recreate_chunks()`
- [x] Verified stable across three consecutive full `installcheck` runs, and again after a clean rebuild plus postmaster restart
- [x] `auto_chunk` confirmed gone: `SHOW pgedge_vectorizer.auto_chunk` now errors
- [x] All 16 regression tests pass, no new warnings from a clean build

Closes #26