### PR TITLE
Document that changing the embedding model breaks an existing chunk table

### DIFF
--- a/docs/best_practices.md
+++ b/docs/best_practices.md
@@ -34,3 +34,12 @@ Effective data management ensures clean operations and provides flexibility when
 - Use the `reprocess_chunks()` function to queue existing chunks that are missing embeddings.
 - Use the `recreate_chunks()` function for a complete chunk regeneration, which deletes all existing chunks first.
 - Each column gets independent chunk tables and triggers, so you can disable them selectively as needed.
+- Settle on an embedding model before enabling vectorization, because the
+  model's dimension is fixed into the chunk table when the table is
+  created.
+- Rebuild the vectorizer with `disable_vectorization()` and
+  `enable_vectorization()` after changing to a model of a different
+  dimension, since `recreate_chunks()` deletes chunk rows without
+  altering the column.
+- Budget for the provider cost of re-embedding an entire table before
+  changing the model on a populated one.

--- a/docs/best_practices.md
+++ b/docs/best_practices.md
@@ -37,9 +37,11 @@ Effective data management ensures clean operations and provides flexibility when
 - Settle on an embedding model before enabling vectorization, because the
   model's dimension is fixed into the chunk table when the table is
   created.
-- Rebuild the vectorizer with `disable_vectorization()` and
-  `enable_vectorization()` after changing to a model of a different
-  dimension, since `recreate_chunks()` deletes chunk rows without
-  altering the column.
+- Rebuild the vectorizer with `disable_vectorization(...,
+  drop_chunk_table => TRUE)` and then `enable_vectorization()` after
+  changing to a model of a different dimension, repeating this for every
+  vectorized column. Neither `recreate_chunks()` nor a
+  `disable_vectorization()` that keeps the chunk table alters the column,
+  so neither resolves the mismatch.
 - Budget for the provider cost of re-embedding an entire table before
   changing the model on a populated one.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -14,6 +14,20 @@ These settings configure the connection to your embedding provider, including th
 | `pgedge_vectorizer.model` | `text-embedding-3-small` | Model name | No | No | No |
 | `pgedge_vectorizer.extra_headers` | (empty) | Semicolon-separated `key: value` HTTP headers added to all API requests | No | No | No |
 
+!!! warning "The model fixes the vector dimension of a chunk table"
+
+    The model determines how many dimensions the provider returns, and
+    `enable_vectorization()` fixes that number into the chunk table's
+    `embedding vector(N)` column when the table is created. Changing
+    `pgedge_vectorizer.model` to a model with a different dimension does
+    not migrate an existing chunk table. The background worker compares
+    the dimensions before writing, so nothing is corrupted, but it marks
+    the affected queue items `failed` with the message
+    `Dimension mismatch: model=N, table=M` and no new embeddings are
+    stored for that table until you act. The
+    [Troubleshooting](troubleshooting.md) document describes how to
+    recover.
+
 ## Worker Settings
 
 These settings control the background workers that process the embedding queue, including concurrency, batch sizes, and retry behavior.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -13,7 +13,7 @@ SHOW shared_preload_libraries;
 
 ## Workers Not Processing After CREATE EXTENSION
 
-Background workers start with PostgreSQL — before the extension is created. Workers automatically detect the extension using exponential backoff (checking every 5s, 10s, 20s, ... up to 5 minutes). After running `CREATE EXTENSION pgedge_vectorizer`, workers should discover it within seconds.
+Background workers start with PostgreSQL, before the extension is created. Workers automatically detect the extension using exponential backoff (checking every 5s, 10s, 20s, ... up to 5 minutes). After running `CREATE EXTENSION pgedge_vectorizer`, workers should discover it within seconds.
 
 If workers don't start processing:
 
@@ -64,3 +64,72 @@ SELECT * FROM pgedge_vectorizer.failed_items;
 ```sql
 SELECT pgedge_vectorizer.retry_failed();
 ```
+
+## Dimension Mismatch After Changing the Model
+
+Each chunk table stores its vectors in an `embedding vector(N)` column,
+where N is fixed when `enable_vectorization()` creates the table. If you
+change `pgedge_vectorizer.model` to a model returning a different number
+of dimensions, the worker cannot write the new vectors into the existing
+column, and embeddings stop being produced for that table.
+
+Nothing is corrupted when this happens. The worker compares the two
+dimensions before it writes, so the existing embeddings are left intact
+and no vector of the wrong size is ever stored.
+
+The affected queue items move to `failed` rather than being retried,
+because retrying cannot succeed. Run the following query to identify
+them:
+
+```sql
+SELECT chunk_table, error_message, count(*)
+  FROM pgedge_vectorizer.queue
+ WHERE status = 'failed'
+ GROUP BY chunk_table, error_message;
+```
+
+An affected item reports `Dimension mismatch: model=N, table=M`, where N
+is the dimension the configured model returned and M is the dimension
+the chunk table expects. The server log carries a matching warning that
+names the table.
+
+Restoring the previous model is the quicker of the two remedies, and is
+the right one if the change was accidental:
+
+```sql
+ALTER SYSTEM SET pgedge_vectorizer.model = 'text-embedding-3-small';
+SELECT pg_reload_conf();
+SELECT pgedge_vectorizer.retry_failed();
+```
+
+Rebuilding the vectorizer keeps the new model and re-embeds the table
+under it. Note that `recreate_chunks()` does not resolve a dimension
+change, because that function deletes the rows of a chunk table without
+altering the type of the column. Follow these steps instead:
+
+1. Set the new model and reload the configuration so that the dimension
+   detection uses the model you want.
+
+    ```sql
+    ALTER SYSTEM SET pgedge_vectorizer.model = 'text-embedding-3-large';
+    SELECT pg_reload_conf();
+    ```
+
+2. Drop the vectorizer together with its chunk table, which discards the
+   embeddings of the old dimension.
+
+    ```sql
+    SELECT pgedge_vectorizer.disable_vectorization(
+        'docs', 'body', drop_chunk_table => TRUE);
+    ```
+
+3. Enable vectorization again, which detects the new dimension, creates
+   the chunk table to match, and queues every source row.
+
+    ```sql
+    SELECT pgedge_vectorizer.enable_vectorization('docs', 'body');
+    ```
+
+Re-embedding calls the provider for every chunk in the table, so confirm
+the cost against your provider's pricing before starting on a large
+table.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -13,7 +13,13 @@ SHOW shared_preload_libraries;
 
 ## Workers Not Processing After CREATE EXTENSION
 
-Background workers start with PostgreSQL, before the extension is created. Workers automatically detect the extension using exponential backoff (checking every 5s, 10s, 20s, ... up to 5 minutes). After running `CREATE EXTENSION pgedge_vectorizer`, workers should discover it within seconds.
+Background workers start with PostgreSQL, before the extension is
+created. A worker checks for the extension on an exponential backoff,
+waiting 5s, then 10s, then 20s, and so on up to a ceiling of 5 minutes.
+After running `CREATE EXTENSION pgedge_vectorizer`, a worker discovers it
+on its next check, so a database configured long before the extension was
+created can wait up to 5 minutes. Reload the configuration to have the
+workers check immediately.
 
 If workers don't start processing:
 
@@ -94,13 +100,18 @@ the chunk table expects. The server log carries a matching warning that
 names the table.
 
 Restoring the previous model is the quicker of the two remedies, and is
-the right one if the change was accidental:
+the right one if the change was accidental. Substitute the model that
+built the table rather than the name shown here, because setting any
+other model leaves the dimensions mismatched:
 
 ```sql
-ALTER SYSTEM SET pgedge_vectorizer.model = 'text-embedding-3-small';
+ALTER SYSTEM SET pgedge_vectorizer.model = 'the-previous-model';
 SELECT pg_reload_conf();
 SELECT pgedge_vectorizer.retry_failed();
 ```
+
+The `table=M` figure in the error gives the dimension the chunk table
+expects, so the model you restore must be one that returns M dimensions.
 
 Rebuilding the vectorizer keeps the new model and re-embeds the table
 under it. Note that `recreate_chunks()` does not resolve a dimension
@@ -130,6 +141,16 @@ altering the type of the column. Follow these steps instead:
     SELECT pgedge_vectorizer.enable_vectorization('docs', 'body');
     ```
 
-Re-embedding calls the provider for every chunk in the table, so confirm
-the cost against your provider's pricing before starting on a large
-table.
+Repeat those steps for every vectorized column, not just the one you
+noticed. The model is a single global setting while chunk tables are
+independent per column, so changing it affects every vectorizer whose
+dimension no longer matches. The following query lists them:
+
+```sql
+SELECT source_table, source_column, chunk_table
+  FROM pgedge_vectorizer.vectorizers
+ ORDER BY source_table, source_column;
+```
+
+Re-embedding calls the provider for every chunk in every table rebuilt,
+so confirm the cost against your provider's pricing before starting.


### PR DESCRIPTION
Follows the discussion on #27, where we established that the code already guards against this properly and the gap is purely documentation.

## What was missing

`enable_vectorization()` writes the provider's dimension into the chunk table's `embedding vector(N)` column when it creates the table, so the model choice is baked in permanently. Change `pgedge_vectorizer.model` to a model of a different size afterwards and the worker cannot write.

It handles that correctly: `src/worker.c:1512` compares the two dimensions before writing, logs an actionable warning, and marks the batch `failed` with `Dimension mismatch: model=N, table=M`. Nothing is corrupted. But the documentation mentioned neither the constraint nor the recovery, and there was no mention of dimensions at all in `configuration.md`, `best_practices.md` or `troubleshooting.md`.

## The part that matters most

`recreate_chunks()` is the function a reader would reach for, and `best_practices.md` currently recommends it for "a complete chunk regeneration". **It cannot resolve a dimension change.** It deletes the rows of the chunk table and leaves the column type untouched, so every requeued row fails in exactly the same way and the user goes round in a circle.

I verified this on a live table rather than reasoning about it:

| step | resulting column type |
|---|---|
| `enable_vectorization(..., embedding_dimension => 3)` | `vector(3)` |
| after `recreate_chunks()` | `vector(3)` — unchanged |
| after `disable_vectorization(..., drop_chunk_table => TRUE)` then `enable_vectorization()` | `vector(5)`, with every row requeued |

So the docs now say plainly that `recreate_chunks()` is not the answer here, and give the rebuild that is.

## Changes

`configuration.md` gains a warning admonition beneath the provider settings table, since that is where someone reads about the model in the first place. `troubleshooting.md` gains a section with the symptoms, a query to identify affected items, and both recovery routes: restoring the old model, which is right when the change was accidental, and rebuilding, which keeps the new model. `best_practices.md` gains three notes covering choosing the model up front, the rebuild, and budgeting for the provider cost of re-embedding.

## Verification

Every claim was checked against the source rather than written from memory: all five functions named exist, `disable_vectorization()` really does take `drop_chunk_table`, the quoted `Dimension mismatch: model=N, table=M` text matches `src/worker.c:1527` exactly, the queue columns used in the example query exist, and the documented default model matches `src/guc.c`. New prose wraps at 79 characters and carries no em-dashes; I also removed a pre-existing em-dash from a neighbouring paragraph.

`mkdocs` is not installed here, so the site build is unverified and CI or a local `mkdocs build --strict` should confirm the admonition renders. The `admonition` extension is enabled in `mkdocs.yml`, though this is the first use of it in these docs.

One observation, not addressed here: `best_practices.md` uses bold text as section headings throughout, which the house style warns against because MkDocs can misread it as a heading and add it to the navigation pane. I added to the existing Data Management section rather than introduce another one. Worth a separate tidy-up if you agree.