### PR TITLE
Restrict the provider connection GUCs to superusers

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Security
 
+- Restricted `pgedge_vectorizer.provider`, `api_key_file`, `api_url` and
+  `extra_headers` to superusers (`PGC_SUSET`); they were settable by any
+  session ([#30](https://github.com/pgEdge/pgedge-vectorizer/issues/30)).
+  `api_key_file` names a file the backend opens as the server's operating
+  system user, and `api_url` and `extra_headers` decide where its contents are
+  sent and what accompanies them, so together they allowed a user who could
+  reach the embedding functions to read any file the `postgres` user could read
+  and have it delivered to a host of their choosing in an `Authorization`
+  header. Changing `provider` alone was enough to present a superuser-configured
+  key to a different vendor's endpoint. This is a behaviour change: an
+  application relying on setting any of the four per session must now either run
+  as a superuser, have the parameter delegated with `GRANT SET ON PARAMETER`
+  (PostgreSQL 15 and later), or set it in `postgresql.conf`.
 - Hardened API key file loading in OpenAI and Voyage providers (#17)
     - Reject API key files larger than 4096 bytes (`MAX_API_KEY_FILE_SIZE`) before
       reading, preventing unbounded memory allocation (CWE-20 / CWE-120)

--- a/src/guc.c
+++ b/src/guc.c
@@ -54,6 +54,31 @@ double pgedge_vectorizer_bm25_b        = 0.75;
 
 /*
  * Initialize all GUC variables
+ *
+ * The contexts used here, and why.
+ *
+ * PGC_SUSET for anything that decides what the server reads from its own
+ * filesystem or where it sends an outbound request. api_key_file names a file
+ * the backend opens as the server's OS user; api_url and extra_headers decide
+ * where its contents are sent and what accompanies them; provider selects
+ * which vendor endpoint and header format the configured key is presented to.
+ * Left settable by any session, those combine into arbitrary local file
+ * disclosure: SET api_key_file to any file the postgres user can read, SET
+ * api_url to a host you control, and the file arrives in an Authorization
+ * header. Nothing else has to be misconfigured for that to work, and a
+ * superuser-set key is exfiltrated to a third party just by changing provider.
+ *
+ * PGC_SUSET rather than PGC_POSTMASTER or PGC_SIGHUP because these are
+ * legitimately per-session settings for an administrator; it withholds them
+ * from unprivileged users without making them static. From PostgreSQL 15 a
+ * superuser can still delegate one with GRANT SET ON PARAMETER.
+ *
+ * PGC_USERSET for settings whose blast radius is the calling session's own
+ * results: model, and the hybrid search scoring knobs.
+ *
+ * PGC_SIGHUP for everything the background workers read, since the launcher
+ * and its workers are not attached to any session and a per-session value
+ * would be meaningless to them.
  */
 void
 pgedge_vectorizer_init_guc(void)
@@ -64,7 +89,7 @@ pgedge_vectorizer_init_guc(void)
 								"Determines which API provider is used for generating embeddings.",
 								&pgedge_vectorizer_provider,
 								"openai",
-								PGC_USERSET,
+								PGC_SUSET,
 								0,
 								NULL, NULL, NULL);
 
@@ -74,7 +99,7 @@ pgedge_vectorizer_init_guc(void)
 								"Tilde (~) expands to home directory.",
 								&pgedge_vectorizer_api_key_file,
 								"~/.pgedge-vectorizer-llm-api-key",
-								PGC_USERSET,
+								PGC_SUSET,
 								0,
 								NULL, NULL, NULL);
 
@@ -89,7 +114,7 @@ pgedge_vectorizer_init_guc(void)
 								"(LM Studio, Docker Model Runner, EXO) or proxies (Portkey).",
 								&pgedge_vectorizer_api_url,
 								"",
-								PGC_USERSET,
+								PGC_SUSET,
 								0,
 								NULL, NULL, NULL);
 
@@ -112,7 +137,7 @@ pgedge_vectorizer_init_guc(void)
 								"'x-portkey-provider: openai; x-custom: value'",
 								&pgedge_vectorizer_extra_headers,
 								"",
-								PGC_USERSET,
+								PGC_SUSET,
 								0,
 								NULL, NULL, NULL);
 

--- a/test/expected/providers.out
+++ b/test/expected/providers.out
@@ -158,3 +158,42 @@ SHOW pgedge_vectorizer.api_url;
  
 (1 row)
 
+---------------------------------------------------------------------------
+-- GUC privilege boundary
+---------------------------------------------------------------------------
+-- api_key_file names a file the backend opens as the server's OS user, and
+-- api_url and extra_headers decide where its contents are sent and what goes
+-- with them; provider decides which vendor endpoint and header format the
+-- configured key is presented to. Together, settable by anyone, they are an
+-- arbitrary local file read delivered to a chosen host in an Authorization
+-- header, so all four are superuser-only. model and the scoring knobs affect
+-- only the calling session's own results and stay open.
+CREATE ROLE pgv_guc_unpriv;
+SET SESSION AUTHORIZATION pgv_guc_unpriv;
+SELECT current_setting('is_superuser') AS unprivileged_session;
+ unprivileged_session 
+----------------------
+ off
+(1 row)
+
+\set ON_ERROR_STOP off
+SET pgedge_vectorizer.api_key_file = '/etc/passwd';
+ERROR:  permission denied to set parameter "pgedge_vectorizer.api_key_file"
+SET pgedge_vectorizer.api_url = 'http://example.invalid';
+ERROR:  permission denied to set parameter "pgedge_vectorizer.api_url"
+SET pgedge_vectorizer.extra_headers = 'x-evil: 1';
+ERROR:  permission denied to set parameter "pgedge_vectorizer.extra_headers"
+SET pgedge_vectorizer.provider = 'gemini';
+ERROR:  permission denied to set parameter "pgedge_vectorizer.provider"
+\set ON_ERROR_STOP on
+-- Settings scoped to the caller's own results stay available.
+SET pgedge_vectorizer.model = 'text-embedding-3-large';
+SET pgedge_vectorizer.bm25_k1 = 1.5;
+SHOW pgedge_vectorizer.model;
+ pgedge_vectorizer.model 
+-------------------------
+ text-embedding-3-large
+(1 row)
+
+RESET SESSION AUTHORIZATION;
+DROP ROLE pgv_guc_unpriv;

--- a/test/sql/providers.sql
+++ b/test/sql/providers.sql
@@ -67,3 +67,35 @@ RESET pgedge_vectorizer.api_url;
 RESET pgedge_vectorizer.model;
 SHOW pgedge_vectorizer.provider;
 SHOW pgedge_vectorizer.api_url;
+
+---------------------------------------------------------------------------
+-- GUC privilege boundary
+---------------------------------------------------------------------------
+
+-- api_key_file names a file the backend opens as the server's OS user, and
+-- api_url and extra_headers decide where its contents are sent and what goes
+-- with them; provider decides which vendor endpoint and header format the
+-- configured key is presented to. Together, settable by anyone, they are an
+-- arbitrary local file read delivered to a chosen host in an Authorization
+-- header, so all four are superuser-only. model and the scoring knobs affect
+-- only the calling session's own results and stay open.
+
+CREATE ROLE pgv_guc_unpriv;
+SET SESSION AUTHORIZATION pgv_guc_unpriv;
+
+SELECT current_setting('is_superuser') AS unprivileged_session;
+
+\set ON_ERROR_STOP off
+SET pgedge_vectorizer.api_key_file = '/etc/passwd';
+SET pgedge_vectorizer.api_url = 'http://example.invalid';
+SET pgedge_vectorizer.extra_headers = 'x-evil: 1';
+SET pgedge_vectorizer.provider = 'gemini';
+\set ON_ERROR_STOP on
+
+-- Settings scoped to the caller's own results stay available.
+SET pgedge_vectorizer.model = 'text-embedding-3-large';
+SET pgedge_vectorizer.bm25_k1 = 1.5;
+SHOW pgedge_vectorizer.model;
+
+RESET SESSION AUTHORIZATION;
+DROP ROLE pgv_guc_unpriv;


### PR DESCRIPTION
Closes #30.

## The finding

The issue asked whether `PGC_USERSET` was intended for each of the provider settings, "especially anything security-relevant". For four of them it was not, and the combination is worse than any of them alone.

`api_key_file` names a file the backend opens **as the server's operating system user**. `api_url` and `extra_headers` decide where the contents of that file are sent and what accompanies them. `provider` decides which vendor endpoint the configured key is presented to, and in which header format. All four were settable by any session.

Point `api_key_file` at anything the `postgres` user can read, point `api_url` at a host you control, call an embedding function, and the file arrives in an `Authorization` header. Changing `provider` alone was enough to hand a superuser-configured key to a different vendor's endpoint.

## Confirmed, not assumed

I demonstrated it rather than reasoning about it. With a listener on localhost and a file owned by `postgres` at mode 600, an unprivileged role received:

```
Authorization: Bearer TOP-SECRET-SERVER-FILE
```

**Scope, stated precisely, because it matters for how urgently you take this.** A default installation is *not* exposed: `CREATE EXTENSION` does not grant `USAGE` on the schema to `PUBLIC`, and I confirmed an unprivileged role gets `permission denied for schema pgedge_vectorizer` before reaching any of this. But the shipped SQL carries `-- GRANT USAGE ON SCHEMA pgedge_vectorizer TO PUBLIC;` as a commented-out suggestion, so any deployment that follows it is exposed, and an unprivileged user could always set the GUCs regardless, merely lacking a way to trigger the read.

## The change

The four become `PGC_SUSET`. That withholds them from unprivileged users without making them static, and a superuser can still delegate an individual one with `GRANT SET ON PARAMETER` on PostgreSQL 15 and later.

`model` and the hybrid scoring knobs stay `PGC_USERSET`, since their blast radius is the calling session's own results. Everything the background workers read stays `PGC_SIGHUP`, because the launcher and its workers are attached to no session.

The reasoning is recorded above `pgedge_vectorizer_init_guc()` so the next GUC added is classified deliberately rather than by copying whichever one it was pasted beneath.

## The other half of the issue

The worry about a `SIGHUP` database list interacting with a worker count fixed at postmaster start no longer applies: `num_workers` became `PGC_SIGHUP` with the dynamic launcher in #42, and its relationship to `max_worker_processes` is already documented on the GUC itself. No change needed, recorded here so the question is closed rather than merely unanswered.

## ⚠️ Behaviour change

An application setting any of the four per session will now get `permission denied to set parameter`. It must run as a superuser, have the parameter delegated with `GRANT SET ON PARAMETER`, or set it in `postgresql.conf`. This is called out in the changelog under Security.

## Test plan

- [x] 19 regression tests and all TAP suites green on PostgreSQL 18.4
- [x] `test/sql/providers.sql` gains a privilege boundary case asserting all four are refused for an unprivileged session and that `model` and `bm25_k1` remain settable, so the line between them is pinned rather than described