### PR TITLE
Order the trigger listings in the vectorization test

### DIFF
--- a/test/expected/vectorization.out
+++ b/test/expected/vectorization.out
@@ -35,13 +35,17 @@ WHERE tablename = 'test_docs_content_chunks';
 (1 row)
 
 -- Verify trigger was created
+-- ORDER BY because this returns the three cleanup triggers per column, and an
+-- unordered scan of pg_trigger returns them in physical order, which shifts
+-- with whatever earlier tests left behind.
 SELECT tgname FROM pg_trigger
-WHERE tgname LIKE '%test_docs%vectorization%';
+WHERE tgname LIKE '%test_docs%vectorization%'
+ORDER BY tgname;
                           tgname                           
 -----------------------------------------------------------
- test_docs_content_vectorization_trigger
  test_docs_content_9bafa066_vectorization_delete_trigger
  test_docs_content_9bafa066_vectorization_truncate_trigger
+ test_docs_content_vectorization_trigger
 (3 rows)
 
 -- Insert a test document
@@ -118,12 +122,13 @@ NOTICE:  Processed 1 existing rows
 
 -- Verify trigger was re-created
 SELECT tgname FROM pg_trigger
-WHERE tgname LIKE '%test_docs%vectorization%';
+WHERE tgname LIKE '%test_docs%vectorization%'
+ORDER BY tgname;
                           tgname                           
 -----------------------------------------------------------
- test_docs_content_vectorization_trigger
  test_docs_content_9bafa066_vectorization_delete_trigger
  test_docs_content_9bafa066_vectorization_truncate_trigger
+ test_docs_content_vectorization_trigger
 (3 rows)
 
 -- Verify chunks still exist (upserted, not duplicated)

--- a/test/sql/vectorization.sql
+++ b/test/sql/vectorization.sql
@@ -23,8 +23,12 @@ SELECT tablename FROM pg_tables
 WHERE tablename = 'test_docs_content_chunks';
 
 -- Verify trigger was created
+-- ORDER BY because this returns the three cleanup triggers per column, and an
+-- unordered scan of pg_trigger returns them in physical order, which shifts
+-- with whatever earlier tests left behind.
 SELECT tgname FROM pg_trigger
-WHERE tgname LIKE '%test_docs%vectorization%';
+WHERE tgname LIKE '%test_docs%vectorization%'
+ORDER BY tgname;
 
 -- Insert a test document
 INSERT INTO test_docs (title, content)
@@ -66,7 +70,8 @@ SELECT pgedge_vectorizer.enable_vectorization(
 
 -- Verify trigger was re-created
 SELECT tgname FROM pg_trigger
-WHERE tgname LIKE '%test_docs%vectorization%';
+WHERE tgname LIKE '%test_docs%vectorization%'
+ORDER BY tgname;
 
 -- Verify chunks still exist (upserted, not duplicated)
 SELECT COUNT(*) AS chunk_count FROM test_docs_content_chunks;


### PR DESCRIPTION
## Summary

`main` is currently red. `test/sql/vectorization.sql` lists triggers twice with no `ORDER BY`:

```sql
SELECT tgname FROM pg_trigger
WHERE tgname LIKE '%test_docs%vectorization%';
```

That was harmless while the query returned one row. #38 made vectorization install three triggers per column, so it now returns three, and an unordered scan of `pg_trigger` returns them in physical order.

Physical order is not stable across the suite — it shifts with whatever earlier tests left behind. Adding `pk_type_session` to `REGRESS` ahead of `vectorization` in #40 was enough to change it, and the test fails with the same three rows in a different sequence:

```
- test_docs_content_vectorization_trigger
  test_docs_content_9bafa066_vectorization_delete_trigger
  test_docs_content_9bafa066_vectorization_truncate_trigger
+ test_docs_content_vectorization_trigger
```

Neither PR is at fault on its own. #38 left an unordered query returning multiple rows, which happened to be stable until something perturbed it; #40 perturbed it. It only surfaced on merge because #40's branch predated #38, so its own CI ran against a tree where the query still returned one row.

## Fix

Add `ORDER BY tgname` to both listings and regenerate the expected output. The `name` type collates as `C`, so this is byte-order and does not vary with the database locale.

## Test plan

Verified against PostgreSQL 17.10.

- [x] Suite fails on unmodified `main` — `vectorization` only, purely on row order
- [x] All 18 tests pass with this change
- [x] Run twice to confirm the ordering is now stable rather than incidentally correct
- [x] Only the two listings changed; no assertion's meaning altered
