### PR TITLE
Drop terms too long for the BM25 hash key

### DIFF
--- a/src/bm25.c
+++ b/src/bm25.c
@@ -178,9 +178,12 @@ bm25_tokenize(const char *text, int *ntokens)
 		 * BM25_MAX_TERM_LEN bytes, so two distinct terms sharing that much of
 		 * a prefix would otherwise merge into one entry, giving a combined
 		 * term frequency and a shared weight.  Dropping them costs nothing a
-		 * truncating match was giving: an alphabetic run this long is not a
-		 * term anyone searches for, and both the indexing and query paths
-		 * tokenize through here, so they are excluded consistently.
+		 * truncating match was giving: normalize_text_inplace() has already
+		 * turned every non-alpha byte into a space, so a token this long is
+		 * an unbroken run of letters rather than a URL, a hash or a path,
+		 * and is not a term anyone searches for.  Both the indexing and
+		 * query paths tokenize through here, so they are excluded
+		 * consistently.
 		 */
 		if (!is_stopword(tok) &&
 			strnlen(tok, BM25_MAX_TERM_LEN) < BM25_MAX_TERM_LEN)

--- a/src/bm25.c
+++ b/src/bm25.c
@@ -172,7 +172,18 @@ bm25_tokenize(const char *text, int *ntokens)
 	tok = strtok_r(buf, " ", &saveptr);
 	while (tok != NULL)
 	{
-		if (!is_stopword(tok))
+		/*
+		 * Drop terms too long for the hash key rather than letting dynahash
+		 * truncate them.  Both this table and the IDF table key on
+		 * BM25_MAX_TERM_LEN bytes, so two distinct terms sharing that much of
+		 * a prefix would otherwise merge into one entry, giving a combined
+		 * term frequency and a shared weight.  Dropping them costs nothing a
+		 * truncating match was giving: an alphabetic run this long is not a
+		 * term anyone searches for, and both the indexing and query paths
+		 * tokenize through here, so they are excluded consistently.
+		 */
+		if (!is_stopword(tok) &&
+			strnlen(tok, BM25_MAX_TERM_LEN) < BM25_MAX_TERM_LEN)
 		{
 			bool            found;
 			TermDedupEntry *entry;

--- a/test/expected/hybrid_test.out
+++ b/test/expected/hybrid_test.out
@@ -304,6 +304,22 @@ SELECT COALESCE(
                     1
 (1 row)
 
+-- The other side of the boundary: two distinct terms just inside the limit
+-- must stay distinct. Dropping what does not fit is only correct if nothing
+-- below the limit merges, so this is what would catch a guard that shortened
+-- the effective key rather than one that failed to apply.
+SELECT COALESCE(
+    array_length(
+        pgedge_vectorizer.bm25_tokenize(
+            repeat('a', 126) || 'x ' || repeat('a', 126) || 'y'),
+        1),
+    0
+) AS max_length_pair_distinct;
+ max_length_pair_distinct 
+--------------------------
+                        2
+(1 row)
+
 ---------------------------------------------------------------------------
 -- Test 18: bm25_decrement_idf_stats handles NULL/empty terms gracefully
 ---------------------------------------------------------------------------

--- a/test/expected/hybrid_test.out
+++ b/test/expected/hybrid_test.out
@@ -264,6 +264,47 @@ SELECT COALESCE(
 (1 row)
 
 ---------------------------------------------------------------------------
+-- Test 17b: terms too long for the hash key are dropped, not merged
+---------------------------------------------------------------------------
+-- The dedup and IDF hashes both key on BM25_MAX_TERM_LEN (128) bytes, so
+-- dynahash truncates anything longer. Two distinct terms sharing that much
+-- of a prefix would merge into one entry with a combined term frequency and
+-- a shared weight. They are dropped instead.
+SELECT COALESCE(
+    array_length(pgedge_vectorizer.bm25_tokenize(repeat('a', 200)), 1),
+    0
+) AS overlong_term_dropped;
+ overlong_term_dropped 
+-----------------------
+                     0
+(1 row)
+
+-- Two distinct 151-character terms differing only in their last character.
+-- Truncated to 127 bytes they are identical, so before this change the pair
+-- collapsed to a single token.
+SELECT COALESCE(
+    array_length(
+        pgedge_vectorizer.bm25_tokenize(
+            repeat('a', 150) || 'x ' || repeat('a', 150) || 'y'),
+        1),
+    0
+) AS overlong_pair_dropped;
+ overlong_pair_dropped 
+-----------------------
+                     0
+(1 row)
+
+-- A term just inside the limit is still indexed
+SELECT COALESCE(
+    array_length(pgedge_vectorizer.bm25_tokenize(repeat('a', 127)), 1),
+    0
+) AS max_length_term_kept;
+ max_length_term_kept 
+----------------------
+                    1
+(1 row)
+
+---------------------------------------------------------------------------
 -- Test 18: bm25_decrement_idf_stats handles NULL/empty terms gracefully
 ---------------------------------------------------------------------------
 -- Should return without error for NULL terms

--- a/test/sql/hybrid_test.sql
+++ b/test/sql/hybrid_test.sql
@@ -215,6 +215,37 @@ SELECT COALESCE(
 ) AS token_count;
 
 ---------------------------------------------------------------------------
+-- Test 17b: terms too long for the hash key are dropped, not merged
+---------------------------------------------------------------------------
+
+-- The dedup and IDF hashes both key on BM25_MAX_TERM_LEN (128) bytes, so
+-- dynahash truncates anything longer. Two distinct terms sharing that much
+-- of a prefix would merge into one entry with a combined term frequency and
+-- a shared weight. They are dropped instead.
+
+SELECT COALESCE(
+    array_length(pgedge_vectorizer.bm25_tokenize(repeat('a', 200)), 1),
+    0
+) AS overlong_term_dropped;
+
+-- Two distinct 151-character terms differing only in their last character.
+-- Truncated to 127 bytes they are identical, so before this change the pair
+-- collapsed to a single token.
+SELECT COALESCE(
+    array_length(
+        pgedge_vectorizer.bm25_tokenize(
+            repeat('a', 150) || 'x ' || repeat('a', 150) || 'y'),
+        1),
+    0
+) AS overlong_pair_dropped;
+
+-- A term just inside the limit is still indexed
+SELECT COALESCE(
+    array_length(pgedge_vectorizer.bm25_tokenize(repeat('a', 127)), 1),
+    0
+) AS max_length_term_kept;
+
+---------------------------------------------------------------------------
 -- Test 18: bm25_decrement_idf_stats handles NULL/empty terms gracefully
 ---------------------------------------------------------------------------
 

--- a/test/sql/hybrid_test.sql
+++ b/test/sql/hybrid_test.sql
@@ -245,6 +245,18 @@ SELECT COALESCE(
     0
 ) AS max_length_term_kept;
 
+-- The other side of the boundary: two distinct terms just inside the limit
+-- must stay distinct. Dropping what does not fit is only correct if nothing
+-- below the limit merges, so this is what would catch a guard that shortened
+-- the effective key rather than one that failed to apply.
+SELECT COALESCE(
+    array_length(
+        pgedge_vectorizer.bm25_tokenize(
+            repeat('a', 126) || 'x ' || repeat('a', 126) || 'y'),
+        1),
+    0
+) AS max_length_pair_distinct;
+
 ---------------------------------------------------------------------------
 -- Test 18: bm25_decrement_idf_stats handles NULL/empty terms gracefully
 ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The tokenizer's dedup table and the IDF table both key on `BM25_MAX_TERM_LEN` (128) bytes, and dynahash truncates anything longer. Two distinct terms sharing that much of a prefix merge into one entry: a single token carrying their combined term frequency, and one shared IDF weight standing in for both.

Silent, and wrong in both directions — the merged term gets an inflated frequency, and a query for either one matches the other.

## Fix

Skip terms that do not fit the key, at tokenization:

```c
if (!is_stopword(tok) && strlen(tok) < BM25_MAX_TERM_LEN)
```

Nothing is lost that a truncating match was providing. An alphabetic run of 128 characters is not a term anyone searches for, and both the indexing and query paths tokenize through `bm25_tokenize()`, so they are excluded consistently rather than one side matching a truncation the other does not produce.

## Test plan

Verified against PostgreSQL 17.10 from a clean build.

- [x] All 19 regression tests pass
- [x] The merge is demonstrated directly: two 151-character terms differing only in their final character tokenize to **one** token without the guard and are dropped with it
- [x] A 127-character term is still indexed, so the boundary is where it claims to be

The pair test is the discriminating one — a single overlong term merely disappearing could be explained several ways, but two distinct terms collapsing into one token is the defect itself.
