### PR TITLE
Budget cleanup trigger names in bytes, not characters

### DIFF
--- a/sql/pgedge_vectorizer--1.0--1.1.sql
+++ b/sql/pgedge_vectorizer--1.0--1.1.sql
@@ -167,15 +167,24 @@ CREATE OR REPLACE FUNCTION pgedge_vectorizer.cleanup_trigger_name(
 ) RETURNS TEXT AS $$
 DECLARE
     digest TEXT;
+    prefix TEXT;
     room   INT;
 BEGIN
     digest := substr(md5(p_source_table || '.' || p_source_column), 1, 8);
 
-    -- One character for the separator before the digest.
-    room := 63 - length(p_suffix) - length(digest) - 1;
+    -- Budget in bytes, not characters: the limit is 63 bytes, so a multibyte
+    -- name measured in characters would overflow and be truncated by the
+    -- server, cutting into the digest.  One byte for the separator.
+    room := GREATEST(63 - octet_length(p_suffix) - octet_length(digest) - 1, 0);
 
-    RETURN left(p_source_table || '_' || p_source_column, GREATEST(room, 0))
-           || '_' || digest || p_suffix;
+    -- No more than `room` characters can fit in `room` bytes, so start there
+    -- and drop whole characters until the prefix is within the byte budget.
+    prefix := left(p_source_table || '_' || p_source_column, room);
+    WHILE octet_length(prefix) > room LOOP
+        prefix := left(prefix, -1);
+    END LOOP;
+
+    RETURN prefix || '_' || digest || p_suffix;
 END;
 $$ LANGUAGE plpgsql IMMUTABLE;
 

--- a/sql/pgedge_vectorizer--1.1.sql
+++ b/sql/pgedge_vectorizer--1.1.sql
@@ -159,15 +159,24 @@ CREATE FUNCTION pgedge_vectorizer.cleanup_trigger_name(
 ) RETURNS TEXT AS $$
 DECLARE
     digest TEXT;
+    prefix TEXT;
     room   INT;
 BEGIN
     digest := substr(md5(p_source_table || '.' || p_source_column), 1, 8);
 
-    -- One character for the separator before the digest.
-    room := 63 - length(p_suffix) - length(digest) - 1;
+    -- Budget in bytes, not characters: the limit is 63 bytes, so a multibyte
+    -- name measured in characters would overflow and be truncated by the
+    -- server, cutting into the digest.  One byte for the separator.
+    room := GREATEST(63 - octet_length(p_suffix) - octet_length(digest) - 1, 0);
 
-    RETURN left(p_source_table || '_' || p_source_column, GREATEST(room, 0))
-           || '_' || digest || p_suffix;
+    -- No more than `room` characters can fit in `room` bytes, so start there
+    -- and drop whole characters until the prefix is within the byte budget.
+    prefix := left(p_source_table || '_' || p_source_column, room);
+    WHILE octet_length(prefix) > room LOOP
+        prefix := left(prefix, -1);
+    END LOOP;
+
+    RETURN prefix || '_' || digest || p_suffix;
 END;
 $$ LANGUAGE plpgsql IMMUTABLE;
 

--- a/test/expected/delete_truncate.out
+++ b/test/expected/delete_truncate.out
@@ -258,3 +258,37 @@ SELECT count(*) AS long_name_triggers_after_disable FROM pg_trigger
 (1 row)
 
 DROP TABLE dt_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa;
+-- The 63 limit is bytes, not characters.  Budgeting in characters lets a
+-- multibyte name overflow, and the server then truncates it -- cutting off the
+-- digest, which is the collision the digest exists to prevent.  The ::name
+-- casts apply that truncation, so these compare the names as actually stored.
+--
+-- Three-byte characters are what push the digest past the limit, so this
+-- assumes a UTF-8 database.
+SELECT octet_length(pgedge_vectorizer.cleanup_trigger_name(
+           repeat('日', 40), repeat('本', 40),
+           '_vectorization_delete_trigger')) <= 63 AS multibyte_name_fits,
+       pgedge_vectorizer.cleanup_trigger_name(
+           repeat('日', 40), repeat('本', 40), '_vectorization_delete_trigger')::name
+       <> pgedge_vectorizer.cleanup_trigger_name(
+           repeat('日', 40), repeat('本', 40), '_vectorization_truncate_trigger')::name
+           AS delete_and_truncate_distinct,
+       pgedge_vectorizer.cleanup_trigger_name(
+           repeat('日', 40), 'a', '_vectorization_delete_trigger')::name
+       <> pgedge_vectorizer.cleanup_trigger_name(
+           repeat('日', 40), 'b', '_vectorization_delete_trigger')::name
+           AS two_columns_distinct;
+ multibyte_name_fits | delete_and_truncate_distinct | two_columns_distinct 
+---------------------+------------------------------+----------------------
+ t                   | t                            | t
+(1 row)
+
+-- ASCII names must be unaffected by the byte-based budget.
+SELECT pgedge_vectorizer.cleanup_trigger_name(
+           'dt_docs', 'body', '_vectorization_delete_trigger')
+           AS ascii_name_unchanged;
+                ascii_name_unchanged                
+----------------------------------------------------
+ dt_docs_body_f8876619_vectorization_delete_trigger
+(1 row)
+

--- a/test/sql/delete_truncate.sql
+++ b/test/sql/delete_truncate.sql
@@ -119,3 +119,29 @@ SELECT count(*) AS long_name_triggers_after_disable FROM pg_trigger
  WHERE tgrelid = 'dt_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'::regclass AND NOT tgisinternal;
 
 DROP TABLE dt_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa;
+
+-- The 63 limit is bytes, not characters.  Budgeting in characters lets a
+-- multibyte name overflow, and the server then truncates it -- cutting off the
+-- digest, which is the collision the digest exists to prevent.  The ::name
+-- casts apply that truncation, so these compare the names as actually stored.
+--
+-- Three-byte characters are what push the digest past the limit, so this
+-- assumes a UTF-8 database.
+SELECT octet_length(pgedge_vectorizer.cleanup_trigger_name(
+           repeat('日', 40), repeat('本', 40),
+           '_vectorization_delete_trigger')) <= 63 AS multibyte_name_fits,
+       pgedge_vectorizer.cleanup_trigger_name(
+           repeat('日', 40), repeat('本', 40), '_vectorization_delete_trigger')::name
+       <> pgedge_vectorizer.cleanup_trigger_name(
+           repeat('日', 40), repeat('本', 40), '_vectorization_truncate_trigger')::name
+           AS delete_and_truncate_distinct,
+       pgedge_vectorizer.cleanup_trigger_name(
+           repeat('日', 40), 'a', '_vectorization_delete_trigger')::name
+       <> pgedge_vectorizer.cleanup_trigger_name(
+           repeat('日', 40), 'b', '_vectorization_delete_trigger')::name
+           AS two_columns_distinct;
+
+-- ASCII names must be unaffected by the byte-based budget.
+SELECT pgedge_vectorizer.cleanup_trigger_name(
+           'dt_docs', 'body', '_vectorization_delete_trigger')
+           AS ascii_name_unchanged;


### PR DESCRIPTION
## Summary

`cleanup_trigger_name()` budgets against PostgreSQL's 63-**byte** identifier limit but spends that budget with `length()` and `left()`, which count **characters**:

```sql
room := 63 - length(p_suffix) - length(digest) - 1;
RETURN left(p_source_table || '_' || p_source_column, GREATEST(room, 0))
       || '_' || digest || p_suffix;
```

With three-byte characters the generated name reaches **113 bytes** for a 40-character table and column, against the 63 the server keeps. The server truncates what it is given, and at that size the cut lands *inside* the readable prefix — so the digest is removed entirely.

That digest is the only thing distinguishing one vectorized column's triggers from another's, so losing it reinstates exactly the collision it was added in 9135dfe to prevent. Measured against the current `main`:

| property | value |
|---|---|
| generated length, delete trigger | 113 bytes (limit 63) |
| digest survives truncation | no |
| delete vs truncate name for one column | **collide** |
| delete names for two columns on one table | **collide** |

Because the triggers are created with `CREATE OR REPLACE TRIGGER`, the second silently replaces the first. Cleanup then stops happening for one of them, with no error raised at any point — the same silent failure mode the digest was introduced to close.

## Approach

Measure the budget with `octet_length()` and drop whole characters until the prefix fits it:

```sql
room := GREATEST(63 - octet_length(p_suffix) - octet_length(digest) - 1, 0);

prefix := left(p_source_table || '_' || p_source_column, room);
WHILE octet_length(prefix) > room LOOP
    prefix := left(prefix, -1);
END LOOP;
```

Starting from `left(prefix, room)` bounds the loop: no more than `room` characters can fit in `room` bytes, and `room` is about 25 here, so the worst case is a couple of dozen iterations in an `IMMUTABLE` function called only at trigger creation.

Both `--1.1.sql` and `--1.0--1.1.sql` carry the function and are changed together; I diffed the two bodies afterwards to confirm they stayed identical.

## Notes for the reviewer

**Two-byte characters do not reproduce this, which drove the test design.** My first attempt used `é`, and it passed against the unfixed function. At `room = 25` characters the prefix is only 50 bytes, so the digest lands at bytes 51–59 and survives truncation intact. The threshold is three-byte characters, where the prefix alone is 75 bytes and overruns the limit on its own. Worth knowing if the test's use of CJK looks arbitrary — anything narrower does not exercise the defect.

**The test asserts through `::name`**, so the comparison is against the truncated form the server actually stores rather than the raw string the function returns. Comparing the raw values would report "distinct" even in the broken case.

**It assumes a UTF-8 database.** Three-byte characters cannot be represented otherwise, and CI's `pg_createcluster` and Homebrew both default to UTF-8. This is the first multibyte *identifier* in the suite; `pk_types.sql` has non-ASCII only inside a string literal.

**No changelog entry.** `cleanup_trigger_name()` is new in the unreleased 1.1, so this defect never reached a release — it is part of getting that feature right rather than a fix to shipped behaviour.

**Based directly on `main`, not stacked.** It touches only `cleanup_trigger_name()` and the tail of `delete_truncate.sql`, so it is independent of the IDF statistics follow-up and can merge in either order.

## Test plan

Verified against PostgreSQL 17.9 from a clean build; CI covers 14 through 19.

- [x] All 17 regression tests pass
- [x] The new assertions read `f / f / f` against the unfixed function and `t / t / t` after, so the test fails on the current `main` behaviour rather than passing vacuously
- [x] Collision reproduced directly on `main`'s function: `d::name = t::name` returns true for CJK identifiers, and again for two different columns on one table
- [x] ASCII names are unchanged by the byte-based budget, asserted explicitly
- [x] Both SQL scripts diffed to confirm the two copies of the function remain identical

Refs #24

