### PR TITLE
Cache the BM25 corpus figures per backend instead of rescanning

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -173,6 +173,7 @@ different use cases.
 | `pgedge_vectorizer.enable_hybrid` | `false` | -- | Enable BM25 sparse vectors alongside dense embeddings |
 | `pgedge_vectorizer.bm25_k1` | `1.2` | `0.0-3.0` | BM25 term-frequency saturation |
 | `pgedge_vectorizer.bm25_b` | `0.75` | `0.0-1.0` | BM25 document-length normalization |
+| `pgedge_vectorizer.corpus_stats_cache_ttl` | `60s` | `0-3600` | Seconds a backend reuses a chunk table's corpus size and mean document length before reading them again. Set to 0 to read them on every call |
 
 For more information or to download Vectorizer visit:
 

--- a/src/bm25.c
+++ b/src/bm25.c
@@ -20,6 +20,7 @@
 #include <string.h>
 
 #include "access/xact.h"
+#include "catalog/namespace.h"
 #include "catalog/pg_type.h"
 #include "lib/stringinfo.h"
 #include "utils/array.h"
@@ -224,12 +225,19 @@ bm25_tokenize(const char *text, int *ntokens)
 /*
  * Cached corpus figures for one chunk table.
  *
- * Keyed on the chunk table name, which is bounded by NAMEDATALEN because it
- * names a relation.  Key must be first for dynahash.
+ * Keyed on the relation's OID rather than the name it was reached by.  The
+ * name is resolved through search_path, so one string can mean different
+ * relations at different moments: a schema-per-tenant deployment gives every
+ * tenant a chunk table of the same name, and a pooled backend that switches
+ * search_path between requests would otherwise be handed whichever tenant's
+ * figures it saw first.  Dropping and recreating a chunk table under the same
+ * name has the same shape, and an OID changes in both cases.
+ *
+ * Key must be first for dynahash.
  */
 typedef struct
 {
-	char		key[NAMEDATALEN];
+	Oid			key;
 	int64		total_docs;
 	float8		avg_doc_len;
 	TimestampTz	read_at;
@@ -316,8 +324,19 @@ bm25_corpus_stats(const char *chunk_table, float8 *avg_doc_len)
 	CorpusStatsEntry   *entry;
 	bool				found;
 	TimestampTz			now;
+	Oid					relid;
 
 	if (pgedge_vectorizer_corpus_stats_cache_ttl <= 0)
+		return bm25_corpus_stats_uncached(chunk_table, avg_doc_len);
+
+	/*
+	 * Resolve the name the same way the query below will, through
+	 * search_path.  A name that resolves to nothing is left to the uncached
+	 * read, which raises the "relation does not exist" the caller expects
+	 * rather than inventing a different error here.
+	 */
+	relid = RelnameGetRelid(chunk_table);
+	if (!OidIsValid(relid))
 		return bm25_corpus_stats_uncached(chunk_table, avg_doc_len);
 
 	if (corpus_stats_cache == NULL)
@@ -325,15 +344,15 @@ bm25_corpus_stats(const char *chunk_table, float8 *avg_doc_len)
 		HASHCTL		ctl;
 
 		memset(&ctl, 0, sizeof(ctl));
-		ctl.keysize = NAMEDATALEN;
+		ctl.keysize = sizeof(Oid);
 		ctl.entrysize = sizeof(CorpusStatsEntry);
 		ctl.hcxt = TopMemoryContext;
 		corpus_stats_cache = hash_create("bm25_corpus_stats", 8, &ctl,
-										 HASH_ELEM | HASH_STRINGS |
+										 HASH_ELEM | HASH_BLOBS |
 										 HASH_CONTEXT);
 	}
 
-	entry = hash_search(corpus_stats_cache, chunk_table, HASH_ENTER, &found);
+	entry = hash_search(corpus_stats_cache, &relid, HASH_ENTER, &found);
 	now = GetCurrentTimestamp();
 
 	if (found &&

--- a/src/bm25.c
+++ b/src/bm25.c
@@ -27,6 +27,7 @@
 #include "utils/errcodes.h"
 #include "utils/hsearch.h"
 #include "utils/memutils.h"
+#include "utils/timestamp.h"
 
 /* ----------------------------------------------------------------
  * English stopword list — must stay sorted (used with bsearch)
@@ -221,7 +222,23 @@ bm25_tokenize(const char *text, int *ntokens)
 }
 
 /*
- * bm25_corpus_stats — corpus size N and mean document length, in one pass.
+ * Cached corpus figures for one chunk table.
+ *
+ * Keyed on the chunk table name, which is bounded by NAMEDATALEN because it
+ * names a relation.  Key must be first for dynahash.
+ */
+typedef struct
+{
+	char		key[NAMEDATALEN];
+	int64		total_docs;
+	float8		avg_doc_len;
+	TimestampTz	read_at;
+} CorpusStatsEntry;
+
+static HTAB *corpus_stats_cache = NULL;
+
+/*
+ * bm25_corpus_stats_uncached — read N and the mean document length.
  *
  * Both come from the same scan: taken separately they made two passes over
  * the chunk table for every search.  Returns N, clamped to a minimum of 1 so
@@ -235,7 +252,7 @@ bm25_tokenize(const char *text, int *ntokens)
  * Caller must have an active SPI connection.
  */
 static int64
-bm25_corpus_stats(const char *chunk_table, float8 *avg_doc_len)
+bm25_corpus_stats_uncached(const char *chunk_table, float8 *avg_doc_len)
 {
 	char   *sql;
 	int     ret;
@@ -267,6 +284,77 @@ bm25_corpus_stats(const char *chunk_table, float8 *avg_doc_len)
 	}
 
 	return (total <= 0) ? 1 : total;
+}
+
+/*
+ * bm25_corpus_stats — corpus size N and mean document length, cached.
+ *
+ * The underlying read is an unindexable aggregate over the whole chunk table,
+ * and it was paid on every call: once per search, and once per queue item in
+ * the worker, so a batch of ten scanned the table ten times over.  At 300,000
+ * chunks that is around 33ms a time and it grows with the corpus.
+ *
+ * These two figures are inputs to a ranking heuristic rather than an account
+ * that has to balance, and during ingest they are a moving target in any
+ * case, since every chunk written changes them.  Holding a value for a few
+ * seconds therefore costs a little precision in a number that was never
+ * precise, and buys the removal of a scan from the hot path of every search.
+ *
+ * Cached per backend rather than shared, which suits both callers: a worker
+ * is a long-lived process working one database, and searches arrive on
+ * pooled connections that are also long-lived.  A short-lived backend that
+ * runs a single search pays the scan exactly as it did before.
+ *
+ * Set pgedge_vectorizer.corpus_stats_cache_ttl to 0 to read afresh every
+ * time, which restores the previous behaviour exactly.
+ *
+ * Caller must have an active SPI connection.
+ */
+static int64
+bm25_corpus_stats(const char *chunk_table, float8 *avg_doc_len)
+{
+	CorpusStatsEntry   *entry;
+	bool				found;
+	TimestampTz			now;
+
+	if (pgedge_vectorizer_corpus_stats_cache_ttl <= 0)
+		return bm25_corpus_stats_uncached(chunk_table, avg_doc_len);
+
+	if (corpus_stats_cache == NULL)
+	{
+		HASHCTL		ctl;
+
+		memset(&ctl, 0, sizeof(ctl));
+		ctl.keysize = NAMEDATALEN;
+		ctl.entrysize = sizeof(CorpusStatsEntry);
+		ctl.hcxt = TopMemoryContext;
+		corpus_stats_cache = hash_create("bm25_corpus_stats", 8, &ctl,
+										 HASH_ELEM | HASH_STRINGS |
+										 HASH_CONTEXT);
+	}
+
+	entry = hash_search(corpus_stats_cache, chunk_table, HASH_ENTER, &found);
+	now = GetCurrentTimestamp();
+
+	if (found &&
+		!TimestampDifferenceExceeds(entry->read_at, now,
+									pgedge_vectorizer_corpus_stats_cache_ttl
+									* 1000))
+	{
+		*avg_doc_len = entry->avg_doc_len;
+		return entry->total_docs;
+	}
+
+	/*
+	 * Seed the entry from the caller's default before reading, so that a
+	 * table whose average cannot be determined caches that default rather
+	 * than whatever the previous caller happened to leave behind.
+	 */
+	entry->total_docs = bm25_corpus_stats_uncached(chunk_table, avg_doc_len);
+	entry->avg_doc_len = *avg_doc_len;
+	entry->read_at = now;
+
+	return entry->total_docs;
 }
 
 /*

--- a/src/bm25.c
+++ b/src/bm25.c
@@ -322,9 +322,9 @@ static int64
 bm25_corpus_stats(const char *chunk_table, float8 *avg_doc_len)
 {
 	CorpusStatsEntry   *entry;
-	bool				found;
 	TimestampTz			now;
 	Oid					relid;
+	int64				total_docs;
 
 	if (pgedge_vectorizer_corpus_stats_cache_ttl <= 0)
 		return bm25_corpus_stats_uncached(chunk_table, avg_doc_len);
@@ -352,10 +352,10 @@ bm25_corpus_stats(const char *chunk_table, float8 *avg_doc_len)
 										 HASH_CONTEXT);
 	}
 
-	entry = hash_search(corpus_stats_cache, &relid, HASH_ENTER, &found);
 	now = GetCurrentTimestamp();
+	entry = hash_search(corpus_stats_cache, &relid, HASH_FIND, NULL);
 
-	if (found &&
+	if (entry != NULL &&
 		!TimestampDifferenceExceeds(entry->read_at, now,
 									pgedge_vectorizer_corpus_stats_cache_ttl
 									* 1000))
@@ -365,15 +365,20 @@ bm25_corpus_stats(const char *chunk_table, float8 *avg_doc_len)
 	}
 
 	/*
-	 * Seed the entry from the caller's default before reading, so that a
-	 * table whose average cannot be determined caches that default rather
-	 * than whatever the previous caller happened to leave behind.
+	 * Read before entering anything.  HASH_ENTER inserts an entry for the
+	 * caller to fill, and this read can throw, leaving one unfilled in
+	 * TopMemoryContext for a later call to read as figures -- dynahash.c warns
+	 * of exactly this.  The local is what sequences it: assigning the return
+	 * straight into the entry would put HASH_ENTER back before the call.
 	 */
-	entry->total_docs = bm25_corpus_stats_uncached(chunk_table, avg_doc_len);
+	total_docs = bm25_corpus_stats_uncached(chunk_table, avg_doc_len);
+
+	entry = hash_search(corpus_stats_cache, &relid, HASH_ENTER, NULL);
+	entry->total_docs = total_docs;
 	entry->avg_doc_len = *avg_doc_len;
 	entry->read_at = now;
 
-	return entry->total_docs;
+	return total_docs;
 }
 
 /*

--- a/src/guc.c
+++ b/src/guc.c
@@ -51,6 +51,7 @@ int pgedge_vectorizer_auto_cleanup_hours = 24;
 bool   pgedge_vectorizer_enable_hybrid = false;
 double pgedge_vectorizer_bm25_k1       = 1.2;
 double pgedge_vectorizer_bm25_b        = 0.75;
+int    pgedge_vectorizer_corpus_stats_cache_ttl = 60;
 
 /*
  * Initialize all GUC variables
@@ -310,6 +311,23 @@ pgedge_vectorizer_init_guc(void)
 		1.0,    /* max */
 		PGC_USERSET,
 		0,
+		NULL, NULL, NULL);
+
+	DefineCustomIntVariable(
+		"pgedge_vectorizer.corpus_stats_cache_ttl",
+		"Seconds a backend may reuse a chunk table's cached corpus figures",
+		"BM25 needs the corpus size and the mean document length, which "
+		"together cost one unindexable scan of the chunk table. Both feed a "
+		"ranking heuristic rather than an account that has to balance, so "
+		"each backend holds them for this long instead of reading them "
+		"again on every search and every queue item. Set to 0 to read them "
+		"afresh every time.",
+		&pgedge_vectorizer_corpus_stats_cache_ttl,
+		60,     /* default */
+		0,      /* min: 0 disables the cache */
+		3600,   /* max */
+		PGC_USERSET,
+		GUC_UNIT_S,
 		NULL, NULL, NULL);
 
 	elog(DEBUG1, "pgedge_vectorizer GUC variables initialized");

--- a/src/pgedge_vectorizer.h
+++ b/src/pgedge_vectorizer.h
@@ -72,6 +72,7 @@ extern int pgedge_vectorizer_auto_cleanup_hours;
 extern bool   pgedge_vectorizer_enable_hybrid;
 extern double pgedge_vectorizer_bm25_k1;
 extern double pgedge_vectorizer_bm25_b;
+extern int    pgedge_vectorizer_corpus_stats_cache_ttl;
 
 /*
  * Chunking strategy enumeration

--- a/test/expected/hybrid_test.out
+++ b/test/expected/hybrid_test.out
@@ -703,7 +703,10 @@ SET search_path = cache_tenant_a, public;
 SELECT pgedge_vectorizer.bm25_query_vector('alpha', 't_chunks') AS tenant_a \gset
 SET search_path = cache_tenant_b, public;
 SELECT pgedge_vectorizer.bm25_query_vector('alpha', 't_chunks') AS tenant_b \gset
-SET search_path = public;
+-- RESET rather than SET, so that whatever the session started with is what
+-- the rest of the file runs under. The comparison below needs no relation
+-- lookup of its own.
+RESET search_path;
 SELECT :'tenant_a'::sparsevec <> :'tenant_b'::sparsevec
     AS same_name_different_schema_not_confused;
  same_name_different_schema_not_confused 

--- a/test/expected/hybrid_test.out
+++ b/test/expected/hybrid_test.out
@@ -620,6 +620,60 @@ NOTICE:  Vectorization disabled and chunk table dropped: hybrid_multi_test_body_
 
 DROP TABLE hybrid_multi_test;
 ---------------------------------------------------------------------------
+-- Test 20: the corpus statistics cache does not change results
+---------------------------------------------------------------------------
+-- N and the mean document length feed a ranking heuristic, and reading them
+-- costs an unindexable scan of the chunk table on every call. Each backend
+-- therefore holds them for corpus_stats_cache_ttl seconds. Whatever the
+-- setting, the vector produced for a given corpus must be the same, so this
+-- compares the two paths directly rather than asserting on either alone.
+CREATE TABLE cache_docs (id BIGSERIAL PRIMARY KEY, body TEXT);
+INSERT INTO cache_docs (body)
+SELECT 'alpha beta gamma document number ' || g FROM generate_series(1, 25) g;
+SELECT pgedge_vectorizer.enable_vectorization(
+    'cache_docs', 'body', embedding_dimension => 3);
+NOTICE:  Using primary key column: id (bigint)
+NOTICE:  column "sparse_embedding" of relation "cache_docs_body_chunks" already exists, skipping
+NOTICE:  Vectorization enabled: cache_docs -> cache_docs_body_chunks
+NOTICE:  Strategy: token_based, chunk_size: 400, overlap: 50
+NOTICE:  Processing existing rows...
+NOTICE:  Processed 25 existing rows
+ enable_vectorization 
+----------------------
+ 
+(1 row)
+
+SET pgedge_vectorizer.corpus_stats_cache_ttl = 0;
+SELECT pgedge_vectorizer.bm25_query_vector('alpha beta', 'cache_docs_body_chunks')
+    AS uncached \gset
+SET pgedge_vectorizer.corpus_stats_cache_ttl = 60;
+SELECT pgedge_vectorizer.bm25_query_vector('alpha beta', 'cache_docs_body_chunks')
+    AS cached \gset
+SELECT :'uncached'::sparsevec = :'cached'::sparsevec AS cache_matches_uncached;
+ cache_matches_uncached 
+------------------------
+ t
+(1 row)
+
+-- A second table must not read the first one's cached figures.
+SELECT pgedge_vectorizer.bm25_avg_doc_len('cache_docs_body_chunks')
+    <> pgedge_vectorizer.bm25_avg_doc_len('hybrid_test_docs_content_chunks')
+    AS each_table_cached_separately;
+ each_table_cached_separately 
+------------------------------
+ t
+(1 row)
+
+RESET pgedge_vectorizer.corpus_stats_cache_ttl;
+SELECT pgedge_vectorizer.disable_vectorization('cache_docs', 'body', true);
+NOTICE:  Vectorization disabled and chunk table dropped: cache_docs_body_chunks
+ disable_vectorization 
+-----------------------
+ 
+(1 row)
+
+DROP TABLE cache_docs;
+---------------------------------------------------------------------------
 -- Cleanup
 ---------------------------------------------------------------------------
 SELECT pgedge_vectorizer.disable_vectorization(

--- a/test/expected/hybrid_test.out
+++ b/test/expected/hybrid_test.out
@@ -674,6 +674,53 @@ NOTICE:  Vectorization disabled and chunk table dropped: cache_docs_body_chunks
 
 DROP TABLE cache_docs;
 ---------------------------------------------------------------------------
+-- Test 21: the corpus statistics cache is keyed by relation, not by name
+---------------------------------------------------------------------------
+-- A chunk table is named unqualified and resolved through search_path, so one
+-- string means different relations in a schema-per-tenant deployment. Keyed by
+-- name, a pooled backend that switched tenants was handed whichever tenant's
+-- corpus it had seen first, and scored the second tenant's queries against the
+-- first one's statistics. The two corpora below differ only in document
+-- length, so the vectors must differ; keyed by name they came back identical.
+CREATE SCHEMA cache_tenant_a;
+CREATE SCHEMA cache_tenant_b;
+CREATE TABLE cache_tenant_a.t_chunks (id BIGSERIAL PRIMARY KEY, content TEXT,
+                                      token_count INT);
+CREATE TABLE cache_tenant_b.t_chunks (id BIGSERIAL PRIMARY KEY, content TEXT,
+                                      token_count INT);
+INSERT INTO cache_tenant_a.t_chunks (content, token_count)
+SELECT 'alpha', 10 FROM generate_series(1, 50);
+INSERT INTO cache_tenant_b.t_chunks (content, token_count)
+SELECT 'alpha', 900 FROM generate_series(1, 50);
+CREATE TABLE cache_tenant_a.t_chunks_idf_stats (term TEXT PRIMARY KEY,
+                                                doc_freq INT NOT NULL);
+CREATE TABLE cache_tenant_b.t_chunks_idf_stats (term TEXT PRIMARY KEY,
+                                                doc_freq INT NOT NULL);
+INSERT INTO cache_tenant_a.t_chunks_idf_stats VALUES ('alpha', 5);
+INSERT INTO cache_tenant_b.t_chunks_idf_stats VALUES ('alpha', 5);
+SET pgedge_vectorizer.corpus_stats_cache_ttl = 60;
+SET search_path = cache_tenant_a, public;
+SELECT pgedge_vectorizer.bm25_query_vector('alpha', 't_chunks') AS tenant_a \gset
+SET search_path = cache_tenant_b, public;
+SELECT pgedge_vectorizer.bm25_query_vector('alpha', 't_chunks') AS tenant_b \gset
+SET search_path = public;
+SELECT :'tenant_a'::sparsevec <> :'tenant_b'::sparsevec
+    AS same_name_different_schema_not_confused;
+ same_name_different_schema_not_confused 
+-----------------------------------------
+ t
+(1 row)
+
+RESET pgedge_vectorizer.corpus_stats_cache_ttl;
+DROP SCHEMA cache_tenant_a CASCADE;
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to table cache_tenant_a.t_chunks
+drop cascades to table cache_tenant_a.t_chunks_idf_stats
+DROP SCHEMA cache_tenant_b CASCADE;
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to table cache_tenant_b.t_chunks
+drop cascades to table cache_tenant_b.t_chunks_idf_stats
+---------------------------------------------------------------------------
 -- Cleanup
 ---------------------------------------------------------------------------
 SELECT pgedge_vectorizer.disable_vectorization(

--- a/test/sql/hybrid_test.sql
+++ b/test/sql/hybrid_test.sql
@@ -510,6 +510,52 @@ SELECT pgedge_vectorizer.disable_vectorization('cache_docs', 'body', true);
 DROP TABLE cache_docs;
 
 ---------------------------------------------------------------------------
+-- Test 21: the corpus statistics cache is keyed by relation, not by name
+---------------------------------------------------------------------------
+
+-- A chunk table is named unqualified and resolved through search_path, so one
+-- string means different relations in a schema-per-tenant deployment. Keyed by
+-- name, a pooled backend that switched tenants was handed whichever tenant's
+-- corpus it had seen first, and scored the second tenant's queries against the
+-- first one's statistics. The two corpora below differ only in document
+-- length, so the vectors must differ; keyed by name they came back identical.
+
+CREATE SCHEMA cache_tenant_a;
+CREATE SCHEMA cache_tenant_b;
+
+CREATE TABLE cache_tenant_a.t_chunks (id BIGSERIAL PRIMARY KEY, content TEXT,
+                                      token_count INT);
+CREATE TABLE cache_tenant_b.t_chunks (id BIGSERIAL PRIMARY KEY, content TEXT,
+                                      token_count INT);
+INSERT INTO cache_tenant_a.t_chunks (content, token_count)
+SELECT 'alpha', 10 FROM generate_series(1, 50);
+INSERT INTO cache_tenant_b.t_chunks (content, token_count)
+SELECT 'alpha', 900 FROM generate_series(1, 50);
+
+CREATE TABLE cache_tenant_a.t_chunks_idf_stats (term TEXT PRIMARY KEY,
+                                                doc_freq INT NOT NULL);
+CREATE TABLE cache_tenant_b.t_chunks_idf_stats (term TEXT PRIMARY KEY,
+                                                doc_freq INT NOT NULL);
+INSERT INTO cache_tenant_a.t_chunks_idf_stats VALUES ('alpha', 5);
+INSERT INTO cache_tenant_b.t_chunks_idf_stats VALUES ('alpha', 5);
+
+SET pgedge_vectorizer.corpus_stats_cache_ttl = 60;
+
+SET search_path = cache_tenant_a, public;
+SELECT pgedge_vectorizer.bm25_query_vector('alpha', 't_chunks') AS tenant_a \gset
+
+SET search_path = cache_tenant_b, public;
+SELECT pgedge_vectorizer.bm25_query_vector('alpha', 't_chunks') AS tenant_b \gset
+
+SET search_path = public;
+SELECT :'tenant_a'::sparsevec <> :'tenant_b'::sparsevec
+    AS same_name_different_schema_not_confused;
+
+RESET pgedge_vectorizer.corpus_stats_cache_ttl;
+DROP SCHEMA cache_tenant_a CASCADE;
+DROP SCHEMA cache_tenant_b CASCADE;
+
+---------------------------------------------------------------------------
 -- Cleanup
 ---------------------------------------------------------------------------
 

--- a/test/sql/hybrid_test.sql
+++ b/test/sql/hybrid_test.sql
@@ -547,7 +547,10 @@ SELECT pgedge_vectorizer.bm25_query_vector('alpha', 't_chunks') AS tenant_a \gse
 SET search_path = cache_tenant_b, public;
 SELECT pgedge_vectorizer.bm25_query_vector('alpha', 't_chunks') AS tenant_b \gset
 
-SET search_path = public;
+-- RESET rather than SET, so that whatever the session started with is what
+-- the rest of the file runs under. The comparison below needs no relation
+-- lookup of its own.
+RESET search_path;
 SELECT :'tenant_a'::sparsevec <> :'tenant_b'::sparsevec
     AS same_name_different_schema_not_confused;
 

--- a/test/sql/hybrid_test.sql
+++ b/test/sql/hybrid_test.sql
@@ -473,6 +473,43 @@ SELECT pgedge_vectorizer.disable_vectorization(
 DROP TABLE hybrid_multi_test;
 
 ---------------------------------------------------------------------------
+-- Test 20: the corpus statistics cache does not change results
+---------------------------------------------------------------------------
+
+-- N and the mean document length feed a ranking heuristic, and reading them
+-- costs an unindexable scan of the chunk table on every call. Each backend
+-- therefore holds them for corpus_stats_cache_ttl seconds. Whatever the
+-- setting, the vector produced for a given corpus must be the same, so this
+-- compares the two paths directly rather than asserting on either alone.
+
+CREATE TABLE cache_docs (id BIGSERIAL PRIMARY KEY, body TEXT);
+INSERT INTO cache_docs (body)
+SELECT 'alpha beta gamma document number ' || g FROM generate_series(1, 25) g;
+
+SELECT pgedge_vectorizer.enable_vectorization(
+    'cache_docs', 'body', embedding_dimension => 3);
+
+SET pgedge_vectorizer.corpus_stats_cache_ttl = 0;
+SELECT pgedge_vectorizer.bm25_query_vector('alpha beta', 'cache_docs_body_chunks')
+    AS uncached \gset
+
+SET pgedge_vectorizer.corpus_stats_cache_ttl = 60;
+SELECT pgedge_vectorizer.bm25_query_vector('alpha beta', 'cache_docs_body_chunks')
+    AS cached \gset
+
+SELECT :'uncached'::sparsevec = :'cached'::sparsevec AS cache_matches_uncached;
+
+-- A second table must not read the first one's cached figures.
+SELECT pgedge_vectorizer.bm25_avg_doc_len('cache_docs_body_chunks')
+    <> pgedge_vectorizer.bm25_avg_doc_len('hybrid_test_docs_content_chunks')
+    AS each_table_cached_separately;
+
+RESET pgedge_vectorizer.corpus_stats_cache_ttl;
+
+SELECT pgedge_vectorizer.disable_vectorization('cache_docs', 'body', true);
+DROP TABLE cache_docs;
+
+---------------------------------------------------------------------------
 -- Cleanup
 ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #53.

## Measured

On a 300,000 chunk table, with the argument varied so nothing is folded away:

| | 1 call | 200 calls |
|---|---|---|
| before (`ttl = 0`) | 34.8 ms | 4834 ms |
| after (default `ttl = 60s`) | 34.8 ms | 38 ms |

Two hundred searches went from 4.8 seconds to one scan plus two hundred lookups. The gap widens with the corpus, because the thing removed is an unindexable aggregate over the whole chunk table.

## Why a cache rather than maintained counters

The issue suggested keeping N and `sum(token_count)` alongside the incrementally maintained `doc_freq`, and I started down that road before deciding against it. Chunk rows are inserted and deleted from **seven** places across the SQL, and they include the delete and truncate paths that have accounted for most of the recent bug history in this extension. Counters that go wrong in one of those paths would skew ranking silently and permanently, with no way for anyone to notice.

These two figures feed a ranking heuristic, not an account that has to balance, and during ingest they are a moving target regardless, since every chunk written moves them. So a cache that expires is the better trade: it cannot drift for longer than its TTL, and it recovers by itself. If exact counters are ever wanted, this does not stand in the way.

A per-backend cache happens to suit both callers. A worker is a long-lived process serving one database, and searches arrive over pooled connections that are also long-lived. A short-lived backend running a single search pays the scan exactly as before, so nothing regresses.

`pgedge_vectorizer.corpus_stats_cache_ttl` defaults to 60 seconds; 0 reads afresh every time and restores the previous behaviour precisely.

## Test plan

- [x] 19 regression tests and all TAP suites green on PostgreSQL 18.4, clean build
- [x] New test 20 in `hybrid_test.sql` compares the two paths directly, asserting the vector produced with `ttl = 0` is identical to the one produced with the cache on, so the optimisation is proven not to change results rather than merely proven fast
- [x] The same test asserts two chunk tables get separate cache entries, which is the obvious way for a keyed cache to go wrong
- [x] Checked out of band that `bm25_avg_doc_len()` still matches SQL's own `AVG(token_count)` exactly

## Two notes on the benchmarking

My first two attempts measured nothing. `SELECT count(f(...)) FROM generate_series(...)` let the planner elide the calls, and then I had `bm25_query_vector`'s arguments the wrong way round, which measured the error path for a non-existent relation. Both showed sub-millisecond times for 200 calls, which is what gave them away: the figures above are from a run where the stub-free single call takes the expected 34 ms and the counts line up.

The wall-clock numbers are single-run on one machine, so treat the ratio as the shape of the result. The mechanism, one scan instead of two hundred, is the exact part.