### PR TITLE
Tie the IDF hash to the caller's memory context

### DIFF
--- a/src/bm25.c
+++ b/src/bm25.c
@@ -304,14 +304,19 @@ bm25_load_idf_stats(const char *chunk_table)
 	if (!ok || ret != SPI_OK_SELECT || SPI_processed == 0)
 		return NULL;
 
-	/* Build hash table from SPI results for O(1) lookups */
+	/*
+	 * Build hash table from SPI results for O(1) lookups.  HASH_CONTEXT ties
+	 * it to the caller's SPI context; the default is TopMemoryContext, which
+	 * leaks whenever an error is reached before hash_destroy().
+	 */
 	memset(&ctl, 0, sizeof(ctl));
 	ctl.keysize   = BM25_MAX_TERM_LEN;
 	ctl.entrysize = sizeof(IdfHashEntry);
+	ctl.hcxt      = CurrentMemoryContext;
 	htab = hash_create("bm25_idf_stats",
 					   (int) SPI_processed * 2,
 					   &ctl,
-					   HASH_ELEM | HASH_STRINGS);
+					   HASH_ELEM | HASH_STRINGS | HASH_CONTEXT);
 
 	for (int i = 0; i < (int) SPI_processed; i++)
 	{


### PR DESCRIPTION
## Summary

`bm25_load_idf_stats()` calls `hash_create()` without `HASH_CONTEXT`, so dynahash parents the table on `TopMemoryContext` (`dynahash.c:383-386`). Nothing resets that short of backend exit, so any error reached before `hash_destroy()` strands the allocation for the life of the session — one per occurrence, cumulative.

The background worker makes it reachable: its per-chunk `PG_CATCH` (`src/worker.c:1191`) does not destroy the table and continues the loop, and the retry path puts the failing item back as `pending`. A queue item that keeps failing leaks on every attempt.

Each stray is ~8 KB regardless of vocabulary size — that is the `ALLOCSET_DEFAULT_INITSIZE` block, not the entry count.

## Fix

Pass the caller's context:

```diff
+	ctl.hcxt      = CurrentMemoryContext;
-					   HASH_ELEM | HASH_STRINGS);
+					   HASH_ELEM | HASH_STRINGS | HASH_CONTEXT);
```

`CurrentMemoryContext` at that point is `SPI Proc < TopTransactionContext < TopMemoryContext` — measured, not assumed, and identical for a plain `SELECT`, inside `CREATE TABLE AS`, and inside a PL/pgSQL block. It is created before the hash and torn down after every use of it in both callers, so there is no risk of the table being freed while still live. Worst case becomes "held until the transaction ends" instead of "held forever".

## Test plan

Repro: a table whose `_idf_stats` companion exists but which lacks `token_count`, so the load succeeds and `bm25_avg_doc_len_internal()` then errors before `hash_destroy()` is reached.

| | orphaned `bm25_idf_stats` contexts | bytes |
|---|---:|---:|
| before | 5 | 40,960 |
| after | 0 | 0 |

- [x] Five failing calls in one session, counted via `pg_backend_memory_contexts`
- [x] All 19 regression tests pass from a clean build (PostgreSQL 17.10)

No regression test: the fixture is deliberately malformed and the assertion would couple a test to backend memory internals. The measurement above is the evidence.
