### PR TITLE
Back off when a worker cannot start at all

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,10 @@ test/isolationcheck_tmp_check/
 # PGXS creates tmp_check at the top level for TAP tests, since that is where
 # the Makefile invoking prove lives
 tmp_check/
+# PostgreSQL::Test writes its per-test logs alongside it, into log/. These are
+# named regress_log_* and *.log, so the *.log rule below does not cover them
+# all, and the directory has to be ignored outright.
+log/
 
 # PostgreSQL extension build files
 *.control.in

--- a/README.md
+++ b/README.md
@@ -438,6 +438,11 @@ ALTER SYSTEM SET pgedge_vectorizer.num_workers = 4;
 SELECT pg_reload_conf();
 ```
 
+Workers are drawn from `max_worker_processes`, so raising `num_workers` beyond
+the slots left spare there achieves nothing; the launcher simply logs that
+`max_worker_processes` may be exhausted and carries on with what it has.
+Raising `max_worker_processes` itself does require a restart.
+
 2. Increase batch size:
 ```sql
 ALTER SYSTEM SET pgedge_vectorizer.batch_size = 20;

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -40,6 +40,11 @@ ALTER SYSTEM SET pgedge_vectorizer.num_workers = 4;
 SELECT pg_reload_conf();
 ```
 
+Workers are drawn from `max_worker_processes`, so raising `num_workers` beyond
+the slots left spare there achieves nothing; the launcher simply logs that
+`max_worker_processes` may be exhausted and carries on with what it has.
+Raising `max_worker_processes` itself does require a restart.
+
 2. Increase batch size:
 ```sql
 ALTER SYSTEM SET pgedge_vectorizer.batch_size = 20;

--- a/src/worker.c
+++ b/src/worker.c
@@ -50,11 +50,57 @@ typedef struct LauncherSlot
 	char		dbname[NAMEDATALEN];
 	BackgroundWorkerHandle *handle;
 	bool		terminating;	/* asked to stop; awaiting confirmation */
+	TimestampTz spawn_time;		/* when this worker was registered */
 } LauncherSlot;
 
 static LauncherSlot launcher_slots[PGEDGE_VECTORIZER_MAX_WORKERS];
 static int	launcher_nslots = 0;
 static int	launcher_cursor = 0;	/* round-robin position in the database list */
+
+/*
+ * Failed-start backoff.
+ *
+ * A worker that cannot start at all, because its database does not exist or
+ * will not accept connections, exits within a few milliseconds, and the exit
+ * notification brings the launcher straight back round to spawn a replacement.
+ * Nothing in the spawn path rate limits that, so the launcher forks as fast as
+ * the postmaster will oblige: left alone it burns thousands of PIDs a minute
+ * and fills the log at a comparable rate. A single mistyped name in
+ * pgedge_vectorizer.databases is enough to provoke it.
+ *
+ * A worker is judged to have failed to start if it exits within
+ * LAUNCHER_FAILED_START_MS of being spawned. Its database is then held off for
+ * an interval that doubles on each successive failure, from
+ * LAUNCHER_RETRY_INTERVAL_MIN_MS up to LAUNCHER_RETRY_INTERVAL_MAX_MS, which
+ * mirrors the extension-not-installed backoff in
+ * pgedge_vectorizer_worker_main(). A worker that lives longer than the
+ * threshold clears its database's backoff, so a database that recovers is
+ * serviced at full speed again.
+ *
+ * The threshold sits below the one second minimum of
+ * pgedge_vectorizer.worker_service_quantum, so a worker yielding its slot at
+ * the end of a quantum can never be mistaken for one that failed to start. It
+ * is still two orders of magnitude more than a failing worker needs to reach
+ * its FATAL, so the distinction is not a fine one in practice.
+ *
+ * This state is keyed by database name rather than held on the slot, because
+ * launcher_reap_workers() drops the slot at the moment the worker exits and
+ * the backoff has to outlive it.
+ */
+#define LAUNCHER_FAILED_START_MS			500
+#define LAUNCHER_RETRY_INTERVAL_MIN_MS		5000
+#define LAUNCHER_RETRY_INTERVAL_MAX_MS		300000
+
+typedef struct LauncherBackoff
+{
+	char		dbname[NAMEDATALEN];
+	int			interval_ms;	/* interval applied for the latest failure */
+	TimestampTz retry_after;	/* no further attempt before this */
+} LauncherBackoff;
+
+static LauncherBackoff *launcher_backoffs = NULL;
+static int	launcher_nbackoffs = 0;
+static int	launcher_backoffs_size = 0;
 
 /*
  * Sweep intervals.
@@ -72,6 +118,9 @@ static int	launcher_cursor = 0;	/* round-robin position in the database list */
  * Sweep briskly whilst databases are queued waiting for a turn, since a missed
  * wakeup there costs throughput, and rarely once every database has its own
  * resident worker.
+ *
+ * Whichever applies is shortened when a failed-start backoff is due to expire
+ * sooner, so that a database being retried does not wait out the idle sweep.
  */
 #define LAUNCHER_SWEEP_INTERVAL_ROTATING_MS		1000
 #define LAUNCHER_SWEEP_INTERVAL_IDLE_MS			60000
@@ -94,6 +143,11 @@ static BackgroundWorkerHandle *launch_worker_for_database(const char *dbname);
 static void launcher_reap_workers(void);
 static bool database_has_worker(const char *dbname);
 static void launcher_sweep(char **db_names, int db_count);
+static LauncherBackoff *launcher_backoff_find(const char *dbname);
+static void launcher_backoff_record(const char *dbname);
+static void launcher_backoff_clear(const char *dbname);
+static void launcher_backoff_prune(char **db_names, int db_count);
+static long launcher_backoff_next_retry_ms(TimestampTz now);
 
 /*
  * Signal handler for SIGTERM
@@ -316,12 +370,169 @@ launch_worker_for_database(const char *dbname)
 }
 
 /*
+ * Find the backoff entry for a database, or NULL if it has none.
+ */
+static LauncherBackoff *
+launcher_backoff_find(const char *dbname)
+{
+	for (int i = 0; i < launcher_nbackoffs; i++)
+	{
+		if (strcmp(launcher_backoffs[i].dbname, dbname) == 0)
+			return &launcher_backoffs[i];
+	}
+
+	return NULL;
+}
+
+/*
+ * Note that a worker for this database failed to start, and hold the database
+ * off for a while before trying again.
+ *
+ * The interval doubles on each consecutive failure, so a database that is
+ * briefly unavailable is retried promptly whilst one that is misconfigured
+ * settles at a rate that costs nothing to leave running indefinitely.
+ */
+static void
+launcher_backoff_record(const char *dbname)
+{
+	LauncherBackoff *entry = launcher_backoff_find(dbname);
+
+	if (entry == NULL)
+	{
+		/*
+		 * Entries are bounded by the number of configured databases, since
+		 * launcher_backoff_prune() drops those that leave the list.
+		 */
+		if (launcher_nbackoffs >= launcher_backoffs_size)
+		{
+			int			newsize = (launcher_backoffs_size == 0)
+				? 8 : launcher_backoffs_size * 2;
+
+			if (launcher_backoffs == NULL)
+				launcher_backoffs = palloc(newsize * sizeof(LauncherBackoff));
+			else
+				launcher_backoffs = repalloc(launcher_backoffs,
+											 newsize * sizeof(LauncherBackoff));
+			launcher_backoffs_size = newsize;
+		}
+
+		entry = &launcher_backoffs[launcher_nbackoffs++];
+		strlcpy(entry->dbname, dbname, NAMEDATALEN);
+		entry->interval_ms = LAUNCHER_RETRY_INTERVAL_MIN_MS;
+	}
+	else
+	{
+		entry->interval_ms = Min(entry->interval_ms * 2,
+								 LAUNCHER_RETRY_INTERVAL_MAX_MS);
+	}
+
+	entry->retry_after = TimestampTzPlusMilliseconds(GetCurrentTimestamp(),
+													entry->interval_ms);
+
+	elog(LOG, "pgedge_vectorizer launcher: worker for database \"%s\" exited "
+		 "immediately, retrying in %dms", dbname, entry->interval_ms);
+}
+
+/*
+ * Forget any backoff for a database, so that it is serviced at full speed
+ * again once a worker of its own has run successfully.
+ */
+static void
+launcher_backoff_clear(const char *dbname)
+{
+	LauncherBackoff *entry = launcher_backoff_find(dbname);
+
+	if (entry == NULL)
+		return;
+
+	/* Compact the array by moving the final entry into the hole */
+	*entry = launcher_backoffs[launcher_nbackoffs - 1];
+	launcher_nbackoffs--;
+}
+
+/*
+ * Drop backoff entries for databases that are no longer configured, so that
+ * the array cannot outgrow the database list.
+ *
+ * Removing a database and putting it back therefore earns it an immediate
+ * attempt, which is the right answer: the operator has just changed something.
+ */
+static void
+launcher_backoff_prune(char **db_names, int db_count)
+{
+	int			i = 0;
+
+	while (i < launcher_nbackoffs)
+	{
+		bool		still_configured = false;
+
+		for (int j = 0; j < db_count; j++)
+		{
+			if (strcmp(launcher_backoffs[i].dbname, db_names[j]) == 0)
+			{
+				still_configured = true;
+				break;
+			}
+		}
+
+		if (still_configured)
+			i++;
+		else
+		{
+			launcher_backoffs[i] = launcher_backoffs[launcher_nbackoffs - 1];
+			launcher_nbackoffs--;
+		}
+	}
+}
+
+/*
+ * Milliseconds until the earliest retry still in the future, or -1 if there is
+ * none to wait for.
+ *
+ * Entries that have already come due are skipped rather than reported as due
+ * now. The sweep will have taken any it could, so one still sitting here is
+ * waiting on a worker slot rather than on the clock, and returning a zero or
+ * one millisecond timeout for it would spin the launcher until a slot freed.
+ * The exit notification covers that case, and the sweep interval backs it up.
+ *
+ * Never returns zero, so a sub-millisecond wait cannot spin either.
+ */
+static long
+launcher_backoff_next_retry_ms(TimestampTz now)
+{
+	long		earliest = -1;
+
+	for (int i = 0; i < launcher_nbackoffs; i++)
+	{
+		long		secs;
+		int			usecs;
+		long		msecs;
+
+		if (launcher_backoffs[i].retry_after <= now)
+			continue;
+
+		TimestampDifference(now, launcher_backoffs[i].retry_after,
+							&secs, &usecs);
+		msecs = secs * 1000 + usecs / 1000;
+
+		if (msecs < 1)
+			msecs = 1;
+
+		if (earliest < 0 || msecs < earliest)
+			earliest = msecs;
+	}
+
+	return earliest;
+}
+
+/*
  * Drop tracking entries for workers that have exited.
  */
 static void
 launcher_reap_workers(void)
 {
 	int			i = 0;
+	TimestampTz now = GetCurrentTimestamp();
 
 	while (i < launcher_nslots)
 	{
@@ -329,6 +540,19 @@ launcher_reap_workers(void)
 
 		if (GetBackgroundWorkerPid(launcher_slots[i].handle, &pid) == BGWH_STOPPED)
 		{
+			/*
+			 * A worker that exited almost as soon as it was spawned never got
+			 * as far as doing any work, so hold its database off rather than
+			 * spinning on it. One we asked to stop does not count, however
+			 * promptly it obliged.
+			 */
+			if (!launcher_slots[i].terminating &&
+				!TimestampDifferenceExceeds(launcher_slots[i].spawn_time, now,
+											LAUNCHER_FAILED_START_MS))
+				launcher_backoff_record(launcher_slots[i].dbname);
+			else
+				launcher_backoff_clear(launcher_slots[i].dbname);
+
 			pfree(launcher_slots[i].handle);
 
 			/* Compact the array by moving the final entry into the hole */
@@ -434,22 +658,31 @@ launcher_sweep(char **db_names, int db_count)
 {
 	int			visited;
 	bool		warned = false;
+	TimestampTz now;
 
 	if (db_count == 0)
 		return;
 
 	launcher_retire_surplus();
 
+	now = GetCurrentTimestamp();
+
 	for (visited = 0; visited < db_count; visited++)
 	{
 		int			idx = (launcher_cursor + visited) % db_count;
 		const char *dbname = db_names[idx];
+		LauncherBackoff *backoff;
 		BackgroundWorkerHandle *handle;
 
 		if (launcher_nslots >= pgedge_vectorizer_num_workers)
 			break;
 
 		if (database_has_worker(dbname))
+			continue;
+
+		/* Still serving out a failed-start backoff; leave it for a later pass */
+		backoff = launcher_backoff_find(dbname);
+		if (backoff != NULL && now < backoff->retry_after)
 			continue;
 
 		handle = launch_worker_for_database(dbname);
@@ -468,6 +701,7 @@ launcher_sweep(char **db_names, int db_count)
 		strlcpy(launcher_slots[launcher_nslots].dbname, dbname, NAMEDATALEN);
 		launcher_slots[launcher_nslots].handle = handle;
 		launcher_slots[launcher_nslots].terminating = false;
+		launcher_slots[launcher_nslots].spawn_time = GetCurrentTimestamp();
 		launcher_nslots++;
 	}
 
@@ -496,6 +730,8 @@ launcher_reload_databases(char ***db_names, int old_count, bool *logged_empty)
 	}
 
 	db_count = parse_database_list(db_names);
+
+	launcher_backoff_prune(*db_names, db_count);
 
 	if (db_count == 0)
 	{
@@ -564,6 +800,7 @@ pgedge_vectorizer_launcher_main(Datum main_arg)
 	{
 		int			rc;
 		long		sweep_interval;
+		long		retry_ms;
 
 		/* Reload configuration if SIGHUP received */
 		if (got_sighup)
@@ -591,6 +828,14 @@ pgedge_vectorizer_launcher_main(Datum main_arg)
 		sweep_interval = (db_count > pgedge_vectorizer_num_workers)
 			? LAUNCHER_SWEEP_INTERVAL_ROTATING_MS
 			: LAUNCHER_SWEEP_INTERVAL_IDLE_MS;
+
+		/*
+		 * Come back for the earliest pending retry if that falls sooner, so a
+		 * backed-off database is not left waiting out the whole sweep.
+		 */
+		retry_ms = launcher_backoff_next_retry_ms(GetCurrentTimestamp());
+		if (retry_ms >= 0 && retry_ms < sweep_interval)
+			sweep_interval = retry_ms;
 
 		rc = WaitLatch(MyLatch,
 					   WL_LATCH_SET | WL_TIMEOUT | WL_POSTMASTER_DEATH,

--- a/test/t/003_launcher_failed_start_backoff.pl
+++ b/test/t/003_launcher_failed_start_backoff.pl
@@ -1,0 +1,98 @@
+# Copyright (c) 2025 - 2026, pgEdge, Inc.
+#
+# Verify that the launcher backs off when a worker cannot start at all, instead
+# of respawning it as fast as the postmaster will fork.
+#
+# Per-database workers are BGW_NEVER_RESTART, so the launcher owns respawn, and
+# it is told a worker exited by the bgw_notify_pid notification. A worker whose
+# database does not exist reaches its FATAL within a few milliseconds of being
+# spawned, so that notification arrives almost immediately and sends the
+# launcher straight back round to spawn a replacement. Nothing in the spawn path
+# rate limits that by itself.
+#
+# Before the backoff, a single mistyped name in pgedge_vectorizer.databases was
+# therefore enough to have the launcher fork of the order of two hundred
+# doomed workers a second indefinitely, consuming PIDs and writing megabytes of
+# log a minute. The launcher now treats a worker that exits within
+# LAUNCHER_FAILED_START_MS of being spawned as having failed to start, and holds
+# its database off for an interval that doubles from 5s to a 5 minute cap.
+#
+# The margin here is enormous, which is what makes the test worth having: over
+# the ten second window below the unthrottled launcher manages thousands of
+# attempts and the throttled one manages two.
+#
+# Note the log offset captured before the node starts. PostgreSQL::Test keeps
+# logs in ./log when run directly, and that directory persists between runs in a
+# given build tree, so counting from the top of the file would mix in the
+# previous run's attempts and could pass against a binary without the fix.
+
+use strict;
+use warnings;
+
+# See the comment in 001_worker_coverage.pl about loading these at compile time.
+use PostgreSQL::Test::Cluster;
+use PostgreSQL::Test::Utils;
+use Test::More;
+
+my $missing = 'backoff_missing_db';
+
+my $node = PostgreSQL::Test::Cluster->new('vectorizer_backoff');
+$node->init;
+$node->append_conf(
+	'postgresql.conf', qq(
+shared_preload_libraries = 'pgedge_vectorizer'
+pgedge_vectorizer.databases = '$missing'
+pgedge_vectorizer.num_workers = 2
+pgedge_vectorizer.worker_poll_interval = 200
+max_worker_processes = 16
+));
+
+my $log_offset = (-s $node->logfile) // 0;
+
+$node->start;
+
+# Long enough for the first attempt and the retry when the initial 5s backoff
+# expires, and long enough that an unthrottled launcher would be well into four
+# figures.
+sleep 10;
+
+my $log = slurp_file($node->logfile, $log_offset);
+my @attempts = ($log =~ /database "\Q$missing\E" does not exist/g);
+
+cmp_ok(scalar(@attempts), '>', 0,
+	'the launcher does attempt to start a worker for the missing database');
+
+cmp_ok(scalar(@attempts), '<=', 8,
+	'the launcher backs off rather than respawning the failed worker in a loop');
+
+like($log, qr/exited immediately, retrying in \d+ms/,
+	'the launcher reports the backoff it applied');
+
+# A backoff must not wedge the database permanently. Creating it removes the
+# fault, and the next retry should then produce a worker that stays up. No
+# CREATE EXTENSION here: a worker that connects but finds the extension missing
+# waits and rechecks rather than exiting, which is exactly the "started and
+# stayed up" case this needs.
+$node->safe_psql('postgres', "CREATE DATABASE $missing");
+
+my $started = 0;
+my $deadline = time() + 60;
+
+while (time() < $deadline)
+{
+	$log = slurp_file($node->logfile, $log_offset);
+
+	if ($log =~ /worker started \(database: \Q$missing\E\)/)
+	{
+		$started = 1;
+		last;
+	}
+
+	sleep 1;
+}
+
+ok($started,
+	'the launcher retries after the backoff, so a database that appears later is picked up');
+
+$node->stop;
+done_testing();


### PR DESCRIPTION
Follow-up to #42, on top of its branch rather than main, so it can be merged into that PR before it lands.

The SIGUSR1 diagnosis in #42 is right, and I checked each of its three claims against PostgreSQL master rather than taking them on trust: `BackgroundWorkerMain()` does point SIGUSR1 at `PG_SIG_IGN` for workers without `BGWORKER_BACKEND_DATABASE_CONNECTION` (`bgworker.c:775-790`), `CheckProcSignal()` does return false when `MyProcSignalSlot` is NULL, and `contrib/pg_prewarm`'s leader is an exact precedent, registered `BGWORKER_SHMEM_ACCESS` only and installing the same handler (`autoprewarm.c:177`). All three hold.

What the PR does not follow through is that delivering the notification removes an accidental rate limit which was doing real work.

## The problem

A worker whose database does not exist reaches its FATAL within a few milliseconds of being spawned. The notification therefore arrives almost immediately and sends the launcher straight back round to spawn a replacement, which fails just as fast. Nothing in the spawn path rate limits that by itself; previously the 60s idle sweep was the only thing in the way, which is why the launcher has no failure handling at all.

I measured this rather than reasoning about it, symbol-checking the installed `.so` each time to confirm which binary was running. Over an identical 32 second window, with a single mistyped name in `pgedge_vectorizer.databases`:

| | FATALs | PIDs consumed | Server log |
|---|---|---|---|
| `main` (no handler) | 1 | 1 | 4 KB |
| #42 (handler) | 7,636 | ~6,000 | 1.1 MB |

That is roughly 240 forks per second, sustained indefinitely. The same applies to any database that exists but cannot be connected to, `datallowconn = false` being the obvious one, since `BackgroundWorkerInitializeConnection()` FATALs identically. The launcher cannot pre-validate against `pg_database`, having no connection of its own, so this has to be a backoff rather than a check.

## The fix

A worker that exits within `LAUNCHER_FAILED_START_MS` of being spawned is treated as having failed to start, and its database is held off for an interval that doubles from 5s to a 5 minute cap, mirroring the extension-not-installed backoff `pgedge_vectorizer_worker_main()` already applies to itself. A worker that outlives the threshold clears its database's backoff, so one that recovers is serviced at full speed again, and the wait is shortened to the earliest pending retry so a backed-off database does not sit out the whole idle sweep.

Two details worth calling out:

The threshold sits below the one second minimum of `worker_service_quantum`, so a worker yielding its slot at the end of a quantum can never be mistaken for one that failed, and workers the launcher itself asked to stop are excluded however promptly they oblige.

Retries that have come due but cannot proceed for want of a worker slot are deliberately left out of the wait calculation. My first attempt reported them as due now, which spun the launcher at about a thousand wakeups a second until a slot freed: 0.6% of a core continuously, against literally zero CPU ticks once they are skipped. Both numbers measured, since a busy loop inside a fix for a fork storm would have been a poor trade.

## Testing

`test/t/003_launcher_failed_start_backoff.pl` drives the misconfigured-database case, requiring both that attempts stay in single figures and that the backoff is actually reported, then confirms the database is still picked up once it appears. It follows 002's lead in taking a log offset before the node starts, since `log/` persists between runs and counting from the top of the file would mix in the previous run's attempts.

A/B'd against separately built binaries, symbol-checked to confirm which was installed: 2 of its 4 assertions fail without this change, all 4 pass with it. Full suite green on a clean cluster, 15/15 pg_regress and 13/13 TAP across all three files.

## Also here

`log/regress_log_002_worker_respawn` is build output rather than source, it recorded a failing run, and it carried a username, home directory path, locale and timezone into the tree. It is removed, and `log/` is now ignored: the existing `*.log` rule does not match a file with no extension, which is how it slipped through.

**That removal only takes the file off the tip.** The blob is still in `901d25b`, so if this history reaches `main` those details are permanent. Dropping it from that commit instead would settle it properly, and `e3a7acf` here can simply be dropped in the rebase if you do.

Lastly, a caveat on the `num_workers` doc change: reloading is the right advice, but workers are drawn from `max_worker_processes`, so raising `num_workers` past the spare slots there quietly achieves nothing, and raising `max_worker_processes` does still need a restart.
