### PR TITLE
Dynamic worker follow up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,10 @@ test/isolationcheck_tmp_check/
 # PGXS creates tmp_check at the top level for TAP tests, since that is where
 # the Makefile invoking prove lives
 tmp_check/
+# PostgreSQL::Test writes its per-test logs alongside it, into log/. These are
+# named regress_log_* and *.log, so the *.log rule below does not cover them
+# all, and the directory has to be ignored outright.
+log/
 
 # PostgreSQL extension build files
 *.control.in

--- a/README.md
+++ b/README.md
@@ -438,6 +438,11 @@ ALTER SYSTEM SET pgedge_vectorizer.num_workers = 4;
 SELECT pg_reload_conf();
 ```
 
+Workers are drawn from `max_worker_processes`, so raising `num_workers` beyond
+the slots left spare there achieves nothing; the launcher simply logs that
+`max_worker_processes` may be exhausted and carries on with what it has.
+Raising `max_worker_processes` itself does require a restart.
+
 2. Increase batch size:
 ```sql
 ALTER SYSTEM SET pgedge_vectorizer.batch_size = 20;

--- a/README.md
+++ b/README.md
@@ -435,7 +435,7 @@ SELECT * FROM pgedge_vectorizer.failed_items;
 1. Increase number of workers:
 ```sql
 ALTER SYSTEM SET pgedge_vectorizer.num_workers = 4;
--- Restart required
+SELECT pg_reload_conf();
 ```
 
 2. Increase batch size:

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -40,6 +40,11 @@ ALTER SYSTEM SET pgedge_vectorizer.num_workers = 4;
 SELECT pg_reload_conf();
 ```
 
+Workers are drawn from `max_worker_processes`, so raising `num_workers` beyond
+the slots left spare there achieves nothing; the launcher simply logs that
+`max_worker_processes` may be exhausted and carries on with what it has.
+Raising `max_worker_processes` itself does require a restart.
+
 2. Increase batch size:
 ```sql
 ALTER SYSTEM SET pgedge_vectorizer.batch_size = 20;

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -37,7 +37,7 @@ SELECT pg_reload_conf();
 1. Increase workers:
 ```sql
 ALTER SYSTEM SET pgedge_vectorizer.num_workers = 4;
--- Requires restart
+SELECT pg_reload_conf();
 ```
 
 2. Increase batch size:

--- a/src/worker.c
+++ b/src/worker.c
@@ -359,12 +359,8 @@ database_has_worker(const char *dbname)
 }
 
 /*
- * One pass over the database list, spawning workers where they are missing.
- *
- * Databases are visited from a persistent cursor rather than always from the
- * head of the list. Combined with the service quantum that makes busy workers
- * relinquish their slots, this is what guarantees that every database is
- * eventually serviced when there are more databases than slots.
+ * Stop the newest workers until no more than num_workers remain, so that
+ * lowering num_workers takes effect without waiting for workers to yield.
  */
 static void
 launcher_retire_surplus(void)
@@ -427,6 +423,11 @@ launcher_retire_unconfigured(char **db_names, int db_count)
 
 /*
  * One pass over the database list, spawning workers where they are missing.
+ *
+ * Databases are visited from a persistent cursor rather than always from the
+ * head of the list. Combined with the service quantum that makes busy workers
+ * relinquish their slots, this is what guarantees that every database is
+ * eventually serviced when there are more databases than slots.
  */
 static void
 launcher_sweep(char **db_names, int db_count)

--- a/src/worker.c
+++ b/src/worker.c
@@ -50,11 +50,57 @@ typedef struct LauncherSlot
 	char		dbname[NAMEDATALEN];
 	BackgroundWorkerHandle *handle;
 	bool		terminating;	/* asked to stop; awaiting confirmation */
+	TimestampTz spawn_time;		/* when this worker was registered */
 } LauncherSlot;
 
 static LauncherSlot launcher_slots[PGEDGE_VECTORIZER_MAX_WORKERS];
 static int	launcher_nslots = 0;
 static int	launcher_cursor = 0;	/* round-robin position in the database list */
+
+/*
+ * Failed-start backoff.
+ *
+ * A worker that cannot start at all, because its database does not exist or
+ * will not accept connections, exits within a few milliseconds, and the exit
+ * notification brings the launcher straight back round to spawn a replacement.
+ * Nothing in the spawn path rate limits that, so the launcher forks as fast as
+ * the postmaster will oblige: left alone it burns thousands of PIDs a minute
+ * and fills the log at a comparable rate. A single mistyped name in
+ * pgedge_vectorizer.databases is enough to provoke it.
+ *
+ * A worker is judged to have failed to start if it exits within
+ * LAUNCHER_FAILED_START_MS of being spawned. Its database is then held off for
+ * an interval that doubles on each successive failure, from
+ * LAUNCHER_RETRY_INTERVAL_MIN_MS up to LAUNCHER_RETRY_INTERVAL_MAX_MS, which
+ * mirrors the extension-not-installed backoff in
+ * pgedge_vectorizer_worker_main(). A worker that lives longer than the
+ * threshold clears its database's backoff, so a database that recovers is
+ * serviced at full speed again.
+ *
+ * The threshold sits below the one second minimum of
+ * pgedge_vectorizer.worker_service_quantum, so a worker yielding its slot at
+ * the end of a quantum can never be mistaken for one that failed to start. It
+ * is still two orders of magnitude more than a failing worker needs to reach
+ * its FATAL, so the distinction is not a fine one in practice.
+ *
+ * This state is keyed by database name rather than held on the slot, because
+ * launcher_reap_workers() drops the slot at the moment the worker exits and
+ * the backoff has to outlive it.
+ */
+#define LAUNCHER_FAILED_START_MS			500
+#define LAUNCHER_RETRY_INTERVAL_MIN_MS		5000
+#define LAUNCHER_RETRY_INTERVAL_MAX_MS		300000
+
+typedef struct LauncherBackoff
+{
+	char		dbname[NAMEDATALEN];
+	int			interval_ms;	/* interval applied for the latest failure */
+	TimestampTz retry_after;	/* no further attempt before this */
+} LauncherBackoff;
+
+static LauncherBackoff *launcher_backoffs = NULL;
+static int	launcher_nbackoffs = 0;
+static int	launcher_backoffs_size = 0;
 
 /*
  * Sweep intervals.
@@ -72,6 +118,9 @@ static int	launcher_cursor = 0;	/* round-robin position in the database list */
  * Sweep briskly whilst databases are queued waiting for a turn, since a missed
  * wakeup there costs throughput, and rarely once every database has its own
  * resident worker.
+ *
+ * Whichever applies is shortened when a failed-start backoff is due to expire
+ * sooner, so that a database being retried does not wait out the idle sweep.
  */
 #define LAUNCHER_SWEEP_INTERVAL_ROTATING_MS		1000
 #define LAUNCHER_SWEEP_INTERVAL_IDLE_MS			60000
@@ -94,6 +143,11 @@ static BackgroundWorkerHandle *launch_worker_for_database(const char *dbname);
 static void launcher_reap_workers(void);
 static bool database_has_worker(const char *dbname);
 static void launcher_sweep(char **db_names, int db_count);
+static LauncherBackoff *launcher_backoff_find(const char *dbname);
+static void launcher_backoff_record(const char *dbname);
+static void launcher_backoff_clear(const char *dbname);
+static void launcher_backoff_prune(char **db_names, int db_count);
+static long launcher_backoff_next_retry_ms(TimestampTz now);
 
 /*
  * Signal handler for SIGTERM
@@ -316,12 +370,169 @@ launch_worker_for_database(const char *dbname)
 }
 
 /*
+ * Find the backoff entry for a database, or NULL if it has none.
+ */
+static LauncherBackoff *
+launcher_backoff_find(const char *dbname)
+{
+	for (int i = 0; i < launcher_nbackoffs; i++)
+	{
+		if (strcmp(launcher_backoffs[i].dbname, dbname) == 0)
+			return &launcher_backoffs[i];
+	}
+
+	return NULL;
+}
+
+/*
+ * Note that a worker for this database failed to start, and hold the database
+ * off for a while before trying again.
+ *
+ * The interval doubles on each consecutive failure, so a database that is
+ * briefly unavailable is retried promptly whilst one that is misconfigured
+ * settles at a rate that costs nothing to leave running indefinitely.
+ */
+static void
+launcher_backoff_record(const char *dbname)
+{
+	LauncherBackoff *entry = launcher_backoff_find(dbname);
+
+	if (entry == NULL)
+	{
+		/*
+		 * Entries are bounded by the number of configured databases, since
+		 * launcher_backoff_prune() drops those that leave the list.
+		 */
+		if (launcher_nbackoffs >= launcher_backoffs_size)
+		{
+			int			newsize = (launcher_backoffs_size == 0)
+				? 8 : launcher_backoffs_size * 2;
+
+			if (launcher_backoffs == NULL)
+				launcher_backoffs = palloc(newsize * sizeof(LauncherBackoff));
+			else
+				launcher_backoffs = repalloc(launcher_backoffs,
+											 newsize * sizeof(LauncherBackoff));
+			launcher_backoffs_size = newsize;
+		}
+
+		entry = &launcher_backoffs[launcher_nbackoffs++];
+		strlcpy(entry->dbname, dbname, NAMEDATALEN);
+		entry->interval_ms = LAUNCHER_RETRY_INTERVAL_MIN_MS;
+	}
+	else
+	{
+		entry->interval_ms = Min(entry->interval_ms * 2,
+								 LAUNCHER_RETRY_INTERVAL_MAX_MS);
+	}
+
+	entry->retry_after = TimestampTzPlusMilliseconds(GetCurrentTimestamp(),
+													entry->interval_ms);
+
+	elog(LOG, "pgedge_vectorizer launcher: worker for database \"%s\" exited "
+		 "immediately, retrying in %dms", dbname, entry->interval_ms);
+}
+
+/*
+ * Forget any backoff for a database, so that it is serviced at full speed
+ * again once a worker of its own has run successfully.
+ */
+static void
+launcher_backoff_clear(const char *dbname)
+{
+	LauncherBackoff *entry = launcher_backoff_find(dbname);
+
+	if (entry == NULL)
+		return;
+
+	/* Compact the array by moving the final entry into the hole */
+	*entry = launcher_backoffs[launcher_nbackoffs - 1];
+	launcher_nbackoffs--;
+}
+
+/*
+ * Drop backoff entries for databases that are no longer configured, so that
+ * the array cannot outgrow the database list.
+ *
+ * Removing a database and putting it back therefore earns it an immediate
+ * attempt, which is the right answer: the operator has just changed something.
+ */
+static void
+launcher_backoff_prune(char **db_names, int db_count)
+{
+	int			i = 0;
+
+	while (i < launcher_nbackoffs)
+	{
+		bool		still_configured = false;
+
+		for (int j = 0; j < db_count; j++)
+		{
+			if (strcmp(launcher_backoffs[i].dbname, db_names[j]) == 0)
+			{
+				still_configured = true;
+				break;
+			}
+		}
+
+		if (still_configured)
+			i++;
+		else
+		{
+			launcher_backoffs[i] = launcher_backoffs[launcher_nbackoffs - 1];
+			launcher_nbackoffs--;
+		}
+	}
+}
+
+/*
+ * Milliseconds until the earliest retry still in the future, or -1 if there is
+ * none to wait for.
+ *
+ * Entries that have already come due are skipped rather than reported as due
+ * now. The sweep will have taken any it could, so one still sitting here is
+ * waiting on a worker slot rather than on the clock, and returning a zero or
+ * one millisecond timeout for it would spin the launcher until a slot freed.
+ * The exit notification covers that case, and the sweep interval backs it up.
+ *
+ * Never returns zero, so a sub-millisecond wait cannot spin either.
+ */
+static long
+launcher_backoff_next_retry_ms(TimestampTz now)
+{
+	long		earliest = -1;
+
+	for (int i = 0; i < launcher_nbackoffs; i++)
+	{
+		long		secs;
+		int			usecs;
+		long		msecs;
+
+		if (launcher_backoffs[i].retry_after <= now)
+			continue;
+
+		TimestampDifference(now, launcher_backoffs[i].retry_after,
+							&secs, &usecs);
+		msecs = secs * 1000 + usecs / 1000;
+
+		if (msecs < 1)
+			msecs = 1;
+
+		if (earliest < 0 || msecs < earliest)
+			earliest = msecs;
+	}
+
+	return earliest;
+}
+
+/*
  * Drop tracking entries for workers that have exited.
  */
 static void
 launcher_reap_workers(void)
 {
 	int			i = 0;
+	TimestampTz now = GetCurrentTimestamp();
 
 	while (i < launcher_nslots)
 	{
@@ -329,6 +540,19 @@ launcher_reap_workers(void)
 
 		if (GetBackgroundWorkerPid(launcher_slots[i].handle, &pid) == BGWH_STOPPED)
 		{
+			/*
+			 * A worker that exited almost as soon as it was spawned never got
+			 * as far as doing any work, so hold its database off rather than
+			 * spinning on it. One we asked to stop does not count, however
+			 * promptly it obliged.
+			 */
+			if (!launcher_slots[i].terminating &&
+				!TimestampDifferenceExceeds(launcher_slots[i].spawn_time, now,
+											LAUNCHER_FAILED_START_MS))
+				launcher_backoff_record(launcher_slots[i].dbname);
+			else
+				launcher_backoff_clear(launcher_slots[i].dbname);
+
 			pfree(launcher_slots[i].handle);
 
 			/* Compact the array by moving the final entry into the hole */
@@ -434,22 +658,31 @@ launcher_sweep(char **db_names, int db_count)
 {
 	int			visited;
 	bool		warned = false;
+	TimestampTz now;
 
 	if (db_count == 0)
 		return;
 
 	launcher_retire_surplus();
 
+	now = GetCurrentTimestamp();
+
 	for (visited = 0; visited < db_count; visited++)
 	{
 		int			idx = (launcher_cursor + visited) % db_count;
 		const char *dbname = db_names[idx];
+		LauncherBackoff *backoff;
 		BackgroundWorkerHandle *handle;
 
 		if (launcher_nslots >= pgedge_vectorizer_num_workers)
 			break;
 
 		if (database_has_worker(dbname))
+			continue;
+
+		/* Still serving out a failed-start backoff; leave it for a later pass */
+		backoff = launcher_backoff_find(dbname);
+		if (backoff != NULL && now < backoff->retry_after)
 			continue;
 
 		handle = launch_worker_for_database(dbname);
@@ -468,6 +701,7 @@ launcher_sweep(char **db_names, int db_count)
 		strlcpy(launcher_slots[launcher_nslots].dbname, dbname, NAMEDATALEN);
 		launcher_slots[launcher_nslots].handle = handle;
 		launcher_slots[launcher_nslots].terminating = false;
+		launcher_slots[launcher_nslots].spawn_time = GetCurrentTimestamp();
 		launcher_nslots++;
 	}
 
@@ -496,6 +730,8 @@ launcher_reload_databases(char ***db_names, int old_count, bool *logged_empty)
 	}
 
 	db_count = parse_database_list(db_names);
+
+	launcher_backoff_prune(*db_names, db_count);
 
 	if (db_count == 0)
 	{
@@ -564,6 +800,7 @@ pgedge_vectorizer_launcher_main(Datum main_arg)
 	{
 		int			rc;
 		long		sweep_interval;
+		long		retry_ms;
 
 		/* Reload configuration if SIGHUP received */
 		if (got_sighup)
@@ -591,6 +828,14 @@ pgedge_vectorizer_launcher_main(Datum main_arg)
 		sweep_interval = (db_count > pgedge_vectorizer_num_workers)
 			? LAUNCHER_SWEEP_INTERVAL_ROTATING_MS
 			: LAUNCHER_SWEEP_INTERVAL_IDLE_MS;
+
+		/*
+		 * Come back for the earliest pending retry if that falls sooner, so a
+		 * backed-off database is not left waiting out the whole sweep.
+		 */
+		retry_ms = launcher_backoff_next_retry_ms(GetCurrentTimestamp());
+		if (retry_ms >= 0 && retry_ms < sweep_interval)
+			sweep_interval = retry_ms;
 
 		rc = WaitLatch(MyLatch,
 					   WL_LATCH_SET | WL_TIMEOUT | WL_POSTMASTER_DEATH,

--- a/src/worker.c
+++ b/src/worker.c
@@ -20,6 +20,7 @@
 #include "postmaster/bgworker.h"
 #include "postmaster/interrupt.h"
 #include "storage/proc.h"
+#include "storage/procsignal.h"
 #include "tcop/tcopprot.h"
 #include "utils/memutils.h"
 #include "utils/ps_status.h"
@@ -58,16 +59,19 @@ static int	launcher_cursor = 0;	/* round-robin position in the database list */
 /*
  * Sweep intervals.
  *
- * Workers are registered with bgw_notify_pid set to the launcher, but that
- * notification was observed not to wake a launcher holding no database
- * connection, so the sweep interval rather than the notification is what
- * bounds how quickly a freed slot is refilled. Do not rely on the latch being
- * set when a worker exits.
+ * Workers are registered with bgw_notify_pid set to the launcher, and the
+ * launcher installs procsignal_sigusr1_handler, so the postmaster's exit
+ * notification sets the launcher's latch and a freed slot is normally refilled
+ * within milliseconds. See the signal setup in
+ * pgedge_vectorizer_launcher_main() for why the handler has to be installed
+ * explicitly.
  *
- * When there are more databases than slots, databases are queued waiting for a
- * turn and refill latency directly limits throughput, so sweep briskly. When
- * every database has its own worker there is nothing to refill and the sweep
- * only needs to notice configuration changes, so sweep rarely.
+ * These intervals are therefore a backstop rather than the mechanism: they
+ * bound how quickly the launcher notices something no notification covers,
+ * chiefly a configuration change that neither started nor stopped a worker.
+ * Sweep briskly whilst databases are queued waiting for a turn, since a missed
+ * wakeup there costs throughput, and rarely once every database has its own
+ * resident worker.
  */
 #define LAUNCHER_SWEEP_INTERVAL_ROTATING_MS		1000
 #define LAUNCHER_SWEEP_INTERVAL_IDLE_MS			60000
@@ -533,9 +537,22 @@ pgedge_vectorizer_launcher_main(Datum main_arg)
 	bool		reload_list = true;
 	bool		logged_empty = false;
 
-	/* Setup signal handlers */
+	/*
+	 * Setup signal handlers.
+	 *
+	 * SIGUSR1 has to be handled explicitly. BackgroundWorkerMain() only
+	 * installs procsignal_sigusr1_handler for workers that requested
+	 * BGWORKER_BACKEND_DATABASE_CONNECTION, and points SIGUSR1 at SIG_IGN for
+	 * everyone else. This launcher takes no database connection, so without
+	 * this the bgw_notify_pid notification the postmaster sends when a worker
+	 * exits would be discarded and refilling a slot would wait for the next
+	 * sweep. contrib/pg_prewarm's leader does the same thing for the same
+	 * reason; the handler is safe here because CheckProcSignal() ignores a
+	 * process with no ProcSignal slot, leaving just the latch wakeup.
+	 */
 	pqsignal(SIGTERM, worker_sigterm);
 	pqsignal(SIGHUP, worker_sighup);
+	pqsignal(SIGUSR1, procsignal_sigusr1_handler);
 
 	/* We're now ready to receive signals */
 	BackgroundWorkerUnblockSignals();

--- a/test/t/002_worker_respawn.pl
+++ b/test/t/002_worker_respawn.pl
@@ -1,0 +1,100 @@
+# Copyright (c) 2025 - 2026, pgEdge, Inc.
+#
+# Verify that the launcher refills a slot promptly when a worker exits, rather
+# than waiting for its next periodic sweep.
+#
+# Per-database workers are registered BGW_NEVER_RESTART, so the launcher alone
+# is responsible for bringing one back. It learns that a worker exited from the
+# bgw_notify_pid notification, which the postmaster delivers as SIGUSR1. That
+# notification only arrives if the launcher installs a SIGUSR1 handler itself:
+# BackgroundWorkerMain() points SIGUSR1 at SIG_IGN for any worker that did not
+# request BGWORKER_BACKEND_DATABASE_CONNECTION, and the launcher deliberately
+# takes no database connection.
+#
+# With the notification dropped, the only remaining mechanism is the sweep
+# timeout, which is LAUNCHER_SWEEP_INTERVAL_IDLE_MS (60s) whenever every
+# database has its own resident worker. This test therefore uses a
+# non-oversubscribed configuration, where the brisk rotating sweep would
+# otherwise mask the problem, and requires the replacement well inside 60s.
+#
+# Progress is judged from worker PIDs in pg_stat_activity rather than from
+# counting messages in the server log. The log directory persists between runs
+# in a given build tree, so a log-counting test would see the previous run's
+# startup messages and pass without anything having been respawned.
+
+use strict;
+use warnings;
+
+# See the comment in 001_worker_coverage.pl about loading these at compile time.
+use PostgreSQL::Test::Cluster;
+use PostgreSQL::Test::Utils;
+use Test::More;
+
+# Fewer databases than num_workers, so both workers are resident and the
+# launcher uses its idle sweep interval.
+my @dbs = qw(respawndb1 respawndb2);
+
+my $node = PostgreSQL::Test::Cluster->new('vectorizer_respawn');
+$node->init;
+$node->append_conf(
+	'postgresql.conf', qq(
+shared_preload_libraries = 'pgedge_vectorizer'
+pgedge_vectorizer.databases = '@{[ join ',', @dbs ]}'
+pgedge_vectorizer.num_workers = 4
+pgedge_vectorizer.worker_poll_interval = 200
+max_worker_processes = 16
+));
+$node->start;
+
+for my $db (@dbs)
+{
+	$node->safe_psql('postgres', "CREATE DATABASE $db");
+	$node->safe_psql($db,        'CREATE EXTENSION pgedge_vectorizer CASCADE');
+}
+
+# Databases created after startup need a reload before the launcher sees them.
+$node->reload;
+
+my $first = wait_for_worker_pid($node, 'respawndb1', undef, 120);
+like($first, qr/^\d+$/, 'a resident worker starts for the database');
+
+# Terminate the worker cleanly. This exits 0, so unlike a signal death it does
+# not provoke a postmaster-wide crash restart, which would bring the worker
+# back by restarting everything and prove nothing about the launcher.
+$node->safe_psql('postgres', "SELECT pg_terminate_backend($first)");
+
+# The launcher must notice and relaunch. 20s is far longer than the
+# notification path needs and far shorter than the 60s idle sweep, so this
+# fails if the notification is being dropped.
+my $second = wait_for_worker_pid($node, 'respawndb1', $first, 20);
+like($second, qr/^\d+$/,
+	'the launcher relaunches an exited worker without waiting for its idle sweep');
+
+$node->stop;
+done_testing();
+
+# Wait for a worker servicing $db whose PID is not $exclude, and return that
+# PID. Returns the empty string if none appears within $timeout seconds.
+#
+# backend_type reports bgw_type, which the extension sets to its own name; the
+# launcher itself has no row here, having no database connection.
+sub wait_for_worker_pid
+{
+	my ($node, $db, $exclude, $timeout) = @_;
+	my $deadline = time() + $timeout;
+	my $filter = defined($exclude) ? "AND pid <> $exclude" : '';
+
+	while (time() < $deadline)
+	{
+		my $pid = $node->safe_psql('postgres',
+			"SELECT pid FROM pg_stat_activity
+			  WHERE datname = '$db'
+				AND backend_type = 'pgedge_vectorizer' $filter
+			  LIMIT 1");
+
+		return $pid if $pid =~ /^\d+$/;
+		sleep 1;
+	}
+
+	return '';
+}

--- a/test/t/002_worker_respawn.pl
+++ b/test/t/002_worker_respawn.pl
@@ -61,7 +61,14 @@ like($first, qr/^\d+$/, 'a resident worker starts for the database');
 # Terminate the worker cleanly. This exits 0, so unlike a signal death it does
 # not provoke a postmaster-wide crash restart, which would bring the worker
 # back by restarting everything and prove nothing about the launcher.
-$node->safe_psql('postgres', "SELECT pg_terminate_backend($first)");
+#
+# Check the request was accepted. Nothing else retires a worker here, both
+# being resident with a zero quantum, so a false return means the worker went
+# away for a reason this test did not intend and the wait below is measuring
+# something other than the notification path.
+my $terminated =
+  $node->safe_psql('postgres', "SELECT pg_terminate_backend($first)");
+is($terminated, 't', 'the worker accepts the termination request');
 
 # The launcher must notice and relaunch. 20s is far longer than the
 # notification path needs and far shorter than the 60s idle sweep, so this

--- a/test/t/003_launcher_failed_start_backoff.pl
+++ b/test/t/003_launcher_failed_start_backoff.pl
@@ -1,0 +1,98 @@
+# Copyright (c) 2025 - 2026, pgEdge, Inc.
+#
+# Verify that the launcher backs off when a worker cannot start at all, instead
+# of respawning it as fast as the postmaster will fork.
+#
+# Per-database workers are BGW_NEVER_RESTART, so the launcher owns respawn, and
+# it is told a worker exited by the bgw_notify_pid notification. A worker whose
+# database does not exist reaches its FATAL within a few milliseconds of being
+# spawned, so that notification arrives almost immediately and sends the
+# launcher straight back round to spawn a replacement. Nothing in the spawn path
+# rate limits that by itself.
+#
+# Before the backoff, a single mistyped name in pgedge_vectorizer.databases was
+# therefore enough to have the launcher fork of the order of two hundred
+# doomed workers a second indefinitely, consuming PIDs and writing megabytes of
+# log a minute. The launcher now treats a worker that exits within
+# LAUNCHER_FAILED_START_MS of being spawned as having failed to start, and holds
+# its database off for an interval that doubles from 5s to a 5 minute cap.
+#
+# The margin here is enormous, which is what makes the test worth having: over
+# the ten second window below the unthrottled launcher manages thousands of
+# attempts and the throttled one manages two.
+#
+# Note the log offset captured before the node starts. PostgreSQL::Test keeps
+# logs in ./log when run directly, and that directory persists between runs in a
+# given build tree, so counting from the top of the file would mix in the
+# previous run's attempts and could pass against a binary without the fix.
+
+use strict;
+use warnings;
+
+# See the comment in 001_worker_coverage.pl about loading these at compile time.
+use PostgreSQL::Test::Cluster;
+use PostgreSQL::Test::Utils;
+use Test::More;
+
+my $missing = 'backoff_missing_db';
+
+my $node = PostgreSQL::Test::Cluster->new('vectorizer_backoff');
+$node->init;
+$node->append_conf(
+	'postgresql.conf', qq(
+shared_preload_libraries = 'pgedge_vectorizer'
+pgedge_vectorizer.databases = '$missing'
+pgedge_vectorizer.num_workers = 2
+pgedge_vectorizer.worker_poll_interval = 200
+max_worker_processes = 16
+));
+
+my $log_offset = (-s $node->logfile) // 0;
+
+$node->start;
+
+# Long enough for the first attempt and the retry when the initial 5s backoff
+# expires, and long enough that an unthrottled launcher would be well into four
+# figures.
+sleep 10;
+
+my $log = slurp_file($node->logfile, $log_offset);
+my @attempts = ($log =~ /database "\Q$missing\E" does not exist/g);
+
+cmp_ok(scalar(@attempts), '>', 0,
+	'the launcher does attempt to start a worker for the missing database');
+
+cmp_ok(scalar(@attempts), '<=', 8,
+	'the launcher backs off rather than respawning the failed worker in a loop');
+
+like($log, qr/exited immediately, retrying in \d+ms/,
+	'the launcher reports the backoff it applied');
+
+# A backoff must not wedge the database permanently. Creating it removes the
+# fault, and the next retry should then produce a worker that stays up. No
+# CREATE EXTENSION here: a worker that connects but finds the extension missing
+# waits and rechecks rather than exiting, which is exactly the "started and
+# stayed up" case this needs.
+$node->safe_psql('postgres', "CREATE DATABASE $missing");
+
+my $started = 0;
+my $deadline = time() + 60;
+
+while (time() < $deadline)
+{
+	$log = slurp_file($node->logfile, $log_offset);
+
+	if ($log =~ /worker started \(database: \Q$missing\E\)/)
+	{
+		$started = 1;
+		last;
+	}
+
+	sleep 1;
+}
+
+ok($started,
+	'the launcher retries after the backoff, so a database that appears later is picked up');
+
+$node->stop;
+done_testing();


### PR DESCRIPTION
Follow-up to the dynamic worker launcher PR (merged). Three fixes found while reviewing that branch.

1. The launcher never received worker-exit notifications

Per-database workers are BGW_NEVER_RESTART, so the launcher alone brings one back, and it learns a worker exited from the bgw_notify_pid notification the postmaster sends as SIGUSR1.

That notification was being dropped. BackgroundWorkerMain() installs procsignal_sigusr1_handler only for workers requesting BGWORKER_BACKEND_DATABASE_CONNECTION and points SIGUSR1 at SIG_IGN for everyone else — and the launcher deliberately takes no database connection. The sweep timeout was therefore the only mechanism, so a slot freed while every database had a resident worker sat empty for up to the 60s idle interval.

The launcher now installs the handler explicitly, as contrib/pg_prewarm's leader does for the same reason. It is safe with no ProcSignal slot: CheckProcSignal() ignores such a process, leaving just the latch wakeup. The sweep intervals become a backstop rather than the mechanism, and the comment where they are defined says so instead of warning readers off the latch.

Note this is not about crash recovery. A worker that dies on a signal exits with a status the postmaster treats as a crash, which restarts the cluster. The exposed paths are clean exits and FATAL — quantum yields, retirements, pg_terminate_backend, and a worker that fails to connect.

2 & 3. Comment and doc corrections

The block describing the round-robin cursor and service quantum sat above launcher_retire_surplus(), which neither spawns workers nor touches the cursor; moved to launcher_sweep(). And num_workers became PGC_SIGHUP in #37, but two prose examples in README.md and docs/troubleshooting.md still told the reader to restart.

Testing

New test/t/002_worker_respawn.pl terminates a resident worker in a non-oversubscribed cluster, where the sweep is 60s, and requires the replacement within 20s. A/B against separately built binaries, symbol-checked to confirm which was installed: fails without the handler, passes with it.

It judges progress from worker PIDs in pg_stat_activity rather than counting log messages. PostgreSQL::Test keeps logs in ./log when run directly, which persists between runs, so a log-counting version of this test passed twice against a binary confirmed not to contain the fix.

Full suite: 15/15 pg_regress, 6/6 TAP 001, 2/2 TAP 002.