### PR TITLE
Size the provider auth headers dynamically and stop truncating parsed floats

### DIFF
--- a/src/provider_common.c
+++ b/src/provider_common.c
@@ -250,8 +250,22 @@ provider_parse_float_array(const char **pos, float *output, int dim)
 		while (*p && (isdigit((unsigned char) *p) || *p == '.' || *p == '-' ||
 					  *p == '+' || *p == 'e' || *p == 'E'))
 		{
-			if (value_pos < (int) sizeof(value_buf) - 1)
-				value_buf[value_pos++] = *p;
+			/*
+			 * Stop rather than truncate.  No double needs this many
+			 * characters -- %.17g never exceeds 24 -- so a longer run means a
+			 * malformed response, and keeping only the leading digits would
+			 * feed atof() a number of an entirely different magnitude and
+			 * score on it silently.  Every caller treats a short count as a
+			 * dimension mismatch, so returning here reports the response as
+			 * bad instead.
+			 */
+			if (value_pos >= (int) sizeof(value_buf) - 1)
+			{
+				*pos = p;
+				return idx;
+			}
+
+			value_buf[value_pos++] = *p;
 			p++;
 		}
 		value_buf[value_pos] = '\0';

--- a/src/provider_common.c
+++ b/src/provider_common.c
@@ -226,7 +226,9 @@ provider_count_array_dimensions(const char *p)
  *
  * Reads up to `dim` float values from the current position (after '[').
  * Advances *pos past the parsed values (to ']' or end of parsed data).
- * Returns the number of values successfully parsed.
+ * Returns the number of values successfully parsed, or
+ * PROVIDER_PARSE_MALFORMED on a numeric literal too long to be one, in which
+ * case *pos is left on the offending run rather than past it.
  */
 int
 provider_parse_float_array(const char **pos, float *output, int dim)
@@ -255,14 +257,12 @@ provider_parse_float_array(const char **pos, float *output, int dim)
 			 * characters -- %.17g never exceeds 24 -- so a longer run means a
 			 * malformed response, and keeping only the leading digits would
 			 * feed atof() a number of an entirely different magnitude and
-			 * score on it silently.  Every caller treats a short count as a
-			 * dimension mismatch, so returning here reports the response as
-			 * bad instead.
+			 * score on it silently.
 			 */
 			if (value_pos >= (int) sizeof(value_buf) - 1)
 			{
 				*pos = p;
-				return idx;
+				return PROVIDER_PARSE_MALFORMED;
 			}
 
 			value_buf[value_pos++] = *p;
@@ -471,8 +471,11 @@ provider_parse_openai_embedding_response(const char *json_response, int count,
 
 		if (parsed != *dim)
 		{
-			*error_msg = psprintf("Dimension mismatch: expected %d, got %d",
-								  *dim, parsed);
+			*error_msg = (parsed == PROVIDER_PARSE_MALFORMED)
+				? pstrdup("Malformed embedding response: numeric literal too "
+						  "long to be a number")
+				: psprintf("Dimension mismatch: expected %d, got %d",
+						   *dim, parsed);
 			provider_free_embeddings(embeddings, embedding_idx + 1);
 			return NULL;
 		}

--- a/src/provider_common.h
+++ b/src/provider_common.h
@@ -75,7 +75,14 @@ float **provider_parse_openai_embedding_response(const char *json_response,
 /* Count dimensions by counting commas in a JSON float array (after '[') */
 int provider_count_array_dimensions(const char *p);
 
-/* Parse a JSON float array into pre-allocated output; returns count parsed */
+/*
+ * Parse a JSON float array into pre-allocated output; returns count parsed,
+ * or PROVIDER_PARSE_MALFORMED if a numeric literal was too long to be one.
+ * Callers that only compare against the expected count still reject that,
+ * since it can never equal a dimension.
+ */
+#define PROVIDER_PARSE_MALFORMED	(-1)
+
 int provider_parse_float_array(const char **pos, float *output, int dim);
 
 /* Append extra headers from GUC to a curl header list */

--- a/src/provider_gemini.c
+++ b/src/provider_gemini.c
@@ -237,8 +237,11 @@ parse_gemini_batch_embedding_response(const char *json_response, int count,
 
 		if (parsed != *dim)
 		{
-			*error_msg = psprintf("Dimension mismatch: expected %d, got %d",
-								  *dim, parsed);
+			*error_msg = (parsed == PROVIDER_PARSE_MALFORMED)
+				? pstrdup("Malformed embedding response: numeric literal too "
+						  "long to be a number")
+				: psprintf("Dimension mismatch: expected %d, got %d",
+						   *dim, parsed);
 			provider_free_embeddings(embeddings, embedding_idx + 1);
 			return NULL;
 		}

--- a/src/provider_gemini.c
+++ b/src/provider_gemini.c
@@ -127,7 +127,7 @@ gemini_generate_batch(const char **texts, int count, int *dim, char **error_msg)
 	char *json_request;
 	char *url;
 	const char *base_url;
-	char auth_header[512];
+	char *auth_header;
 	StringInfoData request_buf;
 	ResponseBuffer response;
 	float **embeddings;
@@ -164,8 +164,7 @@ gemini_generate_batch(const char **texts, int count, int *dim, char **error_msg)
 				   pgedge_vectorizer_model);
 
 	/* Build auth header */
-	snprintf(auth_header, sizeof(auth_header),
-			 "x-goog-api-key: %s", api_key);
+	auth_header = psprintf("x-goog-api-key: %s", api_key);
 
 	/* Perform request */
 	if (!provider_do_curl_request(url, auth_header, json_request,
@@ -173,6 +172,7 @@ gemini_generate_batch(const char **texts, int count, int *dim, char **error_msg)
 	{
 		pfree(json_request);
 		pfree(url);
+		pfree(auth_header);
 		if (response.data)
 			pfree(response.data);
 		return NULL;
@@ -184,6 +184,7 @@ gemini_generate_batch(const char **texts, int count, int *dim, char **error_msg)
 
 	pfree(json_request);
 	pfree(url);
+	pfree(auth_header);
 	pfree(response.data);
 	return embeddings;
 }

--- a/src/provider_ollama.c
+++ b/src/provider_ollama.c
@@ -205,8 +205,11 @@ parse_ollama_embedding_response(const char *json_response, int *dim,
 
 	if (parsed != *dim)
 	{
-		*error_msg = psprintf("Dimension mismatch: expected %d, got %d",
-							  *dim, parsed);
+		*error_msg = (parsed == PROVIDER_PARSE_MALFORMED)
+			? pstrdup("Malformed embedding response: numeric literal too "
+					  "long to be a number")
+			: psprintf("Dimension mismatch: expected %d, got %d",
+					   *dim, parsed);
 		pfree(embedding);
 		return NULL;
 	}

--- a/src/provider_openai.c
+++ b/src/provider_openai.c
@@ -135,8 +135,7 @@ openai_generate_batch(const char **texts, int count, int *dim, char **error_msg)
 	char *json_request;
 	char *url;
 	const char *base_url;
-	char auth_header[512];
-	const char *auth_header_ptr = NULL;
+	char *auth_header = NULL;
 	ResponseBuffer response;
 	float **embeddings;
 
@@ -160,17 +159,17 @@ openai_generate_batch(const char **texts, int count, int *dim, char **error_msg)
 	/* Build auth header if we have a key */
 	if (api_key != NULL)
 	{
-		snprintf(auth_header, sizeof(auth_header),
-				 "Authorization: Bearer %s", api_key);
-		auth_header_ptr = auth_header;
+		auth_header = psprintf("Authorization: Bearer %s", api_key);
 	}
 
 	/* Perform request */
-	if (!provider_do_curl_request(url, auth_header_ptr, json_request,
+	if (!provider_do_curl_request(url, auth_header, json_request,
 								  "OpenAI", &response, error_msg))
 	{
 		pfree(json_request);
 		pfree(url);
+		if (auth_header)
+			pfree(auth_header);
 		if (response.data)
 			pfree(response.data);
 		return NULL;
@@ -182,6 +181,8 @@ openai_generate_batch(const char **texts, int count, int *dim, char **error_msg)
 
 	pfree(json_request);
 	pfree(url);
+	if (auth_header)
+		pfree(auth_header);
 	pfree(response.data);
 	return embeddings;
 }

--- a/src/provider_voyage.c
+++ b/src/provider_voyage.c
@@ -116,7 +116,7 @@ voyage_generate_batch(const char **texts, int count, int *dim, char **error_msg)
 	char *json_request;
 	char *url;
 	const char *base_url;
-	char auth_header[512];
+	char *auth_header;
 	ResponseBuffer response;
 	float **embeddings;
 
@@ -138,8 +138,7 @@ voyage_generate_batch(const char **texts, int count, int *dim, char **error_msg)
 	url = psprintf("%s/embeddings", base_url);
 
 	/* Build auth header */
-	snprintf(auth_header, sizeof(auth_header),
-			 "Authorization: Bearer %s", api_key);
+	auth_header = psprintf("Authorization: Bearer %s", api_key);
 
 	/* Perform request */
 	if (!provider_do_curl_request(url, auth_header, json_request,
@@ -147,6 +146,7 @@ voyage_generate_batch(const char **texts, int count, int *dim, char **error_msg)
 	{
 		pfree(json_request);
 		pfree(url);
+		pfree(auth_header);
 		if (response.data)
 			pfree(response.data);
 		return NULL;
@@ -158,6 +158,7 @@ voyage_generate_batch(const char **texts, int count, int *dim, char **error_msg)
 
 	pfree(json_request);
 	pfree(url);
+	pfree(auth_header);
 	pfree(response.data);
 	return embeddings;
 }

--- a/src/worker.c
+++ b/src/worker.c
@@ -56,6 +56,11 @@ static time_t last_cleanup_time = 0;
  * a fixed string tells them the item failed, which they can already see from
  * its status, but not why. A fixed buffer rather than a palloc'd copy, since
  * the transaction context this is captured in does not survive the abort.
+ *
+ * Truncation here is deliberate and harmless: this is diagnostic text, the
+ * untruncated message has already gone to the server log via
+ * EmitErrorReport(), and a bounded buffer is what lets the copy outlive the
+ * abort at all.
  */
 #define FAILED_ITEM_ERROR_LEN	1024
 


### PR DESCRIPTION
Closes #31.

## What the audit found

Ten fixed-length buffers exist in the extension. Eight are provably bounded; two had a path where unbounded input could reach them, and both failed by silently truncating.

**The auth headers, and this one is reachable.** `provider_openai.c`, `provider_voyage.c` and `provider_gemini.c` each built their header into `char auth_header[512]`, which leaves roughly 489 bytes for the key after the prefix. Nothing held the key under that: `provider_load_api_key()` accepts a file up to `MAX_API_KEY_FILE_SIZE`, which is **4096**, so the two bounds disagreed by a factor of eight. That is not a theoretical gap, because JWT-style bearer tokens for OpenAI-compatible gateways routinely exceed a thousand characters, and the failure mode would be a credential quietly cut in half producing an authentication error indistinguishable from a wrong key. They now use `psprintf()`, which matches how `url` is already built and freed a few lines above in each of the same three functions, and removes the second bound rather than merely raising it.

**The float parser.** `provider_parse_float_array()` read numeric literals into `char value_buf[32]`, kept only the leading characters of anything longer, and passed that to `atof()`. A literal that long is not something a provider could legitimately send, since `%.17g` never exceeds 24 characters, but the failure mode was to score on a number of an entirely different magnitude in silence. It now stops instead, and since all three callers already treat a short count as a dimension mismatch, that turns a silent wrong answer into a reported bad response with no signature change.

## What was deliberately left alone

The other eight are bounded by construction, and the reasoning is recorded here so the next audit does not have to rederive it:

- the BM25 term keys in `bm25.c` and `bm25.h` cannot be reached by anything overlong since #50 added the guard dropping such terms at tokenization, which is what made those keys safe;
- the three `dbname[NAMEDATALEN]` buffers in `worker.c` are sized to the bound PostgreSQL itself places on a database name, so truncation cannot occur;
- the worker's captured error message is diagnostic text, deliberately bounded so the copy can outlive the transaction abort, and the untruncated original has already reached the server log via `EmitErrorReport()`. The comment now says so explicitly.

## Test plan

- [x] 19 regression tests and all TAP suites green on PostgreSQL 18.4, clean build with no new warnings

**No new tests, said plainly rather than dressed up.** Neither change has a test seam worth building. Exercising the auth header needs a live endpoint that will echo the header back, and the float parser is not reachable from SQL, so covering either would mean standing up a stub HTTP server purely to assert a string length. The auth header change is also a strict improvement regardless of input: `psprintf()` cannot truncate at any length, so there is no boundary left to test.