### PR TITLE
Place pg_noreturn before extern so C23 compilers accept it

### DIFF
--- a/src/pgedge_vectorizer.h
+++ b/src/pgedge_vectorizer.h
@@ -34,7 +34,14 @@
 #error "pgedge_vectorizer requires PostgreSQL 14 or later"
 #endif
 
-/* pg_noreturn compatibility for PostgreSQL 18+ */
+/*
+ * pg_noreturn compatibility for PostgreSQL 18+.
+ *
+ * On a C23 compiler (gcc 15 defaults to -std=gnu23) pg_noreturn expands to the
+ * [[noreturn]] attribute, which the standard only allows at the very start of a
+ * declaration. PGEDGE_NORETURN must therefore be written before "extern", not
+ * between the storage class and the return type.
+ */
 #if PG_VERSION_NUM < 180000
 #define PGEDGE_NORETURN
 #define PGEDGE_NORETURN_SUFFIX pg_attribute_noreturn()
@@ -191,8 +198,8 @@ List *parse_markdown_structure(const char *content);
 void free_markdown_elements(List *elements);
 
 /* worker.c */
-extern PGDLLEXPORT PGEDGE_NORETURN void pgedge_vectorizer_launcher_main(Datum main_arg) PGEDGE_NORETURN_SUFFIX;
-extern PGDLLEXPORT PGEDGE_NORETURN void pgedge_vectorizer_worker_main(Datum main_arg) PGEDGE_NORETURN_SUFFIX;
+PGEDGE_NORETURN extern PGDLLEXPORT void pgedge_vectorizer_launcher_main(Datum main_arg) PGEDGE_NORETURN_SUFFIX;
+PGEDGE_NORETURN extern PGDLLEXPORT void pgedge_vectorizer_worker_main(Datum main_arg) PGEDGE_NORETURN_SUFFIX;
 void register_background_workers(void);
 
 /*


### PR DESCRIPTION
## Problem

The `v1.1-beta1` release run failed on one cell — `Package DEB (ubuntu:resolute amd64 pg19)`:

src/pgedge_vectorizer.h:194:36: error: expected identifier or '(' before 'void'
  194 | extern PGDLLEXPORT PGEDGE_NORETURN void pgedge_vectorizer_launcher_main(...)

`PGEDGE_NORETURN` expands to PostgreSQL's `pg_noreturn`, which PG19 defines as the C23
`[[noreturn]]` attribute when `__STDC_VERSION__ >= 202311L`. C23 only permits an attribute
list at the *start* of a declaration, so placing it between the storage class and the return
type is a syntax error. Ubuntu resolute ships gcc 15, which defaults to `-std=gnu23` — the
only image in the matrix that reaches that branch. PG19's own `c.h` notes the requirement:
*"C23 attributes must be placed at the start of a declaration."*

## Fix

Move `PGEDGE_NORETURN` ahead of `extern` on the two worker entry-point declarations, matching
how PostgreSQL's own headers spell it, and document why the order matters.

## Compatibility

No behavior change on any other cell:

- **pg16/17** — no `pg_noreturn`; `PGEDGE_NORETURN` is empty and the suffix
  `pg_attribute_noreturn()` is unchanged.
- **pg18** — `_Noreturn`, a C11 function specifier, valid anywhere in the declaration specifiers.
- **pg19 on gcc ≤14** — also `_Noreturn`; only gcc 15's C23 default produces `[[noreturn]]`.