### PR TITLE
Reject non-regular files when loading the API key file.

### DIFF
--- a/src/provider_common.c
+++ b/src/provider_common.c
@@ -14,6 +14,7 @@
 
 #include <errno.h>
 #include <fcntl.h>
+#include <pwd.h>
 #include <sys/stat.h>
 #include <unistd.h>
 
@@ -100,9 +101,17 @@ provider_expand_tilde(const char *path)
 {
 	if (path[0] == '~' && (path[1] == '/' || path[1] == '\0'))
 	{
-		const char *home = getenv("HOME");  /* nosemgrep */
-		if (home)
-			return psprintf("%s%s", home, path + 1);
+		struct passwd *pw;
+
+		/*
+		 * Not getenv("HOME"): whatever starts the server decides that, and a
+		 * value pointing elsewhere resolves the key path to a file the server
+		 * was never meant to read (CWE-807).  The passwd entry for the user the
+		 * backend actually runs as cannot be set from the environment.
+		 */
+		pw = getpwuid(geteuid());
+		if (pw != NULL && pw->pw_dir[0] != '\0')
+			return psprintf("%s%s", pw->pw_dir, path + 1);
 	}
 	return pstrdup(path);
 }

--- a/src/provider_common.c
+++ b/src/provider_common.c
@@ -12,6 +12,8 @@
  */
 #include "provider_common.h"
 
+#include <errno.h>
+#include <fcntl.h>
 #include <sys/stat.h>
 #include <unistd.h>
 
@@ -113,10 +115,12 @@ provider_expand_tilde(const char *path)
 char *
 provider_load_api_key(const char *filepath, char **error_msg)
 {
-	FILE *fp;
+	int fd;
 	char *expanded_path;
-	StringInfoData key_buf;
-	int c;
+	char buf[MAX_API_KEY_FILE_SIZE + 1];
+	size_t nread = 0;
+	size_t len = 0;
+	size_t i;
 	struct stat st;
 	MemoryContext oldcontext;
 	char *persistent_key;
@@ -129,9 +133,44 @@ provider_load_api_key(const char *filepath, char **error_msg)
 
 	expanded_path = provider_expand_tilde(filepath);
 
-	if (stat(expanded_path, &st) != 0)
+	/*
+	 * Check the open descriptor rather than the path, so the file inspected is
+	 * the file read (CWE-367).
+	 *
+	 * O_NONBLOCK matters: open() on a FIFO waits for a writer, and it waits in
+	 * libc, so CHECK_FOR_INTERRUPTS() is never reached and the backend cannot
+	 * be cancelled.  Non-blocking returns instead, leaving S_ISREG() below to
+	 * reject the path.  Regular files are unaffected by the flag.
+	 *
+	 * No O_NOFOLLOW: secret stores publish credentials through symlinks.
+	 */
+	fd = open(expanded_path, O_RDONLY | O_CLOEXEC | O_NONBLOCK);
+	if (fd < 0)
 	{
-		*error_msg = psprintf("API key file not found: %s", expanded_path);
+		if (errno == ENOENT)
+			*error_msg = psprintf("API key file not found: %s", expanded_path);
+		else
+			*error_msg = psprintf("Failed to open API key file %s: %m",
+								  expanded_path);
+		pfree(expanded_path);
+		return NULL;
+	}
+
+	if (fstat(fd, &st) != 0)
+	{
+		*error_msg = psprintf("Failed to stat API key file %s: %m",
+							  expanded_path);
+		close(fd);
+		pfree(expanded_path);
+		return NULL;
+	}
+
+	/* A FIFO or device would block the read; a directory reads as empty */
+	if (!S_ISREG(st.st_mode))
+	{
+		*error_msg = psprintf("API key path is not a regular file: %s",
+							  expanded_path);
+		close(fd);
 		pfree(expanded_path);
 		return NULL;
 	}
@@ -142,6 +181,7 @@ provider_load_api_key(const char *filepath, char **error_msg)
 		*error_msg = psprintf("API key file %s is too large (%lld bytes; limit %d)",
 							  expanded_path, (long long) st.st_size,
 							  MAX_API_KEY_FILE_SIZE);
+		close(fd);
 		pfree(expanded_path);
 		return NULL;
 	}
@@ -150,37 +190,81 @@ provider_load_api_key(const char *filepath, char **error_msg)
 		elog(WARNING, "API key file %s has permissive permissions (should be 0600)",
 			 expanded_path);
 
-	fp = fopen(expanded_path, "r");
-	if (fp == NULL)
+	/*
+	 * buf holds one byte more than the limit, so a file appended to since the
+	 * fstat() is refused rather than read truncated.
+	 */
+	for (;;)
 	{
-		*error_msg = psprintf("Failed to open API key file: %s", expanded_path);
-		pfree(expanded_path);
-		return NULL;
+		ssize_t n;
+
+		/* flawfinder: ignore - bounded by the space left in buf */
+		n = read(fd, buf + nread, sizeof(buf) - nread);
+		if (n < 0)
+		{
+			if (errno == EINTR)
+				continue;
+			*error_msg = psprintf("Failed to read API key file %s: %m",
+								  expanded_path);
+			close(fd);
+			pfree(expanded_path);
+			explicit_bzero(buf, sizeof(buf));
+			return NULL;
+		}
+
+		if (n == 0)
+			break;
+
+		nread += (size_t) n;
+
+		if (nread == sizeof(buf))
+		{
+			*error_msg = psprintf("API key file %s is too large (limit %d bytes)",
+								  expanded_path, MAX_API_KEY_FILE_SIZE);
+			close(fd);
+			pfree(expanded_path);
+			explicit_bzero(buf, sizeof(buf));
+			return NULL;
+		}
 	}
+
+	close(fd);
+
+	/* A null byte would cut the key short and look like a wrong credential */
+	for (i = 0; i < nread; i++)
+	{
+		char c = buf[i];
+
+		if (c == '\0')
+		{
+			*error_msg = psprintf("API key file %s contains a null byte",
+								  expanded_path);
+			pfree(expanded_path);
+			explicit_bzero(buf, sizeof(buf));
+			return NULL;
+		}
+
+		if (c != '\n' && c != '\r' && c != ' ' && c != '\t')
+			buf[len++] = c;
+	}
+	buf[len] = '\0';
 
 	pfree(expanded_path);
-	initStringInfo(&key_buf);
 
-	/* flawfinder: ignore - fgetc reads into auto-resizing StringInfo */
-	while ((c = fgetc(fp)) != EOF)
-	{
-		if (c != '\n' && c != '\r' && c != ' ' && c != '\t')
-			appendStringInfoChar(&key_buf, c);
-	}
-	fclose(fp);
-
-	if (key_buf.len == 0)
+	if (len == 0)
 	{
 		*error_msg = pstrdup("API key file is empty");
-		pfree(key_buf.data);
+		explicit_bzero(buf, sizeof(buf));
 		return NULL;
 	}
 
 	oldcontext = MemoryContextSwitchTo(TopMemoryContext);
-	persistent_key = pstrdup(key_buf.data);
+	persistent_key = pstrdup(buf);
 	MemoryContextSwitchTo(oldcontext);
 
-	pfree(key_buf.data);
+	/* Keep no copy of the key in the stack frame */
+	explicit_bzero(buf, sizeof(buf));
+
 	return persistent_key;
 }
 

--- a/src/provider_common.c
+++ b/src/provider_common.c
@@ -18,6 +18,7 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
+#include "storage/fd.h"
 #include "utils/memutils.h"
 
 /*
@@ -152,8 +153,13 @@ provider_load_api_key(const char *filepath, char **error_msg)
 	 * reject the path.  Regular files are unaffected by the flag.
 	 *
 	 * No O_NOFOLLOW: secret stores publish credentials through symlinks.
+	 *
+	 * OpenTransientFile() rather than open() so that the descriptor is
+	 * registered with the transaction: the read loop below can now throw, and
+	 * a raw descriptor would be leaked for the life of the backend rather than
+	 * released on abort.
 	 */
-	fd = open(expanded_path, O_RDONLY | O_CLOEXEC | O_NONBLOCK);
+	fd = OpenTransientFile(expanded_path, O_RDONLY | O_CLOEXEC | O_NONBLOCK);
 	if (fd < 0)
 	{
 		if (errno == ENOENT)
@@ -169,7 +175,7 @@ provider_load_api_key(const char *filepath, char **error_msg)
 	{
 		*error_msg = psprintf("Failed to stat API key file %s: %m",
 							  expanded_path);
-		close(fd);
+		CloseTransientFile(fd);
 		pfree(expanded_path);
 		return NULL;
 	}
@@ -179,7 +185,7 @@ provider_load_api_key(const char *filepath, char **error_msg)
 	{
 		*error_msg = psprintf("API key path is not a regular file: %s",
 							  expanded_path);
-		close(fd);
+		CloseTransientFile(fd);
 		pfree(expanded_path);
 		return NULL;
 	}
@@ -190,7 +196,7 @@ provider_load_api_key(const char *filepath, char **error_msg)
 		*error_msg = psprintf("API key file %s is too large (%lld bytes; limit %d)",
 							  expanded_path, (long long) st.st_size,
 							  MAX_API_KEY_FILE_SIZE);
-		close(fd);
+		CloseTransientFile(fd);
 		pfree(expanded_path);
 		return NULL;
 	}
@@ -212,10 +218,19 @@ provider_load_api_key(const char *filepath, char **error_msg)
 		if (n < 0)
 		{
 			if (errno == EINTR)
+			{
+				/*
+				 * A cancellation or statement timeout arriving mid-read
+				 * surfaces here.  Going straight back into read() would defer
+				 * it for as long as the reads keep being interrupted, so act
+				 * on it first; the descriptor is released by the abort.
+				 */
+				CHECK_FOR_INTERRUPTS();
 				continue;
+			}
 			*error_msg = psprintf("Failed to read API key file %s: %m",
 								  expanded_path);
-			close(fd);
+			CloseTransientFile(fd);
 			pfree(expanded_path);
 			explicit_bzero(buf, sizeof(buf));
 			return NULL;
@@ -230,14 +245,14 @@ provider_load_api_key(const char *filepath, char **error_msg)
 		{
 			*error_msg = psprintf("API key file %s is too large (limit %d bytes)",
 								  expanded_path, MAX_API_KEY_FILE_SIZE);
-			close(fd);
+			CloseTransientFile(fd);
 			pfree(expanded_path);
 			explicit_bzero(buf, sizeof(buf));
 			return NULL;
 		}
 	}
 
-	close(fd);
+	CloseTransientFile(fd);
 
 	/* A null byte would cut the key short and look like a wrong credential */
 	for (i = 0; i < nread; i++)

--- a/test/t/008_api_key_file_not_regular.pl
+++ b/test/t/008_api_key_file_not_regular.pl
@@ -1,0 +1,111 @@
+# Copyright (c) 2025 - 2026, pgEdge, Inc.
+#
+# Verify that pgedge_vectorizer.api_key_file refuses a path that is not a plain
+# file instead of waiting on it.
+#
+# provider_load_api_key() used to stat() the path and then fopen() it. stat()
+# opens nothing, so a FIFO passed every check made of it and the fopen() waited
+# for a writer. That wait happens in libc, so CHECK_FOR_INTERRUPTS() is never
+# reached: the backend showed as active with no wait event and ignored both
+# statement_timeout and query cancellation. /dev/zero failed differently, never
+# reaching end of file, so the read loop grew until the 1GB allocation limit.
+#
+# Each case runs under a timeout, so an unfixed build fails an assertion rather
+# than hanging the suite. The regular-file cases are refused for their contents
+# after the read, which is what shows ordinary files are still opened; none of
+# them reaches the network.
+
+use strict;
+use warnings;
+
+use POSIX qw(mkfifo);
+
+# See the comment in 001_worker_coverage.pl about loading these at compile time.
+use PostgreSQL::Test::Cluster;
+use PostgreSQL::Test::Utils;
+use Test::More;
+
+my $dbname = 'api_key_file';
+
+my $node = PostgreSQL::Test::Cluster->new('vectorizer_api_key_file');
+$node->init;
+$node->append_conf(
+	'postgresql.conf', qq(
+shared_preload_libraries = 'pgedge_vectorizer'
+pgedge_vectorizer.provider = 'openai'
+));
+
+$node->start;
+
+$node->safe_psql('postgres', "CREATE DATABASE $dbname");
+$node->safe_psql($dbname, 'CREATE EXTENSION vector');
+$node->safe_psql($dbname, 'CREATE EXTENSION pgedge_vectorizer');
+
+my $keydir = PostgreSQL::Test::Utils::tempdir;
+
+# 0600 keeps the permissive-permissions warning out of stderr; it is not what is
+# under test here.
+sub write_key_file
+{
+	my ($name, $contents) = @_;
+	my $path = "$keydir/$name";
+
+	open my $fh, '>:raw', $path or die "could not create $path: $!";
+	print $fh $contents;
+	close $fh;
+	chmod 0600, $path or die "could not chmod $path: $!";
+
+	return $path;
+}
+
+# Ask for one embedding with api_key_file set to $path, under a timeout. The
+# provider is never reached; every case is refused while the key is loaded.
+sub check_key_file
+{
+	my ($label, $path, $expected) = @_;
+	my ($stdout, $stderr, $timed_out);
+
+	$node->psql(
+		$dbname,
+		"SET pgedge_vectorizer.provider = 'openai';\n"
+		  . "SET pgedge_vectorizer.api_key_file = '$path';\n"
+		  . "SELECT pgedge_vectorizer.generate_embedding('test');",
+		stdout => \$stdout,
+		stderr => \$stderr,
+		timeout => $PostgreSQL::Test::Utils::timeout_default,
+		timed_out => \$timed_out);
+
+	ok(!$timed_out, "$label: answered rather than waited");
+	like($stderr, $expected, "$label: reported the reason");
+
+	return;
+}
+
+# The reported failure.
+my $fifo = "$keydir/fifo-key";
+mkfifo($fifo, 0600) or die "could not create $fifo: $!";
+check_key_file('FIFO', $fifo, qr/is not a regular file/);
+
+# Used to be read as zero bytes and reported as an empty key.
+check_key_file('directory', $keydir, qr/is not a regular file/);
+
+# Endless input rather than none: used to grow the buffer until the allocator
+# refused it.
+check_key_file('character device', '/dev/zero', qr/is not a regular file/);
+
+# Regular files from here down: these pass S_ISREG() and are refused later.
+check_key_file('empty file', write_key_file('empty-key', ''),
+	qr/API key file is empty/);
+
+check_key_file('whitespace only', write_key_file('blank-key', " \t\r\n\n"),
+	qr/API key file is empty/);
+
+# One byte past MAX_API_KEY_FILE_SIZE.
+check_key_file('oversized file', write_key_file('big-key', 'x' x 4097),
+	qr/is too large \(4097 bytes; limit 4096\)/);
+
+# A null byte would cut the key short and look like a wrong credential.
+check_key_file('embedded null', write_key_file('nul-key', "sk-\0secret\n"),
+	qr/contains a null byte/);
+
+done_testing();

--- a/test/t/009_api_key_file_tilde_home.pl
+++ b/test/t/009_api_key_file_tilde_home.pl
@@ -1,0 +1,119 @@
+# Copyright (c) 2025 - 2026, pgEdge, Inc.
+#
+# Verify that `~` in pgedge_vectorizer.api_key_file expands to the home
+# directory of the OS user the backend runs as, and not to whatever HOME says.
+#
+# provider_expand_tilde() used to expand `~` with getenv("HOME"). HOME is set by
+# whatever starts the server -- a systemd unit, a container entrypoint, a shell
+# -- so a value pointing somewhere else silently redirected the key path to a
+# file the server was never meant to read, and the key found there was sent to
+# the provider (CWE-807). getpwuid(geteuid()) answers from the passwd database
+# instead, which the environment cannot influence.
+#
+# The cluster is started with HOME pointing at a directory holding a key file,
+# and the test asks for `~/<that file>`. A fixed build resolves past it to the
+# real home directory and reports the key file missing there; an unfixed build
+# finds the planted key and gets as far as the network.
+
+use strict;
+use warnings;
+
+# See the comment in 001_worker_coverage.pl about loading these at compile time.
+use File::Spec;
+
+use PostgreSQL::Test::Cluster;
+use PostgreSQL::Test::Utils;
+use Test::More;
+
+my $dbname = 'api_key_tilde';
+
+# The home directory the fix must resolve to, straight from the passwd entry --
+# the same source provider_expand_tilde() now reads.
+my $real_home = (getpwuid($>))[7];
+plan skip_all => 'no passwd home directory for the current user'
+  unless defined $real_home && $real_home ne '';
+
+# The planted home directory, and a key file name unlikely to exist in the real
+# one -- the test turns on the real home NOT having it.
+#
+# rel2abs matters: tempdir is relative unless TESTDATADIR is absolute, and the
+# backend resolves a relative path against its data directory rather than the
+# directory prove was run from. A relative HOME would fail to find the planted
+# key for that reason instead of because of the fix, which would let an unfixed
+# build look like it had passed.
+my $fake_home = File::Spec->rel2abs(PostgreSQL::Test::Utils::tempdir);
+my $key_name = '.pgedge-vectorizer-tilde-home-test-key';
+
+plan skip_all => "$real_home/$key_name exists; cannot test the missing case"
+  if -e "$real_home/$key_name";
+
+open my $fh, '>:raw', "$fake_home/$key_name"
+  or die "could not create $fake_home/$key_name: $!";
+print $fh "sk-planted-key-must-not-be-read\n";
+close $fh;
+chmod 0600, "$fake_home/$key_name"
+  or die "could not chmod $fake_home/$key_name: $!";
+
+my $node = PostgreSQL::Test::Cluster->new('vectorizer_api_key_tilde');
+$node->init;
+$node->append_conf(
+	'postgresql.conf', qq(
+shared_preload_libraries = 'pgedge_vectorizer'
+pgedge_vectorizer.provider = 'openai'
+));
+
+# The postmaster inherits HOME here and backends fork from it, so this is what
+# the unfixed getenv("HOME") would have read.
+{
+	local $ENV{HOME} = $fake_home;
+	$node->start;
+}
+
+$node->safe_psql('postgres', "CREATE DATABASE $dbname");
+$node->safe_psql($dbname, 'CREATE EXTENSION vector');
+$node->safe_psql($dbname, 'CREATE EXTENSION pgedge_vectorizer');
+
+# Control: confirm the planted HOME really did reach the backend. Without this
+# the main assertion below would also pass on an unfixed build that simply never
+# saw the variable. COPY FROM PROGRAM runs with the backend's environment.
+my $backend_home = $node->safe_psql(
+	$dbname, q(
+CREATE TEMP TABLE env_probe(v text);
+COPY env_probe FROM PROGRAM 'printf "%s" "$HOME"';
+SELECT v FROM env_probe;
+));
+is($backend_home, $fake_home, 'the planted HOME reached the backend');
+
+# The actual test: `~` must ignore that HOME.
+my ($stdout, $stderr, $timed_out);
+$node->psql(
+	$dbname,
+	"SET pgedge_vectorizer.provider = 'openai';\n"
+	  . "SET pgedge_vectorizer.api_key_file = '~/$key_name';\n"
+	  . "SELECT pgedge_vectorizer.generate_embedding('test');",
+	stdout => \$stdout,
+	stderr => \$stderr,
+	timeout => $PostgreSQL::Test::Utils::timeout_default,
+	timed_out => \$timed_out);
+
+ok(!$timed_out, 'tilde expansion answered rather than waited');
+
+# Resolved through the passwd entry: the key file is absent there, and the
+# reported path names the real home rather than the planted one.
+like(
+	$stderr,
+	qr/API key file not found: \Q$real_home\E\/\Q$key_name\E/,
+	'`~` expanded to the passwd home directory');
+
+# Secondary guard: the planted directory must not appear in the message either.
+unlike($stderr, qr/\Q$fake_home\E/,
+	'`~` did not expand to the directory HOME named');
+
+# The independent check, and the one that speaks to the consequence: reaching
+# the provider at all means a key was found and sent. An unfixed build gets an
+# authentication failure back from the planted key here, which is how the
+# original report surfaced; a fixed build never leaves the key-loading step.
+unlike($stderr, qr/API returned HTTP|Incorrect API key/,
+	'the planted key was never sent to the provider');
+
+done_testing();


### PR DESCRIPTION
A leading ~ was expanded with getenv("HOME"), which whatever starts the server decides, so a value pointing elsewhere read a key file the server was never meant to open and sent it to the provider.  getpwuid(geteuid()) answers from the passwd database instead.

read() returning EINTR was retried without CHECK_FOR_INTERRUPTS(), so a cancellation was deferred for as long as the reads kept being interrupted.  The descriptor comes from OpenTransientFile() now, so that it is released on abort.

Both the file type check and the getpwuid() change were claimed in the changelog under 1.1-beta1 without having shipped.

New TAP tests: 008 for the file types (FIFO, directory, character device, empty, whitespace only, oversized, embedded null), 009 for ~ expansion with HOME planted elsewhere.

Fixes #66
Fixes #67