### PR TITLE
Record a queue item's failed attempt after the transaction aborts

### DIFF
--- a/src/worker.c
+++ b/src/worker.c
@@ -1638,7 +1638,18 @@ process_queue_batch(const char *dbname)
 			}
 			else
 			{
-				/* Failed to generate embeddings - update status based on remaining retries */
+				/*
+				 * Failed to generate embeddings - update status based on
+				 * remaining retries.
+				 *
+				 * error_msg is quoted with quote_literal_cstr() rather than
+				 * wrapped in quotes by hand.  A provider's message is
+				 * arbitrary text and several carry an apostrophe of their
+				 * own -- "Invalid response: 'data' field not found", for one
+				 * -- which built invalid SQL and raised from the very code
+				 * meant to record the failure, leaving the batch aborted with
+				 * nothing charged and the items reclaimed on the next poll.
+				 */
 				for (int i = 0; i < batch_count; i++)
 				{
 					int idx = batch_start + i;
@@ -1654,7 +1665,7 @@ process_queue_batch(const char *dbname)
 							"    error_message = %s, "
 							"    next_retry_at = NULL "
 							"WHERE id = %ld",
-							error_msg ? psprintf("'%s'", error_msg) : "NULL",
+							error_msg ? quote_literal_cstr(error_msg) : "NULL",
 							queue_ids[idx]),
 							false, 0);
 					}
@@ -1668,7 +1679,7 @@ process_queue_batch(const char *dbname)
 							"    error_message = %s, "
 							"    next_retry_at = NOW() + (attempts + 1) * INTERVAL '1 minute' "
 							"WHERE id = %ld",
-							error_msg ? psprintf("'%s'", error_msg) : "NULL",
+							error_msg ? quote_literal_cstr(error_msg) : "NULL",
 							queue_ids[idx]),
 							false, 0);
 					}

--- a/src/worker.c
+++ b/src/worker.c
@@ -49,10 +49,20 @@ static time_t last_cleanup_time = 0;
  * next_retry_at holds the item out of the claim, a non-zero attempts count
  * makes the worker process claimed items one at a time, and max_attempts
  * eventually moves it to 'failed'.
+ *
+ * The message that caused the abort is kept here too. It is only readable
+ * before FlushErrorState(), which runs long before the failure is recorded,
+ * and it is what an operator reading pgedge_vectorizer.queue actually needs:
+ * a fixed string tells them the item failed, which they can already see from
+ * its status, but not why. A fixed buffer rather than a palloc'd copy, since
+ * the transaction context this is captured in does not survive the abort.
  */
+#define FAILED_ITEM_ERROR_LEN	1024
+
 static int64 failed_item_queue_id = -1;
 static int	failed_item_attempts = 0;
 static int	failed_item_max_attempts = 0;
+static char failed_item_error[FAILED_ITEM_ERROR_LEN] = "";
 
 /*
  * Launcher state
@@ -154,6 +164,7 @@ static void worker_sigterm(SIGNAL_ARGS);
 static void worker_sighup(SIGNAL_ARGS);
 static void queue_item_begin(int64 queue_id, int attempts, int max_attempts);
 static void queue_item_done(void);
+static void queue_item_note_error(void);
 static void queue_item_record_failure(void);
 static void process_queue_batch(const char *dbname);
 static void cleanup_completed_items(const char *dbname);
@@ -212,6 +223,31 @@ queue_item_begin(int64 queue_id, int attempts, int max_attempts)
 	failed_item_queue_id = queue_id;
 	failed_item_attempts = attempts;
 	failed_item_max_attempts = max_attempts;
+	failed_item_error[0] = '\0';
+}
+
+/*
+ * queue_item_note_error -- keep the message that is about to be discarded.
+ *
+ * Must be called from a PG_CATCH() and before FlushErrorState(), which frees
+ * the error data.  Copied into static storage rather than kept as the palloc'd
+ * ErrorData, because the context it is allocated in does not survive the abort
+ * that has to happen before the failure can be recorded.
+ */
+static void
+queue_item_note_error(void)
+{
+	ErrorData  *edata;
+
+	if (failed_item_queue_id < 0)
+		return;
+
+	edata = CopyErrorData();
+
+	if (edata->message != NULL)
+		strlcpy(failed_item_error, edata->message, sizeof(failed_item_error));
+
+	FreeErrorData(edata);
 }
 
 /*
@@ -235,14 +271,18 @@ queue_item_done(void)
 static void
 queue_item_record_failure(void)
 {
-	int64	queue_id = failed_item_queue_id;
-	int		attempts = failed_item_attempts;
-	bool	exhausted;
+	int64		queue_id = failed_item_queue_id;
+	int			attempts = failed_item_attempts;
+	bool		exhausted;
+	const char *reason;
+	char	   *quoted_reason;
 
 	if (queue_id < 0)
 		return;
 
 	exhausted = (failed_item_attempts + 1 >= failed_item_max_attempts);
+	reason = (failed_item_error[0] != '\0') ? failed_item_error
+											: "Processing failed";
 	queue_item_done();
 
 	/*
@@ -257,6 +297,14 @@ queue_item_record_failure(void)
 		StartTransactionCommand();
 		PushActiveSnapshot(GetTransactionSnapshot());
 		SPI_connect();
+
+		/*
+		 * Quoted here rather than before the transaction, so the copy lives
+		 * in the transaction's context and goes away with it.  An error
+		 * message is arbitrary text and routinely contains an apostrophe, so
+		 * wrapping it in quotes by hand would build invalid SQL.
+		 */
+		quoted_reason = quote_literal_cstr(reason);
 
 		/*
 		 * Match on the state this worker last saw.  A launcher restart can
@@ -276,21 +324,21 @@ queue_item_record_failure(void)
 				"UPDATE pgedge_vectorizer.queue "
 				"SET status = 'failed', "
 				"    attempts = attempts + 1, "
-				"    error_message = 'Processing failed', "
+				"    error_message = %s, "
 				"    next_retry_at = NULL "
 				"WHERE id = " INT64_FORMAT
 				"  AND status = 'pending' AND attempts = %d",
-				queue_id, attempts), false, 0);
+				quoted_reason, queue_id, attempts), false, 0);
 		else
 			SPI_execute(psprintf(
 				"UPDATE pgedge_vectorizer.queue "
 				"SET status = 'pending', "
 				"    attempts = attempts + 1, "
-				"    error_message = 'Processing failed', "
+				"    error_message = %s, "
 				"    next_retry_at = NOW() + (attempts + 1) * INTERVAL '1 minute' "
 				"WHERE id = " INT64_FORMAT
 				"  AND status = 'pending' AND attempts = %d",
-				queue_id, attempts), false, 0);
+				quoted_reason, queue_id, attempts), false, 0);
 
 		if (SPI_processed == 0)
 			elog(DEBUG1, "pgedge_vectorizer worker: queue item " INT64_FORMAT
@@ -1188,6 +1236,13 @@ pgedge_vectorizer_worker_main(Datum main_arg)
 		}
 		PG_CATCH();
 		{
+			/*
+			 * Take the message before FlushErrorState() frees it, so that the
+			 * queue row records why the item failed rather than merely that
+			 * it did.
+			 */
+			queue_item_note_error();
+
 			EmitErrorReport();
 			FlushErrorState();
 

--- a/src/worker.c
+++ b/src/worker.c
@@ -34,6 +34,27 @@ static volatile sig_atomic_t got_sighup = false;
 static time_t last_cleanup_time = 0;
 
 /*
+ * Queue item whose processing was under way when an error escaped.
+ *
+ * A batch runs inside one transaction, so an error anywhere in it aborts the
+ * lot: the 'processing' marks, any chunk rows already written, and any attempt
+ * to record the failure. Bookkeeping written before the abort therefore cannot
+ * survive it, which left attempts stuck at its original value however many
+ * times an item was tried. max_attempts never tripped, next_retry_at was never
+ * set, and a deterministically failing item was reclaimed on every poll.
+ *
+ * The identity of the item is kept here instead, in process-local memory that
+ * the abort cannot touch, and the failure is recorded afterwards in a fresh
+ * transaction. That is enough to restart the machinery the queue already has:
+ * next_retry_at holds the item out of the claim, a non-zero attempts count
+ * makes the worker process claimed items one at a time, and max_attempts
+ * eventually moves it to 'failed'.
+ */
+static int64 failed_item_queue_id = -1;
+static int	failed_item_attempts = 0;
+static int	failed_item_max_attempts = 0;
+
+/*
  * Launcher state
  *
  * All of this is process-local: there is deliberately no shared memory
@@ -42,8 +63,11 @@ static time_t last_cleanup_time = 0;
  *
  * The cost is that a restarted launcher cannot rediscover workers started by
  * its predecessor, so a launcher crash may briefly leave two workers on one
- * database. That is harmless: queue rows are claimed with FOR UPDATE SKIP
- * LOCKED, so concurrent workers simply take disjoint rows.
+ * database. Queue rows are claimed with FOR UPDATE SKIP LOCKED, so concurrent
+ * workers take disjoint rows for as long as they hold their claims. A claim
+ * does not outlive an abort, though, so a row whose worker failed can be taken
+ * up by the other before the first records the failure; queue_item_record_failure()
+ * matches on the state it last saw rather than on the row id alone.
  */
 typedef struct LauncherSlot
 {
@@ -128,6 +152,9 @@ static int	launcher_backoffs_size = 0;
 /* Forward declarations */
 static void worker_sigterm(SIGNAL_ARGS);
 static void worker_sighup(SIGNAL_ARGS);
+static void queue_item_begin(int64 queue_id, int attempts, int max_attempts);
+static void queue_item_done(void);
+static void queue_item_record_failure(void);
 static void process_queue_batch(const char *dbname);
 static void cleanup_completed_items(const char *dbname);
 static void update_embedding(int64 chunk_id, const char *chunk_table,
@@ -171,6 +198,117 @@ worker_sighup(SIGNAL_ARGS)
 	got_sighup = true;
 	SetLatch(MyLatch);
 	errno = save_errno;
+}
+
+/*
+ * queue_item_begin — note the item about to be worked on.
+ *
+ * Called before anything that could raise, so that a failure can be charged to
+ * the right row once the aborted transaction has been cleaned up.
+ */
+static void
+queue_item_begin(int64 queue_id, int attempts, int max_attempts)
+{
+	failed_item_queue_id = queue_id;
+	failed_item_attempts = attempts;
+	failed_item_max_attempts = max_attempts;
+}
+
+/*
+ * queue_item_done — the item completed, so there is nothing to charge.
+ */
+static void
+queue_item_done(void)
+{
+	failed_item_queue_id = -1;
+}
+
+/*
+ * queue_item_record_failure — charge the noted item for a failed attempt.
+ *
+ * Must run after the failed transaction has been aborted, since it opens one
+ * of its own. Errors here are swallowed: this is already the error path, and
+ * losing the bookkeeping is preferable to taking the worker down with it. The
+ * item is cleared either way, so a persistent problem recording failures
+ * cannot make the worker retry the same row forever on that account.
+ */
+static void
+queue_item_record_failure(void)
+{
+	int64	queue_id = failed_item_queue_id;
+	int		attempts = failed_item_attempts;
+	bool	exhausted;
+
+	if (queue_id < 0)
+		return;
+
+	exhausted = (failed_item_attempts + 1 >= failed_item_max_attempts);
+	queue_item_done();
+
+	/*
+	 * Everything, including the transaction setup, sits inside the handler:
+	 * this runs from the worker's own PG_CATCH, which is not a handler for
+	 * errors raised within it, so anything escaping here would take the
+	 * worker down rather than being swallowed as intended.
+	 */
+	PG_TRY();
+	{
+		SetCurrentStatementStartTimestamp();
+		StartTransactionCommand();
+		PushActiveSnapshot(GetTransactionSnapshot());
+		SPI_connect();
+
+		/*
+		 * Match on the state this worker last saw.  A launcher restart can
+		 * briefly leave two workers on one database, and the abort that
+		 * brought us here released this row's lock, so another worker may
+		 * have claimed and finished it in the meantime.  Updating on id
+		 * alone would then revive a completed item as pending, or mark a
+		 * succeeded one failed.
+		 *
+		 * The qualified UPDATE is sufficient on its own: under READ
+		 * COMMITTED it takes the row lock and re-checks its WHERE clause
+		 * against the newest version of the row, so a row that has moved on
+		 * simply fails the match and is left alone.
+		 */
+		if (exhausted)
+			SPI_execute(psprintf(
+				"UPDATE pgedge_vectorizer.queue "
+				"SET status = 'failed', "
+				"    attempts = attempts + 1, "
+				"    error_message = 'Processing failed', "
+				"    next_retry_at = NULL "
+				"WHERE id = " INT64_FORMAT
+				"  AND status = 'pending' AND attempts = %d",
+				queue_id, attempts), false, 0);
+		else
+			SPI_execute(psprintf(
+				"UPDATE pgedge_vectorizer.queue "
+				"SET status = 'pending', "
+				"    attempts = attempts + 1, "
+				"    error_message = 'Processing failed', "
+				"    next_retry_at = NOW() + (attempts + 1) * INTERVAL '1 minute' "
+				"WHERE id = " INT64_FORMAT
+				"  AND status = 'pending' AND attempts = %d",
+				queue_id, attempts), false, 0);
+
+		if (SPI_processed == 0)
+			elog(DEBUG1, "pgedge_vectorizer worker: queue item " INT64_FORMAT
+				 " changed underneath, leaving it alone", queue_id);
+
+		SPI_finish();
+		PopActiveSnapshot();
+		CommitTransactionCommand();
+	}
+	PG_CATCH();
+	{
+		EmitErrorReport();
+		FlushErrorState();
+		AbortCurrentTransaction();
+		elog(LOG, "pgedge_vectorizer worker: could not record failure for "
+			 "queue item " INT64_FORMAT, queue_id);
+	}
+	PG_END_TRY();
 }
 
 /*
@@ -1060,6 +1198,15 @@ pgedge_vectorizer_worker_main(Datum main_arg)
 			/* Abort any transaction */
 			AbortCurrentTransaction();
 
+			/*
+			 * Charge the item that was in flight.  The abort above has to
+			 * come first, since the record is written in a transaction of
+			 * its own and none can be started until this one is cleared.
+			 * Without it the attempt is discarded along with everything else
+			 * and the same row is reclaimed on the next poll, indefinitely.
+			 */
+			queue_item_record_failure();
+
 			/* Recheck extension status on error */
 			extension_exists = false;
 		}
@@ -1160,6 +1307,14 @@ process_queue_batch(const char *dbname)
 			int		ret_dense;
 			Datum	val;
 
+			/*
+			 * Charge this row if the probe raises.  A chunk table named by
+			 * the queue but since dropped fails here, well before the loop
+			 * that processes the items, so noting the item only there would
+			 * leave this failure uncharged.
+			 */
+			queue_item_begin(queue_ids[i], attempts[i], max_attempts[i]);
+
 			ret_dense = SPI_execute(psprintf(
 				"SELECT embedding IS NOT NULL FROM %s WHERE id = %ld",
 				quote_identifier(chunk_tables[i]),
@@ -1176,6 +1331,17 @@ process_queue_batch(const char *dbname)
 			if (sparse_only[i])
 				has_sparse_only = true;
 		}
+
+		/*
+		 * Stop charging the last probed item.  What follows — marking the
+		 * batch, resolving the provider, generating embeddings — either
+		 * fails for the whole batch or for no single item in particular, and
+		 * leaving one noted here would bill it for a fault that is not its
+		 * own.  A misconfigured provider raises for every batch, so left
+		 * uncleared it would work through the queue marking one blameless
+		 * item failed per max_attempts cycles.
+		 */
+		queue_item_done();
 
 		/* If any items have been retried, process individually to isolate failures */
 		if (has_retries && n_items > 1)
@@ -1321,170 +1487,145 @@ process_queue_batch(const char *dbname)
 				for (int i = 0; i < batch_count; i++)
 				{
 					int idx = batch_start + i;
-					PG_TRY();
+
+					/*
+					 * No handler here: a failure is charged to this item by
+					 * the worker's own handler, from the identity noted
+					 * below, once it has aborted the transaction.  Catching
+					 * it locally could achieve nothing, since the queue
+					 * cannot be updated from inside the aborted transaction
+					 * and a re-throw would discard the update in any case.
+					 */
+					queue_item_begin(queue_ids[idx], attempts[idx],
+									 max_attempts[idx]);
+					if (!sparse_only[idx])
+						update_embedding(chunk_ids[idx], chunk_tables[idx], embeddings[i], dim);
+					else if (!pgedge_vectorizer_enable_hybrid)
+						elog(ERROR, "cannot process sparse-only queue item while pgedge_vectorizer.enable_hybrid is disabled");
+
+					/*
+					 * BM25 sparse vector update (opt-in via
+					 * pgedge_vectorizer.enable_hybrid GUC).
+					 */
+					if (pgedge_vectorizer_enable_hybrid)
 					{
-						if (!sparse_only[idx])
-							update_embedding(chunk_ids[idx], chunk_tables[idx], embeddings[i], dim);
-						else if (!pgedge_vectorizer_enable_hybrid)
-							elog(ERROR, "cannot process sparse-only queue item while pgedge_vectorizer.enable_hybrid is disabled");
+						int			ntokens;
+						int			token_count = 0;
+						bool		is_first_process = true;
+						BM25Term   *tokens;
+						HTAB	   *idf_htab;
+						float8		avg_doc_len;
+						char	   *sparse_str;
+						int			ret_bm25;
+						char	   *chunk_sql;
 
 						/*
-						 * BM25 sparse vector update (opt-in via
-						 * pgedge_vectorizer.enable_hybrid GUC).
+						 * Fetch token_count and check whether
+						 * sparse_embedding is already set (for
+						 * idempotency — skip IDF update on retry).
 						 */
-						if (pgedge_vectorizer_enable_hybrid)
+						chunk_sql = psprintf(
+							"SELECT token_count, "
+							"sparse_embedding IS NOT NULL "
+							"FROM %s WHERE id = %ld",
+							quote_identifier(chunk_tables[idx]),
+							chunk_ids[idx]);
+						ret_bm25 = SPI_execute(chunk_sql,
+											   true, 1);
+						pfree(chunk_sql);
+
+						if (ret_bm25 == SPI_OK_SELECT &&
+							SPI_processed > 0)
 						{
-							int			ntokens;
-							int			token_count = 0;
-							bool		is_first_process = true;
-							BM25Term   *tokens;
-							HTAB	   *idf_htab;
-							float8		avg_doc_len;
-							char	   *sparse_str;
-							int			ret_bm25;
-							char	   *chunk_sql;
+							bool   isnull;
+							Datum  v;
+
+							v = SPI_getbinval(
+								SPI_tuptable->vals[0],
+								SPI_tuptable->tupdesc,
+								1, &isnull);
+							if (!isnull)
+								token_count = DatumGetInt32(v);
+
+							v = SPI_getbinval(
+								SPI_tuptable->vals[0],
+								SPI_tuptable->tupdesc,
+								2, &isnull);
+							if (!isnull)
+								is_first_process =
+									!DatumGetBool(v);
 
 							/*
-							 * Fetch token_count and check whether
-							 * sparse_embedding is already set (for
-							 * idempotency — skip IDF update on retry).
+							 * Chunk row exists — proceed with BM25
+							 * scoring and IDF stats update.
+							 * Keeping this inside the SPI_processed > 0
+							 * block ensures we bail out cleanly when
+							 * the chunk has been concurrently deleted.
 							 */
-							chunk_sql = psprintf(
-								"SELECT token_count, "
-								"sparse_embedding IS NOT NULL "
-								"FROM %s WHERE id = %ld",
-								quote_identifier(chunk_tables[idx]),
-								chunk_ids[idx]);
-							ret_bm25 = SPI_execute(chunk_sql,
-												   true, 1);
-							pfree(chunk_sql);
+							if (token_count <= 0)
+								token_count = 1;
 
-							if (ret_bm25 == SPI_OK_SELECT &&
-								SPI_processed > 0)
-							{
-								bool   isnull;
-								Datum  v;
+							tokens = bm25_tokenize(contents[idx],
+												   &ntokens);
+							idf_htab = bm25_load_idf_stats(
+									chunk_tables[idx], tokens, ntokens);
+							avg_doc_len = bm25_avg_doc_len_internal(
+									chunk_tables[idx]);
+							sparse_str = bm25_compute_sparse_str(
+									tokens, ntokens,
+									idf_htab,
+									pgedge_vectorizer_bm25_k1,
+									pgedge_vectorizer_bm25_b,
+									avg_doc_len,
+									token_count);
 
-								v = SPI_getbinval(
-									SPI_tuptable->vals[0],
-									SPI_tuptable->tupdesc,
-									1, &isnull);
-								if (!isnull)
-									token_count = DatumGetInt32(v);
+							ret_bm25 = SPI_execute(
+								psprintf(
+									"UPDATE %s SET "
+									"sparse_embedding = "
+									"%s::sparsevec "
+									"WHERE id = %ld",
+									quote_identifier(chunk_tables[idx]),
+									quote_literal_cstr(sparse_str),
+									chunk_ids[idx]),
+								false, 0);
 
-								v = SPI_getbinval(
-									SPI_tuptable->vals[0],
-									SPI_tuptable->tupdesc,
-									2, &isnull);
-								if (!isnull)
-									is_first_process =
-										!DatumGetBool(v);
+							if (ret_bm25 != SPI_OK_UPDATE)
+								elog(WARNING,
+									 "Failed to update "
+									 "sparse_embedding for "
+									 "chunk " INT64_FORMAT,
+									 chunk_ids[idx]);
 
-								/*
-								 * Chunk row exists — proceed with BM25
-								 * scoring and IDF stats update.
-								 * Keeping this inside the SPI_processed > 0
-								 * block ensures we bail out cleanly when
-								 * the chunk has been concurrently deleted.
-								 */
-								if (token_count <= 0)
-									token_count = 1;
+							if (idf_htab != NULL)
+								hash_destroy(idf_htab);
 
-								tokens = bm25_tokenize(contents[idx],
-													   &ntokens);
-								idf_htab = bm25_load_idf_stats(
-										chunk_tables[idx], tokens, ntokens);
-								avg_doc_len = bm25_avg_doc_len_internal(
-										chunk_tables[idx]);
-								sparse_str = bm25_compute_sparse_str(
-										tokens, ntokens,
-										idf_htab,
-										pgedge_vectorizer_bm25_k1,
-										pgedge_vectorizer_bm25_b,
-										avg_doc_len,
-										token_count);
-
-								ret_bm25 = SPI_execute(
-									psprintf(
-										"UPDATE %s SET "
-										"sparse_embedding = "
-										"%s::sparsevec "
-										"WHERE id = %ld",
-										quote_identifier(chunk_tables[idx]),
-										quote_literal_cstr(sparse_str),
-										chunk_ids[idx]),
-									false, 0);
-
-								if (ret_bm25 != SPI_OK_UPDATE)
-									elog(WARNING,
-										 "Failed to update "
-										 "sparse_embedding for "
-										 "chunk " INT64_FORMAT,
-										 chunk_ids[idx]);
-
-								if (idf_htab != NULL)
-									hash_destroy(idf_htab);
-
-								/*
-								 * Only update IDF stats the first time
-								 * this chunk is processed — retries must
-								 * not increment doc_freq again.
-								 */
-								if (is_first_process)
-									bm25_update_idf_stats(
-										chunk_tables[idx],
-										tokens, ntokens);
-							}
-							/* else: chunk row gone (concurrent delete) —
-							 * skip BM25 entirely to avoid inflating
-							 * corpus stats for a nonexistent chunk.
+							/*
+							 * Only update IDF stats the first time
+							 * this chunk is processed — retries must
+							 * not increment doc_freq again.
 							 */
+							if (is_first_process)
+								bm25_update_idf_stats(
+									chunk_tables[idx],
+									tokens, ntokens);
 						}
-
-						/* Mark as completed */
-						SPI_execute(psprintf(
-							"UPDATE pgedge_vectorizer.queue "
-							"SET status = 'completed', processed_at = NOW() "
-							"WHERE id = %ld",
-							queue_ids[idx]),
-							false, 0);
-
-						elog(DEBUG2, "Successfully processed queue item %ld", queue_ids[idx]);
+						/* else: chunk row gone (concurrent delete) —
+						 * skip BM25 entirely to avoid inflating
+						 * corpus stats for a nonexistent chunk.
+						 */
 					}
-					PG_CATCH();
-					{
-						/* Check if retries remain */
-						if (attempts[idx] + 1 >= max_attempts[idx])
-						{
-							/* No retries left - mark as permanently failed */
-							SPI_execute(psprintf(
-								"UPDATE pgedge_vectorizer.queue "
-								"SET status = 'failed', "
-								"    attempts = attempts + 1, "
-								"    error_message = 'Failed to update embedding', "
-								"    next_retry_at = NULL "
-								"WHERE id = %ld",
-								queue_ids[idx]),
-								false, 0);
-						}
-						else
-						{
-							/* Retries remain - set back to pending with delay */
-							SPI_execute(psprintf(
-								"UPDATE pgedge_vectorizer.queue "
-								"SET status = 'pending', "
-								"    attempts = attempts + 1, "
-								"    error_message = 'Failed to update embedding', "
-								"    next_retry_at = NOW() + (attempts + 1) * INTERVAL '1 minute' "
-								"WHERE id = %ld",
-								queue_ids[idx]),
-								false, 0);
-						}
 
-						/* Re-throw */
-						PG_RE_THROW();
-					}
-					PG_END_TRY();
+					/* Mark as completed */
+					SPI_execute(psprintf(
+						"UPDATE pgedge_vectorizer.queue "
+						"SET status = 'completed', processed_at = NOW() "
+						"WHERE id = %ld",
+						queue_ids[idx]),
+						false, 0);
+
+					elog(DEBUG2, "Successfully processed queue item %ld", queue_ids[idx]);
+					queue_item_done();
 				}
 
 				/* Free embeddings */

--- a/test/t/004_queue_failure_accounting.pl
+++ b/test/t/004_queue_failure_accounting.pl
@@ -132,6 +132,12 @@ while (time() < $deadline)
 is($status, 'failed',
 	'the item is retired once max_attempts is reached');
 
+my $reason = $node->safe_psql($dbname,
+	"SELECT COALESCE(error_message, '') FROM pgedge_vectorizer.queue WHERE chunk_table = 'no_such_chunk_table'");
+
+like($reason, qr/no_such_chunk_table/,
+	'the recorded reason is the error itself, not a fixed string');
+
 my $claimable = $node->safe_psql($dbname, q(
 SELECT count(*) FROM pgedge_vectorizer.queue
  WHERE status = 'pending'
@@ -140,6 +146,38 @@ SELECT count(*) FROM pgedge_vectorizer.queue
 
 is($claimable, '0',
 	'a retired item is no longer claimed');
+
+# An error message is arbitrary text, and plenty of them carry an apostrophe:
+# an identifier with one in it puts it straight into "relation ... does not
+# exist", and several provider messages quote a JSON field name the same way.
+# Interpolated into the UPDATE without quoting that is invalid SQL, and it
+# would raise from the very statement meant to record the failure -- leaving
+# the batch aborted with nothing charged, which is the behaviour this whole
+# test exists to rule out. Injected after the assertions above so that the
+# earlier counts are not disturbed by a second failing item.
+$node->safe_psql(
+	$dbname, qq(
+INSERT INTO pgedge_vectorizer.queue
+    (chunk_id, chunk_table, content, status, metadata, max_attempts)
+VALUES (1, 'no_such''table', 'alpha beta gamma', 'pending',
+        '{"sparse_only": true}'::jsonb, 2)
+));
+
+my $quoted_reason = '';
+$deadline = time() + 30;
+
+while (time() < $deadline)
+{
+	$quoted_reason = $node->safe_psql($dbname,
+		"SELECT COALESCE(error_message, '') FROM pgedge_vectorizer.queue WHERE chunk_table = 'no_such''table'");
+
+	last if $quoted_reason ne '';
+
+	sleep 1;
+}
+
+like($quoted_reason, qr/no_such'table/,
+	'a reason containing an apostrophe is recorded rather than breaking the update');
 
 $node->stop;
 done_testing();

--- a/test/t/004_queue_failure_accounting.pl
+++ b/test/t/004_queue_failure_accounting.pl
@@ -35,23 +35,31 @@ use Test::More;
 
 my $dbname = 'queue_accounting';
 
+# Deliberately no pgedge_vectorizer.databases yet. A worker that reaches a
+# database before its extension exists backs off for five seconds and then for
+# five minutes, which would otherwise decide this test by timing: the database
+# is named only once it is ready, so there is no window in which a worker can
+# look too early.
 my $node = PostgreSQL::Test::Cluster->new('vectorizer_queue_accounting');
 $node->init;
 $node->append_conf(
 	'postgresql.conf', qq(
 shared_preload_libraries = 'pgedge_vectorizer'
-pgedge_vectorizer.databases = '$dbname'
 pgedge_vectorizer.worker_poll_interval = 200
 max_worker_processes = 16
 ));
 
 $node->start;
 
-# Create the extension before the worker's first look, so it does not fall into
-# the extension-not-installed backoff and sit out the window below.
 $node->safe_psql('postgres', "CREATE DATABASE $dbname");
 $node->safe_psql($dbname, 'CREATE EXTENSION vector');
 $node->safe_psql($dbname, 'CREATE EXTENSION pgedge_vectorizer');
+
+# Now that there is something to service, tell the launcher about it. The
+# database list is SIGHUP, so a reload is enough.
+$node->append_conf('postgresql.conf',
+	"pgedge_vectorizer.databases = '$dbname'\n");
+$node->reload;
 
 my $log_offset = (-s $node->logfile) // 0;
 
@@ -64,11 +72,22 @@ VALUES (1, 'no_such_chunk_table', 'alpha beta gamma', 'pending',
         '{"sparse_only": true}'::jsonb, 2)
 ));
 
-# One poll interval is 200ms, so this is many chances to try the row.
-sleep 5;
+# Wait for the attempt rather than assuming one has happened by now, so that
+# worker startup timing cannot decide the result. An unfixed build never
+# records one, so this waits out the timeout and the assertion below fails on
+# the value it did see.
+my $attempts = 0;
+my $deadline = time() + 30;
 
-my $attempts = $node->safe_psql($dbname,
-	"SELECT attempts FROM pgedge_vectorizer.queue WHERE chunk_table = 'no_such_chunk_table'");
+while (time() < $deadline)
+{
+	$attempts = $node->safe_psql($dbname,
+		"SELECT attempts FROM pgedge_vectorizer.queue WHERE chunk_table = 'no_such_chunk_table'");
+
+	last if $attempts > 0;
+
+	sleep 1;
+}
 
 cmp_ok($attempts, '>', 0,
 	'a failed attempt is recorded against the item');
@@ -79,20 +98,22 @@ my $backoff = $node->safe_psql($dbname,
 is($backoff, 't',
 	'the item is held out of the claim until its retry time');
 
-# The point of the backoff: without it the worker retries as fast as it polls.
-# Counting the worker's own "error in processing" line is the most direct
-# measure of that, and the margin is large -- an unfixed build produces of the
-# order of twenty five of these in the window above, a fixed one produces one.
-my $log = slurp_file($node->logfile, $log_offset);
-my @cycles = ($log =~ /error in processing, continuing/g);
+# The point of the backoff: while the retry time is in the future the item
+# should not be touched at all. Counting from here rather than from the insert
+# keeps this independent of how long the wait above took; at a 200ms poll an
+# unfixed build manages of the order of fifteen failures in this window.
+my $quiet_offset = (-s $node->logfile) // 0;
+sleep 3;
+my $quiet = slurp_file($node->logfile, $quiet_offset);
+my @cycles = ($quiet =~ /error in processing, continuing/g);
 
-cmp_ok(scalar(@cycles), '<', 5,
-	'the item is not retried on every poll');
+is(scalar(@cycles), 0,
+	'a backed off item is left alone until its retry time');
 
 # Walk it to the end of its retries. Clearing next_retry_at makes it eligible
 # again immediately rather than waiting out the backoff, which would make this
 # test take minutes.
-my $deadline = time() + 60;
+$deadline = time() + 60;
 my $status = '';
 
 while (time() < $deadline)

--- a/test/t/004_queue_failure_accounting.pl
+++ b/test/t/004_queue_failure_accounting.pl
@@ -1,0 +1,124 @@
+# Copyright (c) 2025 - 2026, pgEdge, Inc.
+#
+# Verify that a queue item which cannot be processed is charged for the attempt,
+# so that it backs off and is eventually retired instead of being retried
+# forever.
+#
+# A batch is processed inside a single transaction, so an error anywhere in it
+# aborts the lot. Recording the failure from inside that transaction therefore
+# could not work: the statement is rejected because the transaction is already
+# aborted, and would be rolled back with everything else even if it were not.
+# attempts stayed at its original value however many times the item was tried,
+# so max_attempts never tripped, next_retry_at was never set, and the item was
+# reclaimed on every poll. Measured against an unfixed build that is of the
+# order of 150 failure cycles a minute for a single bad row.
+#
+# The failure is now recorded after the transaction has been aborted, in one of
+# its own. That restarts three mechanisms the queue already had and which were
+# all gated on attempts moving: next_retry_at holds the item out of the claim,
+# a non-zero attempts count makes the worker process claimed items one at a
+# time, and max_attempts retires it.
+#
+# The fault injected here is a queue row naming a chunk table that does not
+# exist. It is marked sparse_only, which skips the embedding provider
+# altogether, so the test needs no API key. The failure surfaces in the probe
+# that decides whether an item still needs a dense embedding, which runs before
+# the per-item processing loop -- the same place the original symptom appeared.
+
+use strict;
+use warnings;
+
+# See the comment in 001_worker_coverage.pl about loading these at compile time.
+use PostgreSQL::Test::Cluster;
+use PostgreSQL::Test::Utils;
+use Test::More;
+
+my $dbname = 'queue_accounting';
+
+my $node = PostgreSQL::Test::Cluster->new('vectorizer_queue_accounting');
+$node->init;
+$node->append_conf(
+	'postgresql.conf', qq(
+shared_preload_libraries = 'pgedge_vectorizer'
+pgedge_vectorizer.databases = '$dbname'
+pgedge_vectorizer.worker_poll_interval = 200
+max_worker_processes = 16
+));
+
+$node->start;
+
+# Create the extension before the worker's first look, so it does not fall into
+# the extension-not-installed backoff and sit out the window below.
+$node->safe_psql('postgres', "CREATE DATABASE $dbname");
+$node->safe_psql($dbname, 'CREATE EXTENSION vector');
+$node->safe_psql($dbname, 'CREATE EXTENSION pgedge_vectorizer');
+
+my $log_offset = (-s $node->logfile) // 0;
+
+# max_attempts is deliberately low so the whole lifecycle fits in the test.
+$node->safe_psql(
+	$dbname, qq(
+INSERT INTO pgedge_vectorizer.queue
+    (chunk_id, chunk_table, content, status, metadata, max_attempts)
+VALUES (1, 'no_such_chunk_table', 'alpha beta gamma', 'pending',
+        '{"sparse_only": true}'::jsonb, 2)
+));
+
+# One poll interval is 200ms, so this is many chances to try the row.
+sleep 5;
+
+my $attempts = $node->safe_psql($dbname,
+	"SELECT attempts FROM pgedge_vectorizer.queue WHERE chunk_table = 'no_such_chunk_table'");
+
+cmp_ok($attempts, '>', 0,
+	'a failed attempt is recorded against the item');
+
+my $backoff = $node->safe_psql($dbname,
+	"SELECT next_retry_at > now() FROM pgedge_vectorizer.queue WHERE chunk_table = 'no_such_chunk_table'");
+
+is($backoff, 't',
+	'the item is held out of the claim until its retry time');
+
+# The point of the backoff: without it the worker retries as fast as it polls.
+# Counting the worker's own "error in processing" line is the most direct
+# measure of that, and the margin is large -- an unfixed build produces of the
+# order of twenty five of these in the window above, a fixed one produces one.
+my $log = slurp_file($node->logfile, $log_offset);
+my @cycles = ($log =~ /error in processing, continuing/g);
+
+cmp_ok(scalar(@cycles), '<', 5,
+	'the item is not retried on every poll');
+
+# Walk it to the end of its retries. Clearing next_retry_at makes it eligible
+# again immediately rather than waiting out the backoff, which would make this
+# test take minutes.
+my $deadline = time() + 60;
+my $status = '';
+
+while (time() < $deadline)
+{
+	$status = $node->safe_psql($dbname,
+		"SELECT status FROM pgedge_vectorizer.queue WHERE chunk_table = 'no_such_chunk_table'");
+
+	last if $status eq 'failed';
+
+	$node->safe_psql($dbname,
+		"UPDATE pgedge_vectorizer.queue SET next_retry_at = NULL WHERE chunk_table = 'no_such_chunk_table'");
+
+	sleep 1;
+}
+
+is($status, 'failed',
+	'the item is retired once max_attempts is reached');
+
+my $claimable = $node->safe_psql($dbname, q(
+SELECT count(*) FROM pgedge_vectorizer.queue
+ WHERE status = 'pending'
+   AND (next_retry_at IS NULL OR next_retry_at <= now())
+));
+
+is($claimable, '0',
+	'a retired item is no longer claimed');
+
+$node->stop;
+done_testing();


### PR DESCRIPTION
## Summary

A queue item that fails deterministically is reclaimed on every poll, forever. Measured against an item whose chunk table does not exist: **roughly 150 failure cycles a minute, with `attempts` stuck at 0** and `max_attempts` never tripping.

The cause is that failure bookkeeping was written inside the transaction the failure had already doomed. A batch runs in a single transaction (`worker.c`, `StartTransactionCommand` through `CommitTransactionCommand`), so an error anywhere aborts all of it. The per-item handler tried to record the failure with an `UPDATE` from inside that aborted transaction — which cannot execute — and then called `PG_RE_THROW()`, which would have discarded it in any case.

So `attempts` never moved, `next_retry_at` was never set, and nothing ever moved the item to `failed`.

## Why this matters more than the spin

Three mechanisms the queue already has are all gated, directly or indirectly, on `attempts` incrementing:

| mechanism | purpose | state before this change |
|---|---|---|
| `next_retry_at` backoff | hold a failing item out of the claim | never set |
| `has_retries` → one-at-a-time | stop a suspect item taking its batch down with it | never fires |
| `max_attempts` | retire an item that cannot succeed | never reached |

The design was right; one broken thing switched all of it off. That also meant a poison item dragged its batch-mates through repeated embedding: `generate_batch()` runs for the whole batch before the per-item loop, so their embeddings were bought and then discarded on every cycle.

## Fix

Note the item's identity in process-local memory before anything that can raise, and record the failure in a fresh transaction after the worker's handler has aborted the failed one.

**Attribution is deliberately narrow.** The note is taken in the sparse-only probe as well as the per-item loop — the probe runs first and is where a dropped chunk table actually fails, which is how the symptom presented — and is *cleared* once the probe finishes. What runs in between, marking the batch and resolving the provider, fails for the batch rather than for any one item. Leaving an item noted there would bill it for a fault that is not its own, and since a misconfigured provider raises on every batch, that would work through the queue retiring one blameless item per `max_attempts` cycles.

**The update matches on the state this worker last saw**, not on the row id alone. A launcher restart can briefly leave two workers on one database, and the abort released this row's claim, so another worker may have taken and finished it meanwhile. An unconditional update would revive a completed item as pending, or mark a succeeded one failed. No explicit locking is needed: under READ COMMITTED a qualified `UPDATE` re-checks its `WHERE` clause against the newest version of the row, so one that has moved on simply fails the match. Verified directly with two concurrent sessions.

The transaction setup sits inside the `PG_TRY` rather than before it. This runs from the worker's own `PG_CATCH`, which is not a handler for errors raised within it, so anything escaping would take the worker down rather than being swallowed as the contract claims.

The per-item `PG_TRY` is removed rather than left with a catch that only re-throws, which is indistinguishable from having no handler at all.

## Test plan

`test/t/004_queue_failure_accounting.pl` automates the reproduction. It injects a queue row naming a chunk table that does not exist, marked `sparse_only` so the embedding provider is skipped entirely and no API key is required.

- [x] All 19 regression tests pass from a clean build (PostgreSQL 17.10)
- [x] All four TAP tests pass, including the new one
- [x] **Four of its five assertions fail against unfixed `main`**: no attempt recorded, no backoff set, still `pending` after the full window, still claimable
- [x] Measured on the same reproduction: `attempts` reaches 1 with a backoff, failure cycles drop from about 75 in a thirty second window to 1, and the item reaches `failed` at `attempts` 3 and stops being claimed
- [x] Concurrency guard checked separately: a row set to `completed` mid-flight is left untouched, `attempts` unchanged

## Reviewing the diff

Please use `?w=1`. Removing the per-item `PG_TRY` de-indents the 128-line block it wrapped, so the raw diff is several times larger than the change: `git diff -w` is a small fraction of it, and everything outside that is pure re-indentation.

## Not fixed here

An error still aborts the whole claimed batch, so items alongside the failing one are reprocessed and their embeddings re-fetched. That is now bounded by `max_attempts` rather than unbounded. Separating it needs per-item subtransactions, which is a different trade — and worth noting the worker already opens two subtransactions per chunk, so `PGPROC_MAX_CACHED_SUBXIDS` (64) is closer than it looks at larger `batch_size`. Both are better considered on their own.
