### PR TITLE
Fix _idf_stats table memory handling and a crash

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -62,6 +62,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   regardless of the configured value. The GUC now sets `max_attempts` at every
   point a chunk is queued: on initial chunking, on content updates, and on
   `recreate_chunks()` and `reprocess_chunks()`.
+- BM25 IDF statistics tables no longer store `total_docs` or `idf_weight`.
+  Both derive from the corpus size, which is a single value shared by every
+  term, so materialising them per row meant that any change to the corpus
+  invalidated every row at once and deleting a source row had to rewrite the
+  entire vocabulary to keep them true. That rewrite took a lock on every term,
+  so deletes of unrelated rows serialised against each other, and it ran even
+  for statements that removed nothing. A delete now updates only the terms
+  belonging to the rows it removed. The weights are computed when the
+  statistics are read and search results are unchanged.
 
 ### Removed
 
@@ -94,8 +103,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   previously installed an `AFTER INSERT OR UPDATE` trigger only, so removing
   source data left every piece of derived data in place: vector and hybrid
   search returned hits pointing at rows that no longer existed, the queue spent
-  embedding API calls on chunks for deleted rows, and `idf_weight` drifted for
-  the whole corpus, distorting relevance ranking for every query rather than
+  embedding API calls on chunks for deleted rows, and the IDF weighting drifted
+  for the whole corpus, distorting relevance ranking for every query rather than
   only those touching deleted rows.
 
   Vectorization now installs three triggers per column, adding an `AFTER DELETE`

--- a/sql/pgedge_vectorizer--1.0--1.1.sql
+++ b/sql/pgedge_vectorizer--1.0--1.1.sql
@@ -310,13 +310,12 @@ BEGIN
         WHERE sparse_embedding IS NOT NULL',
         chunk_table || '_sparse_idx', chunk_table);
 
-    -- Create BM25 IDF statistics table for this chunk table
+    -- Create BM25 IDF statistics table for this chunk table.
+    -- Only doc_freq is stored; the IDF weight is computed on read.
     EXECUTE format('
         CREATE TABLE IF NOT EXISTS %I (
             term        TEXT    PRIMARY KEY,
             doc_freq    INT     NOT NULL DEFAULT 1,
-            total_docs  INT     NOT NULL DEFAULT 1,
-            idf_weight  FLOAT8  NOT NULL DEFAULT 0.693,
             updated_at  TIMESTAMPTZ DEFAULT now()
         )', chunk_table || '_idf_stats');
 
@@ -1539,8 +1538,6 @@ BEGIN
             'CREATE TABLE IF NOT EXISTS %I ('
             '    term        TEXT    PRIMARY KEY,'
             '    doc_freq    INT     NOT NULL DEFAULT 1,'
-            '    total_docs  INT     NOT NULL DEFAULT 1,'
-            '    idf_weight  FLOAT8  NOT NULL DEFAULT 0.693,'
             '    updated_at  TIMESTAMPTZ DEFAULT now()'
             ')',
             chk_tbl || '_idf_stats');

--- a/sql/pgedge_vectorizer--1.0--1.1.sql
+++ b/sql/pgedge_vectorizer--1.0--1.1.sql
@@ -682,8 +682,6 @@ CREATE OR REPLACE FUNCTION pgedge_vectorizer.bm25_decrement_idf_stats(
     p_terms       TEXT[],
     p_deleted_chunks_count INT DEFAULT 1
 ) RETURNS VOID AS $$
-DECLARE
-    new_total INT;
 BEGIN
     IF p_terms IS NULL OR array_length(p_terms, 1) IS NULL THEN
         RETURN;
@@ -693,69 +691,18 @@ BEGIN
         RETURN;
     END IF;
 
-    -- Count chunks BEFORE the deletion so new_total reflects the post-delete
-    -- corpus size after deleting the current document's chunks.
-    EXECUTE format('SELECT GREATEST(count(*)::int - $1, 0) FROM %I', p_chunk_table)
-    INTO new_total
-    USING p_deleted_chunks_count;
-
     EXECUTE format(
         'UPDATE %I SET'
-        '    doc_freq   = GREATEST(doc_freq - $2, 0),'
-        '    total_docs = $1,'
-        '    idf_weight = CASE'
-        '                     WHEN GREATEST(doc_freq - $2, 0) <= 0 THEN 0.0'
-        '                     ELSE ln(1.0 + ($1::float8 - GREATEST(doc_freq - $2, 0) + 0.5)'
-        '                                  / (GREATEST(doc_freq - $2, 0) + 0.5))'
-        '                 END,'
+        '    doc_freq   = GREATEST(doc_freq - $1, 0),'
         '    updated_at = now()'
-        ' WHERE term = ANY($3)',
+        ' WHERE term = ANY($2)',
         p_chunk_table || '_idf_stats')
-    USING new_total, p_deleted_chunks_count, p_terms;
+    USING p_deleted_chunks_count, p_terms;
 END;
 $$ LANGUAGE plpgsql;
 
 COMMENT ON FUNCTION pgedge_vectorizer.bm25_decrement_idf_stats IS
 'Decrement doc_freq in the _idf_stats table for a set of terms before their source chunks are deleted';
-
--- Recompute total_docs and idf_weight for every term from the current chunk count.
---
--- bm25_decrement_idf_stats() sets total_docs from the chunk count at the moment
--- it runs, which is right for a single document but wrong when several are
--- removed by one statement: called once per document while the chunks are all
--- still present, every call sees the same unchanged count and only the last
--- one's value survives, leaving total_docs disagreeing with the doc_freq values
--- that did accumulate.  Call this once after the chunks have gone to bring the
--- corpus total back in step.
-CREATE OR REPLACE FUNCTION pgedge_vectorizer.bm25_resync_idf_totals(
-    p_chunk_table TEXT
-) RETURNS VOID AS $$
-DECLARE
-    total INT;
-BEGIN
-    IF to_regclass(p_chunk_table || '_idf_stats') IS NULL THEN
-        RETURN;
-    END IF;
-
-    EXECUTE format('SELECT count(*)::int FROM %I', p_chunk_table) INTO total;
-
-    EXECUTE format(
-        'UPDATE %I SET'
-        '    total_docs = $1,'
-        '    idf_weight = CASE'
-        '                     WHEN doc_freq <= 0 THEN 0.0'
-        '                     ELSE ln(1.0 + ($1::float8 - doc_freq + 0.5)'
-        '                                  / (doc_freq + 0.5))'
-        '                 END,'
-        '    updated_at = now()',
-        p_chunk_table || '_idf_stats')
-    USING total;
-END;
-$$ LANGUAGE plpgsql;
-
-COMMENT ON FUNCTION pgedge_vectorizer.bm25_resync_idf_totals IS
-'Recompute total_docs and idf_weight for all terms from the current chunk count';
-
 
 -- Statement-level trigger function cleaning up after DELETE on a source table.
 --
@@ -780,10 +727,8 @@ BEGIN
     pk_col      := COALESCE(TG_ARGV[2], 'id');
     pk_type     := COALESCE(TG_ARGV[3], 'bigint');
 
-    -- Decrement BM25 document frequencies before deleting anything, because
-    -- bm25_decrement_idf_stats() derives the new corpus size by counting the
-    -- chunk table and subtracting the count we pass it.  Doing this afterwards
-    -- would understate the corpus and skew idf_weight for every term.
+    -- Decrement BM25 document frequencies first: the loop counts each
+    -- document's chunks, which is only possible while they still exist.
     FOR old_row IN EXECUTE
         format('SELECT %I::text AS pk_value, %I::text AS content FROM old_rows',
                pk_col, content_col)
@@ -821,11 +766,6 @@ BEGIN
     EXECUTE format(
         'DELETE FROM %I WHERE source_id IN (SELECT o.%I::%s FROM old_rows o)',
         chunk_table, pk_col, pk_type);
-
-    -- Bring the corpus total back in step.  The per-document decrements above
-    -- each set total_docs from the then-unchanged chunk count, so on a bulk
-    -- delete only the last one's value would otherwise survive.
-    PERFORM pgedge_vectorizer.bm25_resync_idf_totals(chunk_table);
 
     RETURN NULL;
 END;

--- a/sql/pgedge_vectorizer--1.1.sql
+++ b/sql/pgedge_vectorizer--1.1.sql
@@ -302,13 +302,12 @@ BEGIN
         WHERE sparse_embedding IS NOT NULL',
         chunk_table || '_sparse_idx', chunk_table);
 
-    -- Create BM25 IDF statistics table for this chunk table
+    -- Create BM25 IDF statistics table for this chunk table.
+    -- Only doc_freq is stored; the IDF weight is computed on read.
     EXECUTE format('
         CREATE TABLE IF NOT EXISTS %I (
             term        TEXT    PRIMARY KEY,
             doc_freq    INT     NOT NULL DEFAULT 1,
-            total_docs  INT     NOT NULL DEFAULT 1,
-            idf_weight  FLOAT8  NOT NULL DEFAULT 0.693,
             updated_at  TIMESTAMPTZ DEFAULT now()
         )', chunk_table || '_idf_stats');
 

--- a/sql/pgedge_vectorizer--1.1.sql
+++ b/sql/pgedge_vectorizer--1.1.sql
@@ -674,8 +674,6 @@ CREATE OR REPLACE FUNCTION pgedge_vectorizer.bm25_decrement_idf_stats(
     p_terms       TEXT[],
     p_deleted_chunks_count INT DEFAULT 1
 ) RETURNS VOID AS $$
-DECLARE
-    new_total INT;
 BEGIN
     IF p_terms IS NULL OR array_length(p_terms, 1) IS NULL THEN
         RETURN;
@@ -685,69 +683,18 @@ BEGIN
         RETURN;
     END IF;
 
-    -- Count chunks BEFORE the deletion so new_total reflects the post-delete
-    -- corpus size after deleting the current document's chunks.
-    EXECUTE format('SELECT GREATEST(count(*)::int - $1, 0) FROM %I', p_chunk_table)
-    INTO new_total
-    USING p_deleted_chunks_count;
-
     EXECUTE format(
         'UPDATE %I SET'
-        '    doc_freq   = GREATEST(doc_freq - $2, 0),'
-        '    total_docs = $1,'
-        '    idf_weight = CASE'
-        '                     WHEN GREATEST(doc_freq - $2, 0) <= 0 THEN 0.0'
-        '                     ELSE ln(1.0 + ($1::float8 - GREATEST(doc_freq - $2, 0) + 0.5)'
-        '                                  / (GREATEST(doc_freq - $2, 0) + 0.5))'
-        '                 END,'
+        '    doc_freq   = GREATEST(doc_freq - $1, 0),'
         '    updated_at = now()'
-        ' WHERE term = ANY($3)',
+        ' WHERE term = ANY($2)',
         p_chunk_table || '_idf_stats')
-    USING new_total, p_deleted_chunks_count, p_terms;
+    USING p_deleted_chunks_count, p_terms;
 END;
 $$ LANGUAGE plpgsql;
 
 COMMENT ON FUNCTION pgedge_vectorizer.bm25_decrement_idf_stats IS
 'Decrement doc_freq in the _idf_stats table for a set of terms before their source chunks are deleted';
-
--- Recompute total_docs and idf_weight for every term from the current chunk count.
---
--- bm25_decrement_idf_stats() sets total_docs from the chunk count at the moment
--- it runs, which is right for a single document but wrong when several are
--- removed by one statement: called once per document while the chunks are all
--- still present, every call sees the same unchanged count and only the last
--- one's value survives, leaving total_docs disagreeing with the doc_freq values
--- that did accumulate.  Call this once after the chunks have gone to bring the
--- corpus total back in step.
-CREATE FUNCTION pgedge_vectorizer.bm25_resync_idf_totals(
-    p_chunk_table TEXT
-) RETURNS VOID AS $$
-DECLARE
-    total INT;
-BEGIN
-    IF to_regclass(p_chunk_table || '_idf_stats') IS NULL THEN
-        RETURN;
-    END IF;
-
-    EXECUTE format('SELECT count(*)::int FROM %I', p_chunk_table) INTO total;
-
-    EXECUTE format(
-        'UPDATE %I SET'
-        '    total_docs = $1,'
-        '    idf_weight = CASE'
-        '                     WHEN doc_freq <= 0 THEN 0.0'
-        '                     ELSE ln(1.0 + ($1::float8 - doc_freq + 0.5)'
-        '                                  / (doc_freq + 0.5))'
-        '                 END,'
-        '    updated_at = now()',
-        p_chunk_table || '_idf_stats')
-    USING total;
-END;
-$$ LANGUAGE plpgsql;
-
-COMMENT ON FUNCTION pgedge_vectorizer.bm25_resync_idf_totals IS
-'Recompute total_docs and idf_weight for all terms from the current chunk count';
-
 
 -- Statement-level trigger function cleaning up after DELETE on a source table.
 --
@@ -772,10 +719,8 @@ BEGIN
     pk_col      := COALESCE(TG_ARGV[2], 'id');
     pk_type     := COALESCE(TG_ARGV[3], 'bigint');
 
-    -- Decrement BM25 document frequencies before deleting anything, because
-    -- bm25_decrement_idf_stats() derives the new corpus size by counting the
-    -- chunk table and subtracting the count we pass it.  Doing this afterwards
-    -- would understate the corpus and skew idf_weight for every term.
+    -- Decrement BM25 document frequencies first: the loop counts each
+    -- document's chunks, which is only possible while they still exist.
     FOR old_row IN EXECUTE
         format('SELECT %I::text AS pk_value, %I::text AS content FROM old_rows',
                pk_col, content_col)
@@ -813,11 +758,6 @@ BEGIN
     EXECUTE format(
         'DELETE FROM %I WHERE source_id IN (SELECT o.%I::%s FROM old_rows o)',
         chunk_table, pk_col, pk_type);
-
-    -- Bring the corpus total back in step.  The per-document decrements above
-    -- each set total_docs from the then-unchanged chunk count, so on a bulk
-    -- delete only the last one's value would otherwise survive.
-    PERFORM pgedge_vectorizer.bm25_resync_idf_totals(chunk_table);
 
     RETURN NULL;
 END;

--- a/src/bm25.c
+++ b/src/bm25.c
@@ -114,8 +114,6 @@ typedef struct
 {
 	char   *term;
 	int     doc_freq;
-	int     total_docs;
-	float8  idf_weight;
 } IdfStat;
 
 /*
@@ -221,6 +219,38 @@ bm25_tokenize(const char *text, int *ntokens)
  */
 
 /*
+ * bm25_chunk_count — number of rows in the chunk table, i.e. the BM25
+ * corpus size N.  Clamped to a minimum of 1 so that callers dividing or
+ * taking logarithms never see zero.  Caller must have an active SPI
+ * connection.  count(*) is left uncast because ::int would raise
+ * "integer out of range" past 2^31 rows.
+ */
+static int64
+bm25_chunk_count(const char *chunk_table)
+{
+	char   *sql;
+	int     ret;
+	int64   total = 0;
+	bool    isnull;
+	Datum   val;
+
+	sql = psprintf("SELECT count(*) FROM %s",
+				   quote_identifier(chunk_table));
+	ret = SPI_execute(sql, true, 1);
+	pfree(sql);
+
+	if (ret == SPI_OK_SELECT && SPI_processed > 0)
+	{
+		val = SPI_getbinval(SPI_tuptable->vals[0],
+							SPI_tuptable->tupdesc, 1, &isnull);
+		if (!isnull)
+			total = DatumGetInt64(val);
+	}
+
+	return (total <= 0) ? 1 : total;
+}
+
+/*
  * read_idf_row — extract one IdfStat from a SPI result row
  */
 static IdfStat
@@ -236,12 +266,6 @@ read_idf_row(SPITupleTable *tuptable, int i)
 	val = SPI_getbinval(tuptable->vals[i], tuptable->tupdesc, 2, &isnull);
 	s.doc_freq = isnull ? 1 : DatumGetInt32(val);
 
-	val = SPI_getbinval(tuptable->vals[i], tuptable->tupdesc, 3, &isnull);
-	s.total_docs = isnull ? 1 : DatumGetInt32(val);
-
-	val = SPI_getbinval(tuptable->vals[i], tuptable->tupdesc, 4, &isnull);
-	s.idf_weight = isnull ? 0.693 : DatumGetFloat8(val);
-
 	return s;
 }
 
@@ -255,13 +279,13 @@ bm25_load_idf_stats(const char *chunk_table)
 	ResourceOwner    oldowner;
 	HTAB            *htab = NULL;
 	HASHCTL          ctl;
+	int64            total_docs = 1;
 
 	{
 		char       *tbl_name = psprintf("%s_idf_stats", chunk_table);
 		const char *qtbl     = quote_identifier(tbl_name);
 
-		sql = psprintf(
-			"SELECT term, doc_freq, total_docs, idf_weight FROM %s", qtbl);
+		sql = psprintf("SELECT term, doc_freq FROM %s", qtbl);
 		pfree(tbl_name);
 	}
 
@@ -275,6 +299,13 @@ bm25_load_idf_stats(const char *chunk_table)
 	BeginInternalSubTransaction(NULL);
 	PG_TRY();
 	{
+		/*
+		 * Must precede the stats query: SPI_execute() replaces SPI_tuptable,
+		 * so counting after would leave the loop reading the count(*) result
+		 * as (term, doc_freq).
+		 */
+		total_docs = bm25_chunk_count(chunk_table);
+
 		ret = SPI_execute(sql, true, 0);
 		ok  = true;
 		ReleaseCurrentSubTransaction();
@@ -321,7 +352,18 @@ bm25_load_idf_stats(const char *chunk_table)
 
 		entry = hash_search(htab, row.term, HASH_ENTER, &found);
 		if (!found)
-			entry->idf_weight = row.idf_weight;
+		{
+			/*
+			 * Derived, not stored: the corpus size is identical for every
+			 * term.  Expression shape matches the SQL it replaced so that
+			 * results are bit-identical.
+			 */
+			entry->idf_weight =
+				(row.doc_freq <= 0)
+					? 0.0
+					: log(1.0 + ((double) total_docs - row.doc_freq + 0.5)
+								/ (row.doc_freq + 0.5));
+		}
 		/* Duplicate terms: keep the first weight encountered */
 	}
 

--- a/src/bm25.c
+++ b/src/bm25.c
@@ -598,17 +598,16 @@ bm25_compute_sparse_vector(BM25Term *tokens, int ntokens,
  * bm25_update_idf_stats
  *
  * Upsert each token's term into {chunk_table}_idf_stats, incrementing
- * doc_freq and recomputing idf_weight.  Runs inside a subtransaction
- * so that a failure does not abort the outer worker transaction.
+ * doc_freq.  Runs inside a subtransaction so that a failure does not
+ * abort the outer worker transaction.
  * Caller must have an active SPI connection.
  */
 /*
- * upsert_term_idf — insert or update a single term's IDF stats row.
- * total_docs is pre-computed once by the caller; passing it here
- * avoids a full-table count(*) scan per term.
+ * upsert_term_idf — insert or increment a single term's document frequency.
+ * Only doc_freq is stored; the IDF weight is computed on read.
  */
 static void
-upsert_term_idf(const char *chunk_table, const char *term, int total_docs)
+upsert_term_idf(const char *chunk_table, const char *term)
 {
 	char       *safe_term  = quote_literal_cstr(term);
 	char       *tbl_name   = psprintf("%s_idf_stats", chunk_table);
@@ -617,20 +616,12 @@ upsert_term_idf(const char *chunk_table, const char *term, int total_docs)
 	int         ret;
 
 	sql = psprintf(
-		"INSERT INTO %s"
-		"    (term, doc_freq, total_docs, idf_weight)"
-		" VALUES (%s, 1, %d,"
-		"         ln(1.0 + (%d - 1.0 + 0.5) / (1.0 + 0.5)))"
+		"INSERT INTO %s (term, doc_freq)"
+		" VALUES (%s, 1)"
 		" ON CONFLICT (term) DO UPDATE SET"
 		"    doc_freq   = %s.doc_freq + 1,"
-		"    total_docs = %d,"
-		"    idf_weight = ln(1.0 +"
-		"        (%d - (%s.doc_freq + 1) + 0.5)"
-		"        / ((%s.doc_freq + 1) + 0.5)),"
 		"    updated_at = now()",
-		qidf, safe_term, total_docs, total_docs,
-		qidf,
-		total_docs, total_docs, qidf, qidf);
+		qidf, safe_term, qidf);
 
 	pfree(tbl_name);
 	pfree(safe_term);
@@ -649,31 +640,9 @@ bm25_update_idf_stats(const char *chunk_table,
 {
 	MemoryContext oldctx;
 	ResourceOwner oldowner;
-	int           total_docs = 0;
-	bool          isnull;
-	Datum         val;
-	char         *sql;
-	int           ret;
 
 	if (ntokens <= 0)
 		return;
-
-	/* Pre-compute total_docs once to avoid per-term count(*) scans */
-	sql = psprintf("SELECT count(*)::int FROM %s",
-				   quote_identifier(chunk_table));
-	ret = SPI_execute(sql, true, 1);
-	pfree(sql);
-
-	if (ret == SPI_OK_SELECT && SPI_processed > 0)
-	{
-		val = SPI_getbinval(SPI_tuptable->vals[0],
-							SPI_tuptable->tupdesc, 1, &isnull);
-		if (!isnull)
-			total_docs = DatumGetInt32(val);
-	}
-
-	if (total_docs <= 0)
-		total_docs = 1;
 
 	oldctx   = CurrentMemoryContext;
 	oldowner = CurrentResourceOwner;
@@ -682,7 +651,7 @@ bm25_update_idf_stats(const char *chunk_table,
 	PG_TRY();
 	{
 		for (int i = 0; i < ntokens; i++)
-			upsert_term_idf(chunk_table, tokens[i].term, total_docs);
+			upsert_term_idf(chunk_table, tokens[i].term);
 
 		ReleaseCurrentSubTransaction();
 	}

--- a/src/bm25.c
+++ b/src/bm25.c
@@ -332,7 +332,17 @@ bm25_load_idf_stats(const char *chunk_table, BM25Term *tokens, int ntokens)
 
 		ret = SPI_execute_with_args(sql, 1, &argtype, &terms, NULL, true, 0);
 		ok  = true;
+
+		/*
+		 * Restore the context and resource owner on the way out, as the
+		 * catch path does.  Releasing a subtransaction leaves them pointing
+		 * at its own owner, and a caller whose statement owns relations --
+		 * CREATE TABLE AS, for one -- then fails with "relcache reference is
+		 * not owned by resource owner".
+		 */
 		ReleaseCurrentSubTransaction();
+		MemoryContextSwitchTo(oldctx);
+		CurrentResourceOwner = oldowner;
 	}
 	PG_CATCH();
 	{
@@ -677,7 +687,10 @@ bm25_update_idf_stats(const char *chunk_table,
 		for (int i = 0; i < ntokens; i++)
 			upsert_term_idf(chunk_table, tokens[i].term);
 
+		/* Restore on the way out, as the catch path does */
 		ReleaseCurrentSubTransaction();
+		MemoryContextSwitchTo(oldctx);
+		CurrentResourceOwner = oldowner;
 	}
 	PG_CATCH();
 	{

--- a/src/bm25.c
+++ b/src/bm25.c
@@ -20,6 +20,7 @@
 #include <string.h>
 
 #include "access/xact.h"
+#include "catalog/pg_type.h"
 #include "lib/stringinfo.h"
 #include "utils/array.h"
 #include "utils/builtins.h"
@@ -270,7 +271,7 @@ read_idf_row(SPITupleTable *tuptable, int i)
 }
 
 HTAB *
-bm25_load_idf_stats(const char *chunk_table)
+bm25_load_idf_stats(const char *chunk_table, BM25Term *tokens, int ntokens)
 {
 	char            *sql;
 	int              ret;
@@ -280,12 +281,35 @@ bm25_load_idf_stats(const char *chunk_table)
 	HTAB            *htab = NULL;
 	HASHCTL          ctl;
 	int64            total_docs = 1;
+	Datum            terms;
+	Oid              argtype = TEXTARRAYOID;
+
+	if (tokens == NULL || ntokens <= 0)
+		return NULL;
+
+	/*
+	 * Only the caller's own terms are ever looked up, so fetch only those
+	 * rather than the whole vocabulary.  term is the primary key, making this
+	 * an index lookup; loading every row cost memory proportional to the
+	 * vocabulary on each call, and the worker calls this once per chunk.
+	 */
+	{
+		Datum *elems = palloc(ntokens * sizeof(Datum));
+
+		for (int i = 0; i < ntokens; i++)
+			elems[i] = CStringGetTextDatum(tokens[i].term);
+
+		terms = PointerGetDatum(construct_array(elems, ntokens, TEXTOID,
+												-1, false, TYPALIGN_INT));
+		pfree(elems);
+	}
 
 	{
 		char       *tbl_name = psprintf("%s_idf_stats", chunk_table);
 		const char *qtbl     = quote_identifier(tbl_name);
 
-		sql = psprintf("SELECT term, doc_freq FROM %s", qtbl);
+		sql = psprintf("SELECT term, doc_freq FROM %s WHERE term = ANY($1)",
+					   qtbl);
 		pfree(tbl_name);
 	}
 
@@ -306,7 +330,7 @@ bm25_load_idf_stats(const char *chunk_table)
 		 */
 		total_docs = bm25_chunk_count(chunk_table);
 
-		ret = SPI_execute(sql, true, 0);
+		ret = SPI_execute_with_args(sql, 1, &argtype, &terms, NULL, true, 0);
 		ok  = true;
 		ReleaseCurrentSubTransaction();
 	}
@@ -340,7 +364,7 @@ bm25_load_idf_stats(const char *chunk_table)
 	ctl.keysize   = BM25_MAX_TERM_LEN;
 	ctl.entrysize = sizeof(IdfHashEntry);
 	htab = hash_create("bm25_idf_stats",
-					   (int) SPI_processed * 2,
+					   ntokens,
 					   &ctl,
 					   HASH_ELEM | HASH_STRINGS);
 
@@ -712,7 +736,7 @@ pgedge_vectorizer_bm25_query_vector(PG_FUNCTION_ARGS)
 	SPI_connect();
 
 	tokens      = bm25_tokenize(query, &ntokens);
-	idf_htab    = bm25_load_idf_stats(chunk_table);
+	idf_htab    = bm25_load_idf_stats(chunk_table, tokens, ntokens);
 	avg_doc_len = bm25_avg_doc_len_internal(chunk_table);
 
 	result = bm25_compute_sparse_vector(

--- a/src/bm25.h
+++ b/src/bm25.h
@@ -62,7 +62,8 @@ extern double pgedge_vectorizer_bm25_b;
  * when done to release memory promptly.
  */
 BM25Term *bm25_tokenize(const char *text, int *ntokens);
-HTAB     *bm25_load_idf_stats(const char *chunk_table);
+HTAB     *bm25_load_idf_stats(const char *chunk_table,
+							  BM25Term *tokens, int ntokens);
 char     *bm25_compute_sparse_str(BM25Term *tokens, int ntokens,
 								  HTAB *idf_htab,
 								  float8 k1, float8 b,

--- a/src/worker.c
+++ b/src/worker.c
@@ -1130,7 +1130,7 @@ process_queue_batch(const char *dbname)
 								tokens = bm25_tokenize(contents[idx],
 													   &ntokens);
 								idf_htab = bm25_load_idf_stats(
-										chunk_tables[idx]);
+										chunk_tables[idx], tokens, ntokens);
 								avg_doc_len = bm25_avg_doc_len_internal(
 										chunk_tables[idx]);
 								sparse_str = bm25_compute_sparse_str(

--- a/test/expected/delete_truncate.out
+++ b/test/expected/delete_truncate.out
@@ -67,11 +67,39 @@ SELECT count(*) AS orphaned_queue_entries
                       0
 (1 row)
 
--- Seed BM25 statistics the way the worker would, so that the corpus accounting
--- below is actually exercised: the worker does not run during these tests, so
--- _idf_stats would otherwise be empty and the assertion vacuous.
-INSERT INTO dt_docs_body_chunks_idf_stats (term, doc_freq, total_docs, idf_weight)
-VALUES ('delta', 1, 2, 0.9), ('eta', 1, 2, 0.9);
+-- Seed BM25 statistics the way the worker would, so that the assertions below
+-- are actually exercised: the worker does not run during these tests, so
+-- _idf_stats would otherwise be empty and they would be vacuous.  Row 2's body
+-- supplies delta/epsilon/zeta and row 3's supplies eta/theta/iota.
+INSERT INTO dt_docs_body_chunks_idf_stats (term, doc_freq)
+VALUES ('delta', 1), ('epsilon', 1), ('zeta', 1),
+       ('eta', 1), ('theta', 1), ('iota', 1);
+-- A delete must touch only the terms of the document it removed.  Stamping
+-- every row first makes a table-wide rewrite visible: the corpus resync this
+-- replaced updated every row unconditionally, so terms belonging to documents
+-- that were not deleted had their updated_at bumped along with the rest.
+UPDATE dt_docs_body_chunks_idf_stats SET updated_at = 'epoch';
+DELETE FROM dt_docs WHERE id = 2;
+-- Terms belonging only to the surviving document must be untouched
+SELECT count(*) AS untouched_terms
+  FROM dt_docs_body_chunks_idf_stats
+ WHERE term IN ('eta', 'theta', 'iota')
+   AND updated_at = 'epoch';
+ untouched_terms 
+-----------------
+               3
+(1 row)
+
+-- while the deleted document's own terms must still have been decremented
+SELECT count(*) AS touched_terms
+  FROM dt_docs_body_chunks_idf_stats
+ WHERE term IN ('delta', 'epsilon', 'zeta')
+   AND updated_at <> 'epoch';
+ touched_terms 
+---------------
+             3
+(1 row)
+
 -- Bulk delete in a single statement, which is the case the statement-level
 -- trigger exists to handle without degenerating into per-row work
 DELETE FROM dt_docs;
@@ -79,18 +107,6 @@ SELECT count(*) AS chunks_after_bulk_delete FROM dt_docs_body_chunks;
  chunks_after_bulk_delete 
 --------------------------
                         0
-(1 row)
-
--- The corpus total must agree with the surviving chunk count. Decrementing per
--- document while the chunks are all still present sets total_docs from the same
--- unchanged count every time, so without a final resync only the last
--- document's value would survive and it would disagree with doc_freq.
-SELECT count(*) AS idf_rows_with_wrong_total
-  FROM dt_docs_body_chunks_idf_stats
- WHERE total_docs <> (SELECT count(*) FROM dt_docs_body_chunks);
- idf_rows_with_wrong_total 
----------------------------
-                         0
 (1 row)
 
 -- TRUNCATE also cleans up

--- a/test/expected/hybrid_test.out
+++ b/test/expected/hybrid_test.out
@@ -321,6 +321,28 @@ SELECT pgedge_vectorizer.bm25_query_vector(
  t
 (1 row)
 
+-- The loader fetches only the query's own terms, so vocabulary belonging to
+-- other documents must not affect the result. This guards the scoping against
+-- changing output; it cannot show the resource saving, which is why the number
+-- of rows loaded is not asserted here.
+--
+-- The baseline is held in a psql variable rather than a table: capturing it
+-- with CREATE TABLE AS crashes the backend on a pre-existing resource-owner
+-- bug in bm25_load_idf_stats(), unrelated to this test.
+SELECT pgedge_vectorizer.bm25_query_vector(
+    'testterm sample', 'hybrid_test_docs_content_chunks')::text AS baseline \gset
+INSERT INTO hybrid_test_docs_content_chunks_idf_stats (term, doc_freq)
+SELECT 'unrelated' || g, 1 FROM generate_series(1, 5000) g;
+SELECT :'baseline'::sparsevec
+       = pgedge_vectorizer.bm25_query_vector(
+             'testterm sample', 'hybrid_test_docs_content_chunks')
+       AS unchanged_by_unrelated_vocabulary;
+ unchanged_by_unrelated_vocabulary 
+-----------------------------------
+ t
+(1 row)
+
+DELETE FROM hybrid_test_docs_content_chunks_idf_stats WHERE term LIKE 'unrelated%';
 -- Clean up the test row
 DELETE FROM hybrid_test_docs_content_chunks_idf_stats WHERE term = 'testterm';
 ---------------------------------------------------------------------------

--- a/test/expected/hybrid_test.out
+++ b/test/expected/hybrid_test.out
@@ -311,6 +311,16 @@ WHERE term = 'testterm';
  testterm |        4
 (1 row)
 
+-- bm25_query_vector against a populated stats table.  Test 14 calls it while
+-- _idf_stats is empty, which returns early without building the IDF hash.
+SELECT pgedge_vectorizer.bm25_query_vector(
+    'testterm sample', 'hybrid_test_docs_content_chunks'
+) IS NOT NULL AS query_vector_with_populated_stats;
+ query_vector_with_populated_stats 
+-----------------------------------
+ t
+(1 row)
+
 -- Clean up the test row
 DELETE FROM hybrid_test_docs_content_chunks_idf_stats WHERE term = 'testterm';
 ---------------------------------------------------------------------------

--- a/test/expected/hybrid_test.out
+++ b/test/expected/hybrid_test.out
@@ -289,8 +289,8 @@ SELECT pgedge_vectorizer.bm25_decrement_idf_stats(
 ---------------------------------------------------------------------------
 -- Seed a term into the IDF stats table
 INSERT INTO hybrid_test_docs_content_chunks_idf_stats
-    (term, doc_freq, total_docs, idf_weight)
-VALUES ('testterm', 5, 10, 1.0);
+    (term, doc_freq)
+VALUES ('testterm', 5);
 -- Decrement by 1
 SELECT pgedge_vectorizer.bm25_decrement_idf_stats(
     'hybrid_test_docs_content_chunks',

--- a/test/expected/hybrid_test.out
+++ b/test/expected/hybrid_test.out
@@ -326,9 +326,6 @@ SELECT pgedge_vectorizer.bm25_query_vector(
 -- changing output; it cannot show the resource saving, which is why the number
 -- of rows loaded is not asserted here.
 --
--- The baseline is held in a psql variable rather than a table: capturing it
--- with CREATE TABLE AS crashes the backend on a pre-existing resource-owner
--- bug in bm25_load_idf_stats(), unrelated to this test.
 SELECT pgedge_vectorizer.bm25_query_vector(
     'testterm sample', 'hybrid_test_docs_content_chunks')::text AS baseline \gset
 INSERT INTO hybrid_test_docs_content_chunks_idf_stats (term, doc_freq)
@@ -343,6 +340,20 @@ SELECT :'baseline'::sparsevec
 (1 row)
 
 DELETE FROM hybrid_test_docs_content_chunks_idf_stats WHERE term LIKE 'unrelated%';
+-- bm25_query_vector() inside a statement that owns relations. The loader runs
+-- its SPI query in a subtransaction; if it does not restore the caller's
+-- resource owner on release, this aborts the backend with "relcache reference
+-- is not owned by resource owner". A plain SELECT does not catch it.
+CREATE TABLE bm25_owner_check AS
+SELECT pgedge_vectorizer.bm25_query_vector(
+    'testterm sample', 'hybrid_test_docs_content_chunks') AS v;
+SELECT count(*) AS rows_written FROM bm25_owner_check;
+ rows_written 
+--------------
+            1
+(1 row)
+
+DROP TABLE bm25_owner_check;
 -- Clean up the test row
 DELETE FROM hybrid_test_docs_content_chunks_idf_stats WHERE term = 'testterm';
 ---------------------------------------------------------------------------

--- a/test/expected/vectorization.out
+++ b/test/expected/vectorization.out
@@ -138,6 +138,17 @@ SELECT COUNT(*) AS chunk_count FROM test_docs_content_chunks;
            1
 (1 row)
 
+-- The stats table stores only the per-term quantity.  The corpus size is one
+-- value shared by every term and the IDF weight derives from it, so both are
+-- computed when the stats are read rather than materialised per row.
+SELECT string_agg(column_name, ', ' ORDER BY ordinal_position) AS idf_stats_columns
+  FROM information_schema.columns
+ WHERE table_name = 'test_docs_content_chunks_idf_stats';
+     idf_stats_columns      
+----------------------------
+ term, doc_freq, updated_at
+(1 row)
+
 -- Clean up
 SELECT pgedge_vectorizer.disable_vectorization('test_docs'::regclass, 'content', true);
 NOTICE:  Vectorization disabled and chunk table dropped: test_docs_content_chunks

--- a/test/sql/delete_truncate.sql
+++ b/test/sql/delete_truncate.sql
@@ -37,24 +37,38 @@ SELECT count(*) AS orphaned_queue_entries
  WHERE q.chunk_table = 'dt_docs_body_chunks'
    AND NOT EXISTS (SELECT 1 FROM dt_docs_body_chunks c WHERE c.id = q.chunk_id);
 
--- Seed BM25 statistics the way the worker would, so that the corpus accounting
--- below is actually exercised: the worker does not run during these tests, so
--- _idf_stats would otherwise be empty and the assertion vacuous.
-INSERT INTO dt_docs_body_chunks_idf_stats (term, doc_freq, total_docs, idf_weight)
-VALUES ('delta', 1, 2, 0.9), ('eta', 1, 2, 0.9);
+-- Seed BM25 statistics the way the worker would, so that the assertions below
+-- are actually exercised: the worker does not run during these tests, so
+-- _idf_stats would otherwise be empty and they would be vacuous.  Row 2's body
+-- supplies delta/epsilon/zeta and row 3's supplies eta/theta/iota.
+INSERT INTO dt_docs_body_chunks_idf_stats (term, doc_freq)
+VALUES ('delta', 1), ('epsilon', 1), ('zeta', 1),
+       ('eta', 1), ('theta', 1), ('iota', 1);
+
+-- A delete must touch only the terms of the document it removed.  Stamping
+-- every row first makes a table-wide rewrite visible: the corpus resync this
+-- replaced updated every row unconditionally, so terms belonging to documents
+-- that were not deleted had their updated_at bumped along with the rest.
+UPDATE dt_docs_body_chunks_idf_stats SET updated_at = 'epoch';
+
+DELETE FROM dt_docs WHERE id = 2;
+
+-- Terms belonging only to the surviving document must be untouched
+SELECT count(*) AS untouched_terms
+  FROM dt_docs_body_chunks_idf_stats
+ WHERE term IN ('eta', 'theta', 'iota')
+   AND updated_at = 'epoch';
+
+-- while the deleted document's own terms must still have been decremented
+SELECT count(*) AS touched_terms
+  FROM dt_docs_body_chunks_idf_stats
+ WHERE term IN ('delta', 'epsilon', 'zeta')
+   AND updated_at <> 'epoch';
 
 -- Bulk delete in a single statement, which is the case the statement-level
 -- trigger exists to handle without degenerating into per-row work
 DELETE FROM dt_docs;
 SELECT count(*) AS chunks_after_bulk_delete FROM dt_docs_body_chunks;
-
--- The corpus total must agree with the surviving chunk count. Decrementing per
--- document while the chunks are all still present sets total_docs from the same
--- unchanged count every time, so without a final resync only the last
--- document's value would survive and it would disagree with doc_freq.
-SELECT count(*) AS idf_rows_with_wrong_total
-  FROM dt_docs_body_chunks_idf_stats
- WHERE total_docs <> (SELECT count(*) FROM dt_docs_body_chunks);
 
 -- TRUNCATE also cleans up
 INSERT INTO dt_docs (body) VALUES (repeat('kappa lambda mu ', 20));

--- a/test/sql/hybrid_test.sql
+++ b/test/sql/hybrid_test.sql
@@ -255,6 +255,27 @@ SELECT pgedge_vectorizer.bm25_query_vector(
     'testterm sample', 'hybrid_test_docs_content_chunks'
 ) IS NOT NULL AS query_vector_with_populated_stats;
 
+-- The loader fetches only the query's own terms, so vocabulary belonging to
+-- other documents must not affect the result. This guards the scoping against
+-- changing output; it cannot show the resource saving, which is why the number
+-- of rows loaded is not asserted here.
+--
+-- The baseline is held in a psql variable rather than a table: capturing it
+-- with CREATE TABLE AS crashes the backend on a pre-existing resource-owner
+-- bug in bm25_load_idf_stats(), unrelated to this test.
+SELECT pgedge_vectorizer.bm25_query_vector(
+    'testterm sample', 'hybrid_test_docs_content_chunks')::text AS baseline \gset
+
+INSERT INTO hybrid_test_docs_content_chunks_idf_stats (term, doc_freq)
+SELECT 'unrelated' || g, 1 FROM generate_series(1, 5000) g;
+
+SELECT :'baseline'::sparsevec
+       = pgedge_vectorizer.bm25_query_vector(
+             'testterm sample', 'hybrid_test_docs_content_chunks')
+       AS unchanged_by_unrelated_vocabulary;
+
+DELETE FROM hybrid_test_docs_content_chunks_idf_stats WHERE term LIKE 'unrelated%';
+
 -- Clean up the test row
 DELETE FROM hybrid_test_docs_content_chunks_idf_stats WHERE term = 'testterm';
 

--- a/test/sql/hybrid_test.sql
+++ b/test/sql/hybrid_test.sql
@@ -249,6 +249,12 @@ SELECT term, doc_freq
 FROM hybrid_test_docs_content_chunks_idf_stats
 WHERE term = 'testterm';
 
+-- bm25_query_vector against a populated stats table.  Test 14 calls it while
+-- _idf_stats is empty, which returns early without building the IDF hash.
+SELECT pgedge_vectorizer.bm25_query_vector(
+    'testterm sample', 'hybrid_test_docs_content_chunks'
+) IS NOT NULL AS query_vector_with_populated_stats;
+
 -- Clean up the test row
 DELETE FROM hybrid_test_docs_content_chunks_idf_stats WHERE term = 'testterm';
 

--- a/test/sql/hybrid_test.sql
+++ b/test/sql/hybrid_test.sql
@@ -234,8 +234,8 @@ SELECT pgedge_vectorizer.bm25_decrement_idf_stats(
 
 -- Seed a term into the IDF stats table
 INSERT INTO hybrid_test_docs_content_chunks_idf_stats
-    (term, doc_freq, total_docs, idf_weight)
-VALUES ('testterm', 5, 10, 1.0);
+    (term, doc_freq)
+VALUES ('testterm', 5);
 
 -- Decrement by 1
 SELECT pgedge_vectorizer.bm25_decrement_idf_stats(

--- a/test/sql/hybrid_test.sql
+++ b/test/sql/hybrid_test.sql
@@ -260,9 +260,6 @@ SELECT pgedge_vectorizer.bm25_query_vector(
 -- changing output; it cannot show the resource saving, which is why the number
 -- of rows loaded is not asserted here.
 --
--- The baseline is held in a psql variable rather than a table: capturing it
--- with CREATE TABLE AS crashes the backend on a pre-existing resource-owner
--- bug in bm25_load_idf_stats(), unrelated to this test.
 SELECT pgedge_vectorizer.bm25_query_vector(
     'testterm sample', 'hybrid_test_docs_content_chunks')::text AS baseline \gset
 
@@ -275,6 +272,16 @@ SELECT :'baseline'::sparsevec
        AS unchanged_by_unrelated_vocabulary;
 
 DELETE FROM hybrid_test_docs_content_chunks_idf_stats WHERE term LIKE 'unrelated%';
+
+-- bm25_query_vector() inside a statement that owns relations. The loader runs
+-- its SPI query in a subtransaction; if it does not restore the caller's
+-- resource owner on release, this aborts the backend with "relcache reference
+-- is not owned by resource owner". A plain SELECT does not catch it.
+CREATE TABLE bm25_owner_check AS
+SELECT pgedge_vectorizer.bm25_query_vector(
+    'testterm sample', 'hybrid_test_docs_content_chunks') AS v;
+SELECT count(*) AS rows_written FROM bm25_owner_check;
+DROP TABLE bm25_owner_check;
 
 -- Clean up the test row
 DELETE FROM hybrid_test_docs_content_chunks_idf_stats WHERE term = 'testterm';

--- a/test/sql/vectorization.sql
+++ b/test/sql/vectorization.sql
@@ -76,6 +76,13 @@ ORDER BY tgname;
 -- Verify chunks still exist (upserted, not duplicated)
 SELECT COUNT(*) AS chunk_count FROM test_docs_content_chunks;
 
+-- The stats table stores only the per-term quantity.  The corpus size is one
+-- value shared by every term and the IDF weight derives from it, so both are
+-- computed when the stats are read rather than materialised per row.
+SELECT string_agg(column_name, ', ' ORDER BY ordinal_position) AS idf_stats_columns
+  FROM information_schema.columns
+ WHERE table_name = 'test_docs_content_chunks_idf_stats';
+
 -- Clean up
 SELECT pgedge_vectorizer.disable_vectorization('test_docs'::regclass, 'content', true);
 DROP TABLE test_docs;


### PR DESCRIPTION
Stacked on https://github.com/pgEdge/pgedge-vectorizer/pull/43; merge that first.

Two fixes in bm25.c, both found while addressing the IDF load.

1. Load only the terms the caller asks for. bm25_load_idf_stats() selected the entire _idf_stats table and copied it into a dynahash — 136 bytes per entry, per backend, per call. The worker does this once per chunk, so ingesting 10,000 chunks reloaded the whole vocabulary 10,000 times.

Nothing ever iterated that hash; the only read is lookup_idf() over the caller's own tokens. So the query is now scoped with WHERE term = ANY($1), an index lookup on the primary key. Both call sites already tokenised before loading.

With a 200,000-term vocabulary, 200 bm25_query_vector calls:

┌────────┬───────────┐
 │        │   time    │
├────────┼───────────┤
 │ before │ 73.190 ms │
├────────┼───────────┤
│ after  │ 1.082 ms  │
└────────┴───────────┘

Results are byte-identical. Semantics are unchanged by construction: lookup_idf() returns log(2.0) both for a NULL hash and for an absent term, so loading less can't change an outcome.

Sizing the hash from ntokens also removes an overflow — the old (int) SPI_processed * 2 cast a uint64 row count to int and doubled it, going negative past ~1.07 billion terms.

2. Restore the caller's resource owner after the IDF subtransactions. bm25_load_idf_stats() and bm25_update_idf_stats() restore the memory context and resource owner in their PG_CATCH paths but not after ReleaseCurrentSubTransaction() on the way out normally. A plain SELECT tolerates that, which is why every existing test passed. A statement that owns relations does not — bm25_query_vector() inside CREATE TABLE AS aborts the backend:

ERROR: relcache reference 0x... is not owned by resource owner TopTransaction

and takes the server into crash recovery. This is pre-existing — reproduced on the unmodified tree before any change here. Fixed on both success paths, matching the idiom PL/pgSQL uses in exec_stmt_block().

Notes

Stacked on #43; merge that first. The two IDF changes touch the same function, and composed in this order the result is clean.

The scoping test only guards the refactor — it asserts unrelated vocabulary doesn't change the result. It can't demonstrate the resource saving; the figures above are the evidence for that.

There is a memory leak that will be addressed separately.

Test plan

Verified against PostgreSQL 17.10.

- [x] All 19 regression tests pass from a clean build
- [x] hybrid_test output unchanged — ranking is unaffected
- [x] Crash test uses CREATE TABLE AS: crashes the backend without the fix, one row written with it
- [x] Both subtransaction sites fixed, not just the one that surfaced the bug