### PR TITLE
Compute BM25 IDF weights on read instead of storing them per term

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -70,7 +70,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   so deletes of unrelated rows serialised against each other, and it ran even
   for statements that removed nothing. A delete now updates only the terms
   belonging to the rows it removed. The weights are computed when the
-  statistics are read and search results are unchanged.
+  statistics are read, so ranking is equivalent wherever a stored weight was
+  current, and corrected wherever it had gone stale — which is the situation
+  this change exists to fix.
 
 ### Removed
 
@@ -89,6 +91,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- Fixed BM25 length normalisation being driven by an incorrect average document
+  length, which suppressed the sparse half of hybrid search. `AVG()` over the
+  integer `token_count` column returns `numeric`, whose `Datum` is a pointer,
+  and the result was read as a `float8` — so `bm25_avg_doc_len()` returned a
+  denormal (around `1e-315`) rather than the real mean, and passed the
+  non-negative guard because a denormal is positive. Dividing document length
+  by that value made every term's frequency component collapse toward zero,
+  so sparse scores were effectively flat and contributed almost nothing to
+  the fused ranking. Present since hybrid search was introduced.
 - Fixed databases beyond `pgedge_vectorizer.num_workers` never being processed
   ([#23](https://github.com/pgEdge/pgedge-vectorizer/issues/23)). Workers were
   assigned to databases by `worker_id % db_count`, and because `worker_id` only

--- a/src/bm25.c
+++ b/src/bm25.c
@@ -207,27 +207,21 @@ bm25_tokenize(const char *text, int *ntokens)
 }
 
 /*
- * bm25_load_idf_stats
+ * bm25_corpus_stats — corpus size N and mean document length, in one pass.
  *
- * Load all rows from {chunk_table}_idf_stats via SPI and return them as
- * a dynahash keyed on term for O(1) IDF lookups.  Returns NULL (not an
- * error) if the stats table does not exist yet.
+ * Both come from the same scan: taken separately they made two passes over
+ * the chunk table for every search.  Returns N, clamped to a minimum of 1 so
+ * that callers dividing or taking logarithms never see zero, and leaves
+ * *avg_doc_len untouched unless a usable average was read.
  *
- * Uses a subtransaction so a missing table does not abort the outer
- * worker transaction.  Re-throws all errors except ERRCODE_UNDEFINED_TABLE.
+ * count(*) is left uncast because ::int would raise "integer out of range"
+ * past 2^31 rows.  AVG() over an integer column yields numeric, so the cast
+ * to float8 is required before DatumGetFloat8().
+ *
  * Caller must have an active SPI connection.
- * Caller should call hash_destroy() on the returned HTAB when done.
- */
-
-/*
- * bm25_chunk_count — number of rows in the chunk table, i.e. the BM25
- * corpus size N.  Clamped to a minimum of 1 so that callers dividing or
- * taking logarithms never see zero.  Caller must have an active SPI
- * connection.  count(*) is left uncast because ::int would raise
- * "integer out of range" past 2^31 rows.
  */
 static int64
-bm25_chunk_count(const char *chunk_table)
+bm25_corpus_stats(const char *chunk_table, float8 *avg_doc_len)
 {
 	char   *sql;
 	int     ret;
@@ -235,7 +229,7 @@ bm25_chunk_count(const char *chunk_table)
 	bool    isnull;
 	Datum   val;
 
-	sql = psprintf("SELECT count(*) FROM %s",
+	sql = psprintf("SELECT count(*), AVG(token_count)::float8 FROM %s",
 				   quote_identifier(chunk_table));
 	ret = SPI_execute(sql, true, 1);
 	pfree(sql);
@@ -246,6 +240,16 @@ bm25_chunk_count(const char *chunk_table)
 							SPI_tuptable->tupdesc, 1, &isnull);
 		if (!isnull)
 			total = DatumGetInt64(val);
+
+		val = SPI_getbinval(SPI_tuptable->vals[0],
+							SPI_tuptable->tupdesc, 2, &isnull);
+		if (!isnull)
+		{
+			float8  avg = DatumGetFloat8(val);
+
+			if (avg > 0.0)
+				*avg_doc_len = avg;
+		}
 	}
 
 	return (total <= 0) ? 1 : total;
@@ -270,8 +274,23 @@ read_idf_row(SPITupleTable *tuptable, int i)
 	return s;
 }
 
+/*
+ * bm25_load_idf_stats
+ *
+ * Load the rows of {chunk_table}_idf_stats matching the caller's terms via
+ * SPI and return them as a dynahash keyed on term for O(1) IDF lookups.
+ * Returns NULL (not an error) if the stats table does not exist yet, or if
+ * there are no terms to look up.  Sets *avg_doc_len to the mean document
+ * length, or 1.0 when none could be read.
+ *
+ * Uses a subtransaction so a missing table does not abort the outer
+ * worker transaction.  Re-throws all errors except ERRCODE_UNDEFINED_TABLE.
+ * Caller must have an active SPI connection.
+ * Caller should call hash_destroy() on the returned HTAB when done.
+ */
 HTAB *
-bm25_load_idf_stats(const char *chunk_table, BM25Term *tokens, int ntokens)
+bm25_load_idf_stats(const char *chunk_table, BM25Term *tokens, int ntokens,
+					float8 *avg_doc_len)
 {
 	char            *sql;
 	int              ret;
@@ -284,8 +303,31 @@ bm25_load_idf_stats(const char *chunk_table, BM25Term *tokens, int ntokens)
 	Datum            terms;
 	Oid              argtype = TEXTARRAYOID;
 
+	/*
+	 * Set before anything can fail, so every return path below leaves the
+	 * caller with a usable length.  Written through the pointer rather than
+	 * kept in a local, so a value read before the stats query survives the
+	 * catch.
+	 */
+	*avg_doc_len = 1.0;
+
 	if (tokens == NULL || ntokens <= 0)
 		return NULL;
+
+	/*
+	 * Read the corpus figures first, and outside the subtransaction below.
+	 *
+	 * First because SPI_execute() replaces SPI_tuptable, so reading them
+	 * after the stats query would leave the loop decoding that result as
+	 * (term, doc_freq).
+	 *
+	 * Outside because the subtransaction deliberately tolerates a missing
+	 * table, which is the right answer for the stats table but not for the
+	 * chunk table: that means the registry points at something that no
+	 * longer exists, and it should surface rather than quietly degrade the
+	 * ranking.
+	 */
+	total_docs = bm25_corpus_stats(chunk_table, avg_doc_len);
 
 	/*
 	 * Only the caller's own terms are ever looked up, so fetch only those
@@ -323,13 +365,6 @@ bm25_load_idf_stats(const char *chunk_table, BM25Term *tokens, int ntokens)
 	BeginInternalSubTransaction(NULL);
 	PG_TRY();
 	{
-		/*
-		 * Must precede the stats query: SPI_execute() replaces SPI_tuptable,
-		 * so counting after would leave the loop reading the count(*) result
-		 * as (term, doc_freq).
-		 */
-		total_docs = bm25_chunk_count(chunk_table);
-
 		ret = SPI_execute_with_args(sql, 1, &argtype, &terms, NULL, true, 0);
 		ok  = true;
 
@@ -759,8 +794,8 @@ pgedge_vectorizer_bm25_query_vector(PG_FUNCTION_ARGS)
 	SPI_connect();
 
 	tokens      = bm25_tokenize(query, &ntokens);
-	idf_htab    = bm25_load_idf_stats(chunk_table, tokens, ntokens);
-	avg_doc_len = bm25_avg_doc_len_internal(chunk_table);
+	idf_htab    = bm25_load_idf_stats(chunk_table, tokens, ntokens,
+									  &avg_doc_len);
 
 	result = bm25_compute_sparse_vector(
 				 tokens, ntokens,

--- a/src/bm25.c
+++ b/src/bm25.c
@@ -425,7 +425,12 @@ bm25_avg_doc_len_internal(const char *chunk_table)
 	Datum   val;
 	float8  result = 1.0;
 
-	sql = psprintf("SELECT AVG(token_count) FROM %s",
+	/*
+	 * AVG() over an integer column yields numeric, whose Datum is a pointer.
+	 * Without the cast DatumGetFloat8() reinterprets those bits as a double,
+	 * producing a denormal that passes the <= 0.0 guard below.
+	 */
+	sql = psprintf("SELECT AVG(token_count)::float8 FROM %s",
 				   quote_identifier(chunk_table));
 	ret = SPI_execute(sql, true, 1);
 	pfree(sql);

--- a/src/bm25.h
+++ b/src/bm25.h
@@ -63,7 +63,8 @@ extern double pgedge_vectorizer_bm25_b;
  */
 BM25Term *bm25_tokenize(const char *text, int *ntokens);
 HTAB     *bm25_load_idf_stats(const char *chunk_table,
-							  BM25Term *tokens, int ntokens);
+							  BM25Term *tokens, int ntokens,
+							  float8 *avg_doc_len);
 char     *bm25_compute_sparse_str(BM25Term *tokens, int ntokens,
 								  HTAB *idf_htab,
 								  float8 k1, float8 b,

--- a/src/worker.c
+++ b/src/worker.c
@@ -1623,9 +1623,8 @@ process_queue_batch(const char *dbname)
 							tokens = bm25_tokenize(contents[idx],
 												   &ntokens);
 							idf_htab = bm25_load_idf_stats(
-									chunk_tables[idx], tokens, ntokens);
-							avg_doc_len = bm25_avg_doc_len_internal(
-									chunk_tables[idx]);
+									chunk_tables[idx], tokens, ntokens,
+									&avg_doc_len);
 							sparse_str = bm25_compute_sparse_str(
 									tokens, ntokens,
 									idf_htab,

--- a/test/expected/hybrid_test.out
+++ b/test/expected/hybrid_test.out
@@ -287,6 +287,31 @@ NOTICE:  Vectorization disabled and chunk table dropped: avg_len_docs_body_chunk
 
 DROP TABLE avg_len_docs;
 ---------------------------------------------------------------------------
+-- Test 15c: a missing chunk table is reported, not absorbed
+---------------------------------------------------------------------------
+-- The stats load runs in a subtransaction that tolerates a missing table,
+-- which is right for the stats table (not vectorized yet) but wrong for the
+-- chunk table, where it means the registry points at something that is gone.
+-- Reading the corpus figures inside that subtransaction would swallow it and
+-- return a silently degraded vector.
+CREATE TABLE orphan_idf_stats (
+    term TEXT PRIMARY KEY,
+    doc_freq INT,
+    updated_at TIMESTAMPTZ DEFAULT now()
+);
+INSERT INTO orphan_idf_stats (term, doc_freq) VALUES ('alpha', 1), ('beta', 1);
+DO $$
+BEGIN
+    PERFORM pgedge_vectorizer.bm25_query_vector('alpha beta', 'orphan');
+    RAISE EXCEPTION 'Expected exception was not raised';
+EXCEPTION
+    WHEN undefined_table THEN
+        RAISE NOTICE 'Got expected exception for missing chunk table';
+END;
+$$;
+NOTICE:  Got expected exception for missing chunk table
+DROP TABLE orphan_idf_stats;
+---------------------------------------------------------------------------
 -- Test 16: BM25 tokenizer returns empty array for NULL input
 ---------------------------------------------------------------------------
 SELECT COALESCE(

--- a/test/expected/hybrid_test.out
+++ b/test/expected/hybrid_test.out
@@ -240,6 +240,53 @@ SELECT pgedge_vectorizer.bm25_avg_doc_len(
 (1 row)
 
 ---------------------------------------------------------------------------
+-- Test 15b: bm25_avg_doc_len equals the actual average
+---------------------------------------------------------------------------
+-- AVG() over an integer column yields numeric, so reading its Datum as a
+-- float8 without a cast gives a denormal rather than the mean.  ">= 0" above
+-- cannot catch that: a denormal is positive.  Compare against the value SQL
+-- computes, on a table with rows in it.
+CREATE TABLE avg_len_docs (id BIGSERIAL PRIMARY KEY, body TEXT);
+INSERT INTO avg_len_docs (body)
+SELECT repeat('alpha beta gamma delta ', 40) FROM generate_series(1, 5);
+SELECT pgedge_vectorizer.enable_vectorization('avg_len_docs', 'body',
+                                              embedding_dimension => 3);
+NOTICE:  Using primary key column: id (bigint)
+NOTICE:  column "sparse_embedding" of relation "avg_len_docs_body_chunks" already exists, skipping
+NOTICE:  Vectorization enabled: avg_len_docs -> avg_len_docs_body_chunks
+NOTICE:  Strategy: token_based, chunk_size: 400, overlap: 50
+NOTICE:  Processing existing rows...
+NOTICE:  Processed 5 existing rows
+ enable_vectorization 
+----------------------
+ 
+(1 row)
+
+SELECT pgedge_vectorizer.bm25_avg_doc_len('avg_len_docs_body_chunks')
+       = (SELECT AVG(token_count)::float8 FROM avg_len_docs_body_chunks)
+       AS avg_doc_len_matches_sql;
+ avg_doc_len_matches_sql 
+-------------------------
+ t
+(1 row)
+
+-- and it must be a plausible document length, not a denormal
+SELECT pgedge_vectorizer.bm25_avg_doc_len('avg_len_docs_body_chunks') > 1.0
+       AS avg_doc_len_is_realistic;
+ avg_doc_len_is_realistic 
+--------------------------
+ t
+(1 row)
+
+SELECT pgedge_vectorizer.disable_vectorization('avg_len_docs', 'body', true);
+NOTICE:  Vectorization disabled and chunk table dropped: avg_len_docs_body_chunks
+ disable_vectorization 
+-----------------------
+ 
+(1 row)
+
+DROP TABLE avg_len_docs;
+---------------------------------------------------------------------------
 -- Test 16: BM25 tokenizer returns empty array for NULL input
 ---------------------------------------------------------------------------
 SELECT COALESCE(

--- a/test/sql/hybrid_test.sql
+++ b/test/sql/hybrid_test.sql
@@ -197,6 +197,33 @@ SELECT pgedge_vectorizer.bm25_avg_doc_len(
 ) >= 0 AS non_negative;
 
 ---------------------------------------------------------------------------
+-- Test 15b: bm25_avg_doc_len equals the actual average
+---------------------------------------------------------------------------
+
+-- AVG() over an integer column yields numeric, so reading its Datum as a
+-- float8 without a cast gives a denormal rather than the mean.  ">= 0" above
+-- cannot catch that: a denormal is positive.  Compare against the value SQL
+-- computes, on a table with rows in it.
+
+CREATE TABLE avg_len_docs (id BIGSERIAL PRIMARY KEY, body TEXT);
+INSERT INTO avg_len_docs (body)
+SELECT repeat('alpha beta gamma delta ', 40) FROM generate_series(1, 5);
+
+SELECT pgedge_vectorizer.enable_vectorization('avg_len_docs', 'body',
+                                              embedding_dimension => 3);
+
+SELECT pgedge_vectorizer.bm25_avg_doc_len('avg_len_docs_body_chunks')
+       = (SELECT AVG(token_count)::float8 FROM avg_len_docs_body_chunks)
+       AS avg_doc_len_matches_sql;
+
+-- and it must be a plausible document length, not a denormal
+SELECT pgedge_vectorizer.bm25_avg_doc_len('avg_len_docs_body_chunks') > 1.0
+       AS avg_doc_len_is_realistic;
+
+SELECT pgedge_vectorizer.disable_vectorization('avg_len_docs', 'body', true);
+DROP TABLE avg_len_docs;
+
+---------------------------------------------------------------------------
 -- Test 16: BM25 tokenizer returns empty array for NULL input
 ---------------------------------------------------------------------------
 

--- a/test/sql/hybrid_test.sql
+++ b/test/sql/hybrid_test.sql
@@ -224,6 +224,35 @@ SELECT pgedge_vectorizer.disable_vectorization('avg_len_docs', 'body', true);
 DROP TABLE avg_len_docs;
 
 ---------------------------------------------------------------------------
+-- Test 15c: a missing chunk table is reported, not absorbed
+---------------------------------------------------------------------------
+
+-- The stats load runs in a subtransaction that tolerates a missing table,
+-- which is right for the stats table (not vectorized yet) but wrong for the
+-- chunk table, where it means the registry points at something that is gone.
+-- Reading the corpus figures inside that subtransaction would swallow it and
+-- return a silently degraded vector.
+
+CREATE TABLE orphan_idf_stats (
+    term TEXT PRIMARY KEY,
+    doc_freq INT,
+    updated_at TIMESTAMPTZ DEFAULT now()
+);
+INSERT INTO orphan_idf_stats (term, doc_freq) VALUES ('alpha', 1), ('beta', 1);
+
+DO $$
+BEGIN
+    PERFORM pgedge_vectorizer.bm25_query_vector('alpha beta', 'orphan');
+    RAISE EXCEPTION 'Expected exception was not raised';
+EXCEPTION
+    WHEN undefined_table THEN
+        RAISE NOTICE 'Got expected exception for missing chunk table';
+END;
+$$;
+
+DROP TABLE orphan_idf_stats;
+
+---------------------------------------------------------------------------
 -- Test 16: BM25 tokenizer returns empty array for NULL input
 ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Replaces #43. The six commits that PR shared with #46 are already on main; these are the two that were not, reconciled by hand onto 35eddbe because neither rebasing nor cherry-picking applied cleanly.

1. AVG(token_count) was being read as a float8 without a cast. token_count is an integer column, so AVG() yields numeric, whose Datum is a pointer. bm25_avg_doc_len_internal() read those bits through DatumGetFloat8() and returned 1.2e-315 where the mean was 230, passing the <= 0.0 guard because a denormal is positive.

That value is the divisor in BM25 length normalisation, so doc_len / avg_doc_len went astronomical, every term's frequency component collapsed toward zero, and the sparse half of hybrid search contributed almost nothing to the fused ranking. Present since hybrid search was introduced.

2. The read path scanned the chunk table twice per query. bm25_chunk_count() and bm25_avg_doc_len_internal() ran back to back in both callers. Folded into a single SELECT count(*), AVG(token_count)::float8, with the average returned through an out-parameter.

Approach

Two commits, each independently testable and green:

f997c38  Read the corpus size and mean document length in one pass
aefae33  Cast AVG(token_count) to float8 before reading it as one

The cast fix is first and standalone so it can be reviewed, cherry-picked or reverted without the fold.

The corpus read sits outside the subtransaction that loads the statistics. That subtransaction discards ERRCODE_UNDEFINED_TABLE, which is right for a stats table that does not exist yet but wrong for the chunk table, where it would turn a registry pointing at a dropped table into a silently degraded ranking rather than an error. It still runs before the stats query so SPI_tuptable is intact, and the terms array is still built before BeginInternalSubTransaction() so it lives in the caller's context.

Notes for the reviewer

One semantics change worth naming. The corpus read sits after the "no terms to look up" early return, so on that path *avg_doc_len keeps its 1.0 default rather than the real mean — previously the caller fetched the average separately and got the true value. Nothing observes it today, since with no tokens the sparse vector is empty whatever the length is, but it would matter if the average were used beyond scoring the tokens just passed in.

hybrid_search() cannot be reached under pg_regress — it fails on a missing provider API key. Every test here exercises the C functions directly, so "19/19 green" is weaker evidence than it looks for the full search path, which is precisely where the AVG() fix changes behaviour.

Search results will change, and substantially. The changelog entry claiming they were unchanged has been reworded, and the normalisation defect recorded under Fixed.

Test plan

Verified against PostgreSQL 17.10 from a clean build.

- [x] All 19 regression tests pass with no new compiler warnings
- [x] Both commits build and pass in isolation, so the branch bisects cleanly
- [x] bm25_avg_doc_len() returns 230 against SQL's 230, where it previously returned 1.2e-315
- [x] Test 15b reads f/f without the cast and t/t with it
- [x] Test 15c asserts undefined_table for a stats table whose chunk table is gone; nothing else covers an inconsistent registry
- [x] CREATE TABLE AS and PL/pgSQL PERFORM paths from #46 still succeed, confirming the reconciliation preserved both sides
- [x] Edge cases probed: all-stopword query returns an empty vector, empty chunk table falls back to 1.0