### PR TITLE
Crash fix: copy the error message out of ErrorContext before taking it

### DIFF
--- a/src/worker.c
+++ b/src/worker.c
@@ -250,11 +250,13 @@ queue_item_note_error(void)
 
 	/*
 	 * CopyErrorData() copies into the current context and asserts it is not
-	 * ErrorContext, which is exactly where a PG_CATCH() body starts: errstart()
-	 * switches there and an error longjmps out without switching back.  Left
-	 * alone this aborts an assert-enabled build outright, and on a release
-	 * build the copy is freed under it by FlushErrorState().  The copy is only
-	 * needed until the message has been taken, so any other context will do.
+	 * ErrorContext, which is exactly where a PG_CATCH() body starts:
+	 * errfinish() switches there and deliberately leaves it set that way when
+	 * it re-throws.  Left alone this aborts an assert-enabled build outright;
+	 * on a release build it instead eats into the space ErrorContext reserves
+	 * so that reporting an error can never itself fail, which is what the
+	 * assertion protects.  The copy is only needed until the message has been
+	 * taken, so any other context will do.
 	 */
 	oldcontext = MemoryContextSwitchTo(TopMemoryContext);
 

--- a/src/worker.c
+++ b/src/worker.c
@@ -242,10 +242,21 @@ queue_item_begin(int64 queue_id, int attempts, int max_attempts)
 static void
 queue_item_note_error(void)
 {
-	ErrorData  *edata;
+	ErrorData	   *edata;
+	MemoryContext	oldcontext;
 
 	if (failed_item_queue_id < 0)
 		return;
+
+	/*
+	 * CopyErrorData() copies into the current context and asserts it is not
+	 * ErrorContext, which is exactly where a PG_CATCH() body starts: errstart()
+	 * switches there and an error longjmps out without switching back.  Left
+	 * alone this aborts an assert-enabled build outright, and on a release
+	 * build the copy is freed under it by FlushErrorState().  The copy is only
+	 * needed until the message has been taken, so any other context will do.
+	 */
+	oldcontext = MemoryContextSwitchTo(TopMemoryContext);
 
 	edata = CopyErrorData();
 
@@ -253,6 +264,8 @@ queue_item_note_error(void)
 		strlcpy(failed_item_error, edata->message, sizeof(failed_item_error));
 
 	FreeErrorData(edata);
+
+	MemoryContextSwitchTo(oldcontext);
 }
 
 /*


### PR DESCRIPTION
queue_item_note_error() called CopyErrorData() from a PG_CATCH() body, which is the one place it may not run: errstart() switches to ErrorContext and an error longjmps out without switching back, so the copy lands in the context FlushErrorState() is about to reset. An assert-enabled build aborts outright on the assertion CopyErrorData() carries for this; a release build frees the copy under itself and gets away with it only because the message is taken first.

Switch away for the duration of the copy. test/t/004 goes from killing the postmaster before its first assertion to passing all seven, and its fifth - that the recorded reason is the error itself - is reached for the first time.