### PR TITLE
Claim queue items oldest first

### DIFF
--- a/src/worker.c
+++ b/src/worker.c
@@ -1095,7 +1095,14 @@ process_queue_batch(const char *dbname)
 		"FROM pgedge_vectorizer.queue "
 		"WHERE status = 'pending' "
 		"AND (next_retry_at IS NULL OR next_retry_at <= NOW()) "
-		"ORDER BY attempts DESC, created_at "
+		/*
+		 * Oldest first.  Ordering by attempts DESC put the items that had
+		 * failed most at the head of every batch, so a provider outage left
+		 * its retry backlog jumping ahead of newly queued work until those
+		 * items exhausted max_attempts.  next_retry_at already spaces retries
+		 * out; age is the only ordering the queue needs.
+		 */
+		"ORDER BY created_at "
 		"LIMIT %d "
 		"FOR UPDATE SKIP LOCKED",
 		batch_size),


### PR DESCRIPTION
## Summary

The batch claim in `process_queue_batch()` ordered by `attempts DESC, created_at`, putting the items that had failed most at the head of every batch:

```sql
WHERE status = 'pending'
AND (next_retry_at IS NULL OR next_retry_at <= NOW())
ORDER BY attempts DESC, created_at
LIMIT %d
FOR UPDATE SKIP LOCKED
```

A provider outage that leaves a backlog of once-failed items therefore has that backlog jump ahead of newly queued work on every poll, until each item exhausts `max_attempts` and moves to `failed`. With the default `batch_size` of 10, a handful of repeatedly failing items can fill each batch while fresh embeddings wait.

`next_retry_at` already spaces retries out, so age is the only ordering the queue needs.

## Fix

Order by `created_at` alone. A retried item keeps its original timestamp, so it rejoins the queue by age rather than either jumping the queue or being starved.

The previous ordering dates to the initial commit with no stated rationale — `git log -S` traces it to `1cd7091 Initial version.` — so this is a correction rather than a reversal of a deliberate design choice. Worth confirming that, since I could only check the recorded history.

## Test plan

- [x] All 19 regression tests pass from a clean build (PostgreSQL 17.10)

**No regression test.** The claim happens inside the worker's batch loop, which `pg_regress` does not drive, and asserting on the `SELECT` from SQL would test a copy of the query rather than the code that runs it. Said plainly rather than adding a test that looks like coverage and is not.
