### PR TITLE
Add vectorizer_status for embedding coverage and backlog

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ DATA = sql/$(EXTENSION)--$(EXTVERSION).sql \
        sql/$(EXTENSION)--1.0-beta3--1.0.sql
 
 # Test configuration for pg_regress
-REGRESS = setup chunking multibyte_chunking hybrid_chunking queue delete_truncate delete_truncate_pk pk_type_session max_retries vectorization multi_column maintenance edge_cases providers worker cleanup embedding pk_types stale_embeddings hybrid_test count_tokens
+REGRESS = setup chunking multibyte_chunking hybrid_chunking queue delete_truncate delete_truncate_pk pk_type_session max_retries vectorization multi_column maintenance edge_cases providers worker cleanup embedding pk_types stale_embeddings hybrid_test count_tokens vectorizer_status
 REGRESS_OPTS = --inputdir=test --outputdir=test
 
 # Documentation files (if any)

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # Supports PostgreSQL 14-17
 
 EXTENSION = pgedge_vectorizer
-EXTVERSION = 1.1
+EXTVERSION = 1.2
 
 # Extension module and data files
 MODULE_big = $(EXTENSION)
@@ -24,7 +24,9 @@ OBJS = src/pgedge_vectorizer.o \
 
 DATA = sql/$(EXTENSION)--$(EXTVERSION).sql \
        sql/$(EXTENSION)--1.0.sql \
+       sql/$(EXTENSION)--1.1.sql \
        sql/$(EXTENSION)--1.0--1.1.sql \
+       sql/$(EXTENSION)--1.1--1.2.sql \
        sql/$(EXTENSION)--1.0-beta2.sql \
        sql/$(EXTENSION)--1.0-beta3.sql \
        sql/$(EXTENSION)--1.0-beta1--1.0-beta2.sql \
@@ -32,7 +34,7 @@ DATA = sql/$(EXTENSION)--$(EXTVERSION).sql \
        sql/$(EXTENSION)--1.0-beta3--1.0.sql
 
 # Test configuration for pg_regress
-REGRESS = setup chunking multibyte_chunking hybrid_chunking queue delete_truncate delete_truncate_pk pk_type_session max_retries vectorization multi_column maintenance edge_cases providers worker cleanup embedding pk_types stale_embeddings hybrid_test
+REGRESS = setup chunking multibyte_chunking hybrid_chunking queue delete_truncate delete_truncate_pk pk_type_session max_retries vectorization multi_column maintenance edge_cases providers worker cleanup embedding pk_types stale_embeddings hybrid_test count_tokens
 REGRESS_OPTS = --inputdir=test --outputdir=test
 
 # Documentation files (if any)

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -391,3 +391,49 @@ Count of pending items.
 ```sql
 SELECT * FROM pgedge_vectorizer.pending_count;
 ```
+
+### vectorizer_status
+
+Embedding coverage and queue backlog for every registered vectorizer, one row
+per source table and column. See
+[Check Embedding Coverage](monitoring.md#check-embedding-coverage) for how to
+read the numbers.
+
+```sql
+SELECT * FROM pgedge_vectorizer.vectorizer_status;
+```
+
+Columns:
+
+- `source_table`, `source_column`, `chunk_table`: The vectorizer, as registered
+- `source_rows`: Rows in the source table
+- `source_rows_covered`: Source rows with at least one embedded chunk
+- `source_coverage`: `source_rows_covered / source_rows`, to four decimal
+  places, or `NULL` for an empty source table. A value above 1 means the chunk
+  table holds rows for source rows that no longer exist
+- `chunks_total`, `chunks_embedded`: Rows in the chunk table, and how many have
+  a non-NULL `embedding`
+- `chunk_coverage`: `chunks_embedded / chunks_total`, to four decimal places,
+  or `NULL` for an empty chunk table
+- `queue_pending`, `queue_processing`, `queue_failed`: Queue items for this
+  chunk table in each state
+- `oldest_pending_age`: How long the oldest pending item has been waiting, or
+  `NULL` if nothing is pending
+- `last_processed_at`: When an item was most recently completed. Only queue
+  rows that still exist are considered, so `clear_completed()` moves this
+  backwards
+
+The counts scan the chunk table and the source table, so this costs
+considerably more than the queue views above. If the chunk or source table has
+been dropped, or the caller cannot read it, the corresponding columns are
+`NULL` rather than the query failing.
+
+The function form of the same name narrows the result to one source table, and
+optionally to one column of it:
+
+```sql
+SELECT * FROM pgedge_vectorizer.vectorizer_status(
+    source_table  REGCLASS DEFAULT NULL,
+    source_column NAME DEFAULT NULL
+);
+```

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -328,6 +328,25 @@ SELECT pgedge_vectorizer.bm25_tokenize(query TEXT);
 
 Returns: `TEXT[]` -- Array of distinct non-stopword terms.
 
+### count_tokens()
+
+Approximate the number of tokens in a piece of text. This is the same estimate
+the chunking engine uses when it decides where a chunk ends, and it is what
+gets stored in the `token_count` column of a chunk table, so it is useful for
+working out why a given piece of text chunked the way it did.
+
+```sql
+SELECT pgedge_vectorizer.count_tokens(content TEXT);
+```
+
+Returns: `INT` -- The estimated token count, or `NULL` for `NULL` input.
+
+The estimate counts UTF-8 characters and divides by four, rounding up, which
+is a reasonable rule of thumb for English prose but no more than that: text
+that tokenises unusually, such as code, dense punctuation or languages other
+than English, will be some way out. Do not use it where an exact count
+matters, such as checking a payload against a provider's hard token limit.
+
 ### show_config()
 
 Display all pgedge_vectorizer configuration settings.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- The `token_count` recorded for each chunk is now computed the same way
+  everywhere. The chunking code in C rounds its four-characters-per-token
+  estimate up, whilst the plpgsql paths that actually write the column
+  open-coded the same estimate as `length(chunk_text) / 4`, which truncates,
+  so the two disagreed by a token on most chunks. Because `token_count` feeds
+  the BM25 document-length normalisation, hybrid search scored chunks written
+  by the trigger slightly differently from chunks written by the C chunker.
+  Both now call the new `count_tokens()` function, so there is one definition
+  of the rule.
+
+### Added
+
+- `pgedge_vectorizer.count_tokens(text)`, which exposes the chunking engine's
+  token estimate so you can see why a piece of text chunked the way it did.
+
 ## [1.1] - 2026-08-28
 
 ### Changed

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -22,6 +22,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - `pgedge_vectorizer.count_tokens(text)`, which exposes the chunking engine's
   token estimate so you can see why a piece of text chunked the way it did.
+- `pgedge_vectorizer.vectorizer_status`, a view reporting embedding coverage
+  and queue backlog for each registered vectorizer, so you can tell how far
+  behind the embeddings are before trusting a search over them, and spot a
+  worker that has stalled ([#25](https://github.com/pgEdge/pgedge-vectorizer/issues/25)).
+  A function of the same name narrows the result to a single source table or
+  column. The counts scan the chunk and source tables, so this is a diagnostic
+  to run deliberately rather than something to poll.
 
 ## [1.1] - 2026-08-28
 

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -33,3 +33,47 @@ SELECT * FROM pgedge_vectorizer.pending_count;
 -- Failed items with errors
 SELECT * FROM pgedge_vectorizer.failed_items;
 ```
+
+## Check Embedding Coverage
+
+Embeddings are generated asynchronously, so there is always some lag between a change to a source table and the embedding catching up with it. The `vectorizer_status` view reports, for every registered vectorizer, how much of the source is embedded and how much work is still outstanding, which is what you need in order to judge whether a search result set reflects recent changes:
+
+```sql
+SELECT * FROM pgedge_vectorizer.vectorizer_status;
+```
+
+```
+source_table        | articles
+source_column       | body
+chunk_table         | articles_body_chunks
+source_rows         | 2110
+source_rows_covered | 2098
+source_coverage     | 0.9943
+chunks_total        | 12043
+chunks_embedded     | 11890
+chunk_coverage      | 0.9873
+queue_pending       | 153
+queue_processing    | 2
+queue_failed        | 0
+oldest_pending_age  | 00:04:12.882
+last_processed_at   | 2026-09-09 11:58:07.114+01
+```
+
+Coverage is reported two ways because they answer different questions. `source_coverage` is the fraction of source rows with at least one embedded chunk, which is the closer match to "can I trust a search over this table"; `chunk_coverage` is the fraction of individual chunks embedded, which is the better measure of how much work is left to do. A large document part-way through being embedded counts as covered on the first measure and only partly on the second.
+
+Alongside those, `queue_pending`, `queue_processing` and `queue_failed` are the backlog for this vectorizer, `oldest_pending_age` is how long the oldest unprocessed item has been waiting, and `last_processed_at` is when an item was most recently completed. A backlog that is not shrinking and an `oldest_pending_age` that keeps growing point at a worker that is not running, or at a provider that is rejecting requests; `queue_failed` above zero is worth following up in `failed_items`.
+
+To look at a single vectorizer rather than all of them, call the function form, optionally naming the column as well:
+
+```sql
+SELECT * FROM pgedge_vectorizer.vectorizer_status('articles'::regclass);
+SELECT * FROM pgedge_vectorizer.vectorizer_status('articles'::regclass, 'body');
+```
+
+Three things are worth knowing before you put this anywhere automated.
+
+It is not cheap. Each row counts the chunk table and the source table, so unlike the queue views above, which read only an indexed queue table, this scans your data. Treat it as a diagnostic you run when you want an answer, rather than something a dashboard polls every few seconds, and use the function form to scope it to one table where you can.
+
+`last_processed_at` reflects only queue rows that still exist, so running `clear_completed()` will move it backwards or set it to NULL. It says when the queue last completed something it still remembers, not when the embeddings were last touched.
+
+A `source_coverage` above 1 means the chunk table holds rows for source rows that no longer exist. That is left visible rather than clamped, because it is a real problem worth seeing: it usually means chunks were orphaned by a bulk operation that bypassed the triggers.

--- a/pgedge_vectorizer.control
+++ b/pgedge_vectorizer.control
@@ -1,6 +1,6 @@
 # pgedge_vectorizer extension
 comment = 'Asynchronous text chunking and vectorization for PostgreSQL'
-default_version = '1.1'
+default_version = '1.2'
 module_pathname = '$libdir/pgedge_vectorizer'
 relocatable = false
 requires = 'vector'

--- a/sql/pgedge_vectorizer--1.1--1.2.sql
+++ b/sql/pgedge_vectorizer--1.1--1.2.sql
@@ -620,3 +620,140 @@ $$ LANGUAGE plpgsql;
 
 COMMENT ON FUNCTION pgedge_vectorizer.recreate_chunks IS
 'Delete all chunks and recreate from source table (complete rebuild)';
+
+---------------------------------------------------------------------------
+-- Vectorizer status: how far behind the embeddings are
+--
+-- Embeddings are derived data generated asynchronously, so there is always
+-- some lag between a source change and the embedding catching up. This
+-- reports, per vectorizer, how much of the source is embedded and how much
+-- work is outstanding, so that a user can tell whether a search result set
+-- reflects recent changes and an operator can spot a stalled worker.
+--
+-- The chunk tables are named in the registry rather than joined statically,
+-- so the counts have to be gathered with dynamic SQL rather than expressed
+-- as a plain view. Each row costs a scan of one chunk table and a count of
+-- one source table, which is considerably more than the queue views cost;
+-- it is a diagnostic to run when you want an answer, not something to put
+-- on a dashboard refreshing every second.
+---------------------------------------------------------------------------
+
+CREATE FUNCTION pgedge_vectorizer.vectorizer_status(
+    p_source_table  REGCLASS DEFAULT NULL,
+    p_source_column NAME DEFAULT NULL
+) RETURNS TABLE (
+    source_table        TEXT,
+    source_column       NAME,
+    chunk_table         TEXT,
+    source_rows         BIGINT,
+    source_rows_covered BIGINT,
+    source_coverage     NUMERIC,
+    chunks_total        BIGINT,
+    chunks_embedded     BIGINT,
+    chunk_coverage      NUMERIC,
+    queue_pending       BIGINT,
+    queue_processing    BIGINT,
+    queue_failed        BIGINT,
+    oldest_pending_age  INTERVAL,
+    last_processed_at   TIMESTAMPTZ
+) AS $$
+DECLARE
+    v            RECORD;
+    src_oid      OID;
+    chunk_oid    OID;
+BEGIN
+    FOR v IN
+        SELECT r.source_table, r.source_column, r.chunk_table
+          FROM pgedge_vectorizer.vectorizers r
+         WHERE (p_source_table IS NULL
+                OR to_regclass(r.source_table) = p_source_table)
+           AND (p_source_column IS NULL OR r.source_column = p_source_column)
+         ORDER BY r.source_table, r.source_column
+    LOOP
+        source_table  := v.source_table;
+        source_column := v.source_column;
+        chunk_table   := v.chunk_table;
+
+        source_rows         := NULL;
+        source_rows_covered := NULL;
+        source_coverage     := NULL;
+        chunks_total        := NULL;
+        chunks_embedded     := NULL;
+        chunk_coverage      := NULL;
+
+        /*
+         * Queue figures first: they come from a table the caller can always
+         * read, and they are the half that stays meaningful even when the
+         * chunk or source table has been dropped from under the registry.
+         *
+         * last_processed_at only reflects queue rows that still exist, so
+         * clear_completed() will move it backwards. That is a property of
+         * the queue, not of the embeddings, and is documented as such.
+         */
+        SELECT count(*) FILTER (WHERE q.status = 'pending'),
+               count(*) FILTER (WHERE q.status = 'processing'),
+               count(*) FILTER (WHERE q.status = 'failed'),
+               NOW() - min(q.created_at) FILTER (WHERE q.status = 'pending'),
+               max(q.processed_at)
+          INTO queue_pending, queue_processing, queue_failed,
+               oldest_pending_age, last_processed_at
+          FROM pgedge_vectorizer.queue q
+         WHERE q.chunk_table = v.chunk_table;
+
+        /*
+         * The counts below read user tables, and the function runs as the
+         * caller. A table that has been dropped, or that the caller cannot
+         * read, leaves the corresponding columns NULL rather than failing
+         * the whole result set: one inaccessible vectorizer should not make
+         * the view useless for every other one.
+         */
+        chunk_oid := to_regclass(v.chunk_table);
+        IF chunk_oid IS NOT NULL
+           AND has_table_privilege(chunk_oid, 'SELECT') THEN
+            EXECUTE format(
+                'SELECT count(*),
+                        count(*) FILTER (WHERE embedding IS NOT NULL),
+                        count(DISTINCT source_id)
+                            FILTER (WHERE embedding IS NOT NULL)
+                   FROM %s', chunk_oid::REGCLASS)
+              INTO chunks_total, chunks_embedded, source_rows_covered;
+
+            IF chunks_total > 0 THEN
+                chunk_coverage := round(chunks_embedded::NUMERIC
+                                        / chunks_total, 4);
+            END IF;
+        END IF;
+
+        src_oid := to_regclass(v.source_table);
+        IF src_oid IS NOT NULL
+           AND has_table_privilege(src_oid, 'SELECT') THEN
+            EXECUTE format('SELECT count(*) FROM %s', src_oid::REGCLASS)
+              INTO source_rows;
+
+            /*
+             * A coverage above 1 means the chunk table holds rows for source
+             * rows that are gone, which is worth seeing rather than hiding
+             * behind a clamp to 1.
+             */
+            IF source_rows > 0 AND source_rows_covered IS NOT NULL THEN
+                source_coverage := round(source_rows_covered::NUMERIC
+                                         / source_rows, 4);
+            END IF;
+        END IF;
+
+        RETURN NEXT;
+    END LOOP;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION pgedge_vectorizer.vectorizer_status IS
+'Embedding coverage and queue backlog for the registered vectorizers, '
+'optionally narrowed to one source table or one source column. Scans the '
+'chunk and source tables, so it costs considerably more than the queue views';
+
+CREATE VIEW pgedge_vectorizer.vectorizer_status AS
+SELECT * FROM pgedge_vectorizer.vectorizer_status(NULL, NULL);
+
+COMMENT ON VIEW pgedge_vectorizer.vectorizer_status IS
+'Embedding coverage and queue backlog for every registered vectorizer';
+

--- a/sql/pgedge_vectorizer--1.1--1.2.sql
+++ b/sql/pgedge_vectorizer--1.1--1.2.sql
@@ -1,0 +1,622 @@
+-- pgedge_vectorizer extension
+-- Version 1.2
+--
+-- Asynchronous text chunking and vectorization for PostgreSQL
+
+-- complain if script is sourced in psql, rather than via CREATE EXTENSION
+\echo Use "ALTER EXTENSION pgedge_vectorizer UPDATE TO '1.2'" to load this file. \quit
+
+---------------------------------------------------------------------------
+-- Approximate token counter, shared with the C chunking code
+--
+-- The chunking engine in C has always sized chunks with this estimate, but
+-- the plpgsql paths that write the token_count column open-coded it as
+-- length(chunk_text) / 4, which truncates where the C code rounds up. The two
+-- therefore disagreed by a token on most chunks, and since token_count feeds
+-- the BM25 document-length normalisation, hybrid search scored chunks written
+-- by the trigger slightly differently from those written by the C chunker.
+-- Exposing the C function and calling it from plpgsql leaves one definition
+-- of the rule.
+---------------------------------------------------------------------------
+
+CREATE FUNCTION pgedge_vectorizer.count_tokens(
+    content TEXT
+) RETURNS INT
+AS 'MODULE_PATHNAME', 'pgedge_vectorizer_count_tokens'
+LANGUAGE C STABLE STRICT;
+
+COMMENT ON FUNCTION pgedge_vectorizer.count_tokens IS
+'Approximate the token count of the given text (UTF-8 characters divided by '
+'four, rounded up). This is the same estimate the chunking engine uses, and '
+'is what gets stored in the token_count column of a chunk table';
+
+---------------------------------------------------------------------------
+-- Redefine the three functions that wrote token_count themselves, so that
+-- they call count_tokens() instead. Existing rows keep whatever count they
+-- were written with; the values are an approximation either way, and a
+-- rewrite of every chunk table is not worth a one-token correction.
+---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION pgedge_vectorizer.enable_vectorization(
+    source_table REGCLASS,
+    source_column NAME,
+    chunk_strategy TEXT DEFAULT NULL,
+    chunk_size INT DEFAULT NULL,
+    chunk_overlap INT DEFAULT NULL,
+    embedding_dimension INT DEFAULT NULL,
+    chunk_table_name TEXT DEFAULT NULL,
+    source_pk NAME DEFAULT NULL
+) RETURNS VOID AS $$
+DECLARE
+    chunk_table TEXT;
+    trigger_name TEXT;
+    actual_strategy TEXT;
+    actual_chunk_size INT;
+    actual_chunk_overlap INT;
+    pk_col_type TEXT;
+    pk_count INT;
+BEGIN
+    -- Use defaults from GUC if not provided
+    actual_strategy := COALESCE(chunk_strategy,
+        current_setting('pgedge_vectorizer.default_chunk_strategy'));
+    actual_chunk_size := COALESCE(chunk_size,
+        current_setting('pgedge_vectorizer.default_chunk_size')::INT);
+    actual_chunk_overlap := COALESCE(chunk_overlap,
+        current_setting('pgedge_vectorizer.default_chunk_overlap')::INT);
+
+    -- Auto-detect embedding dimension from configured model if not specified
+    IF embedding_dimension IS NULL THEN
+        embedding_dimension := pgedge_vectorizer.detect_embedding_dimension();
+        RAISE NOTICE 'Auto-detected embedding dimension: %', embedding_dimension;
+    END IF;
+
+    -- Detect PK column count to reject composite PKs
+    SELECT count(*)
+    INTO pk_count
+    FROM pg_index i
+    JOIN pg_attribute a ON a.attrelid = i.indrelid
+      AND a.attnum = ANY(i.indkey)
+    WHERE i.indrelid = source_table
+      AND i.indisprimary;
+
+    IF pk_count = 0 AND source_pk IS NULL THEN
+        RAISE EXCEPTION 'Table % has no primary key. Use the source_pk parameter to specify the column to use as document identifier.',
+            source_table;
+    END IF;
+
+    IF pk_count > 1 AND source_pk IS NULL THEN
+        RAISE EXCEPTION 'Table % has a composite primary key (% columns), which is not supported by auto-detection. Use the source_pk parameter to specify a single column.',
+            source_table, pk_count;
+    END IF;
+
+    -- Auto-detect PK column name and type if source_pk not specified
+    IF source_pk IS NULL THEN
+        SELECT a.attname, format_type(a.atttypid, a.atttypmod)
+        INTO source_pk, pk_col_type
+        FROM pg_index i
+        JOIN pg_attribute a ON a.attrelid = i.indrelid
+          AND a.attnum = ANY(i.indkey)
+        WHERE i.indrelid = source_table
+          AND i.indisprimary;
+    ELSE
+        -- User specified a column; look up its type
+        SELECT format_type(a.atttypid, a.atttypmod)
+        INTO pk_col_type
+        FROM pg_attribute a
+        WHERE a.attrelid = source_table
+          AND a.attname = source_pk
+          AND NOT a.attisdropped;
+
+        IF pk_col_type IS NULL THEN
+            RAISE EXCEPTION 'Column "%" does not exist on table %',
+                source_pk, source_table;
+        END IF;
+    END IF;
+
+    RAISE NOTICE 'Using primary key column: % (%)', source_pk, pk_col_type;
+
+    -- Determine chunk table name.
+    -- Include source schema in the generated identifier text to avoid
+    -- collisions when two schemas have the same relname.
+    chunk_table := COALESCE(chunk_table_name,
+                            source_table::TEXT || '_' || source_column || '_chunks');
+
+    -- Create chunks table
+    -- Note: pk_col_type uses %s (not %I) because format_type() returns
+    -- canonical SQL type names (e.g. "character varying(26)") that would
+    -- be incorrectly double-quoted by %I. This value is system-controlled.
+    EXECUTE format('
+        CREATE TABLE IF NOT EXISTS %I (
+            id BIGSERIAL PRIMARY KEY,
+            source_id %s NOT NULL,
+            chunk_index INT NOT NULL,
+            content TEXT NOT NULL,
+            token_count INT,
+            embedding vector(%s),
+            sparse_embedding sparsevec(65536),
+            created_at TIMESTAMPTZ DEFAULT NOW(),
+            updated_at TIMESTAMPTZ DEFAULT NOW(),
+            UNIQUE(source_id, chunk_index)
+        )', chunk_table, pk_col_type, embedding_dimension);
+
+    -- Add sparse columns to pre-existing chunk tables (upgrade path).
+    -- These are no-ops for freshly created tables (columns exist already).
+    EXECUTE format('
+        ALTER TABLE %I
+        ADD COLUMN IF NOT EXISTS sparse_embedding sparsevec(65536)',
+        chunk_table);
+
+    -- Create vector index for similarity search
+    EXECUTE format('
+        CREATE INDEX IF NOT EXISTS %I ON %I
+        USING hnsw (embedding vector_cosine_ops)',
+        chunk_table || '_embedding_idx', chunk_table);
+
+    -- Create index on source_id for joins
+    EXECUTE format('
+        CREATE INDEX IF NOT EXISTS %I ON %I (source_id)',
+        chunk_table || '_source_id_idx', chunk_table);
+
+    -- Create HNSW index on sparse_embedding for fast sparse search
+    EXECUTE format('
+        CREATE INDEX IF NOT EXISTS %I ON %I
+        USING hnsw (sparse_embedding sparsevec_ip_ops)
+        WHERE sparse_embedding IS NOT NULL',
+        chunk_table || '_sparse_idx', chunk_table);
+
+    -- Create BM25 IDF statistics table for this chunk table.
+    -- Only doc_freq is stored; the IDF weight is computed on read.
+    EXECUTE format('
+        CREATE TABLE IF NOT EXISTS %I (
+            term        TEXT    PRIMARY KEY,
+            doc_freq    INT     NOT NULL DEFAULT 1,
+            updated_at  TIMESTAMPTZ DEFAULT now()
+        )', chunk_table || '_idf_stats');
+
+    -- Register in vectorizers table for hybrid_search() lookups.
+    -- Use EXECUTE...USING to avoid PL/pgSQL variable/column ambiguity.
+    EXECUTE
+        'INSERT INTO pgedge_vectorizer.vectorizers
+             (source_table, source_column, chunk_table, source_pk, pk_type)
+         VALUES ($1, $2, $3, $4, $5)
+         ON CONFLICT (source_table, source_column)
+         DO UPDATE SET chunk_table = EXCLUDED.chunk_table,
+                       source_pk   = EXCLUDED.source_pk,
+                       pk_type     = EXCLUDED.pk_type'
+    USING source_table::TEXT, source_column, chunk_table, source_pk, pk_col_type;
+
+    -- Create trigger to chunk and queue on insert/update
+    trigger_name := source_table::TEXT || '_' || source_column || '_vectorization_trigger';
+
+    EXECUTE format('
+        CREATE OR REPLACE TRIGGER %I
+        AFTER INSERT OR UPDATE ON %s
+        FOR EACH ROW
+        EXECUTE FUNCTION pgedge_vectorizer.vectorization_trigger(%L, %L, %L, %L, %L, %L, %L)',
+        trigger_name, source_table,
+        source_column, chunk_table, actual_strategy,
+        actual_chunk_size, actual_chunk_overlap, source_pk, pk_col_type);
+
+    -- Clean up derived data when source rows are deleted.  Statement-level with
+    -- a transition table so that bulk deletes do not degenerate into per-row
+    -- work.
+    EXECUTE format('
+        CREATE OR REPLACE TRIGGER %I
+        AFTER DELETE ON %s
+        REFERENCING OLD TABLE AS old_rows
+        FOR EACH STATEMENT
+        EXECUTE FUNCTION pgedge_vectorizer.vectorization_delete_trigger(%L, %L, %L, %L)',
+        pgedge_vectorizer.cleanup_trigger_name(
+            source_table::TEXT, source_column, '_vectorization_delete_trigger'),
+        source_table,
+        source_column, chunk_table, source_pk, pk_col_type);
+
+    -- Clean up when the whole source table is truncated.
+    EXECUTE format('
+        CREATE OR REPLACE TRIGGER %I
+        AFTER TRUNCATE ON %s
+        FOR EACH STATEMENT
+        EXECUTE FUNCTION pgedge_vectorizer.vectorization_truncate_trigger(%L)',
+        pgedge_vectorizer.cleanup_trigger_name(
+            source_table::TEXT, source_column, '_vectorization_truncate_trigger'),
+        source_table, chunk_table);
+
+    RAISE NOTICE 'Vectorization enabled: % -> %', source_table, chunk_table;
+    RAISE NOTICE 'Strategy: %, chunk_size: %, overlap: %',
+        actual_strategy, actual_chunk_size, actual_chunk_overlap;
+
+    -- Process existing rows
+    DECLARE
+        row_record RECORD;
+        doc_content TEXT;
+        chunks TEXT[];
+        chunk_text TEXT;
+        i INT;
+        chunk_id BIGINT;
+        needs_embedding BOOLEAN;
+        needs_sparse BOOLEAN;
+        rows_processed INT := 0;
+    BEGIN
+        RAISE NOTICE 'Processing existing rows...';
+
+        -- pk_val is cast to text here so that row_record.pk_val is always the
+        -- same type across every call to this function within a session,
+        -- regardless of the source table's actual primary key type. PL/pgSQL
+        -- fixes the parameter type of a RECORD field the first time a dynamic
+        -- EXECUTE ... USING statement evaluates it, and reusing that same
+        -- statement later with a differently-typed record field fails with
+        -- "type of parameter N does not match that when preparing the plan"
+        -- (issue #39). Casting at the source, rather than at each USING site,
+        -- is required: PostgreSQL still binds the RECORD field's own runtime
+        -- type before any cast written into the later query text is applied.
+        FOR row_record IN EXECUTE format('SELECT %I::text as pk_val, %I as content FROM %s WHERE %I IS NOT NULL AND %I != ''''',
+            source_pk, source_column, source_table, source_column, source_column)
+        LOOP
+            doc_content := row_record.content;
+
+            -- Chunk the document
+            chunks := pgedge_vectorizer.chunk_text(doc_content, actual_strategy, actual_chunk_size, actual_chunk_overlap);
+
+            -- Insert chunks and queue for embedding
+            FOR i IN 1..array_length(chunks, 1) LOOP
+                chunk_text := chunks[i];
+
+                -- Insert or update chunk (only clear embedding if content changed).
+                -- pk_col_type uses %s: value from format_type() is system-controlled
+                -- (see the comment where the chunk table is created, above).
+                -- $1::%s casts pk_val, now always text, back to the source
+                -- table's actual primary key type.
+                EXECUTE format('
+                    INSERT INTO %I (source_id, chunk_index, content, token_count)
+                    VALUES ($1::%s, $2, $3, $4)
+                    ON CONFLICT (source_id, chunk_index)
+                    DO UPDATE SET content = EXCLUDED.content,
+                                  token_count = EXCLUDED.token_count,
+                                  embedding = CASE
+                                      WHEN %I.content = EXCLUDED.content THEN %I.embedding
+                                      ELSE NULL
+                                  END,
+                                  sparse_embedding = CASE
+                                      WHEN %I.content = EXCLUDED.content THEN %I.sparse_embedding
+                                      ELSE NULL
+                                  END,
+                                  updated_at = NOW()
+                    RETURNING id,
+                              (embedding IS NULL) AS needs_embedding,
+                              (sparse_embedding IS NULL) AS needs_sparse',
+                    chunk_table, pk_col_type, chunk_table, chunk_table, chunk_table, chunk_table)
+                USING row_record.pk_val, i, chunk_text,
+                      pgedge_vectorizer.count_tokens(chunk_text)
+                INTO chunk_id, needs_embedding, needs_sparse;
+
+                -- Queue if dense or sparse work is needed.
+                IF needs_embedding OR needs_sparse THEN
+                    INSERT INTO pgedge_vectorizer.queue (chunk_id, chunk_table, content, metadata, max_attempts)
+                    VALUES (
+                        chunk_id,
+                        chunk_table,
+                        chunk_text,
+                        CASE
+                            WHEN NOT needs_embedding AND needs_sparse
+                                THEN jsonb_build_object('sparse_only', true)
+                            ELSE NULL
+                        END,
+                        current_setting('pgedge_vectorizer.max_retries')::INT
+                    );
+                END IF;
+            END LOOP;
+
+            -- Remove queue entries for stale high-index chunks before deleting them.
+            -- Only targets 'pending'/'failed'; 'processing' items are left for the
+            -- worker to handle gracefully via its SPI_processed == 0 check.
+            -- pk_col_type uses %s: value from format_type() is system-controlled
+            EXECUTE format(
+                'DELETE FROM pgedge_vectorizer.queue
+                 WHERE chunk_table = %L
+                   AND chunk_id IN (
+                       SELECT id FROM %I WHERE source_id = $1::%s AND chunk_index > $2
+                   )
+                   AND status IN (''pending'', ''failed'')',
+                chunk_table, chunk_table, pk_col_type)
+                USING row_record.pk_val, COALESCE(array_length(chunks, 1), 0);
+
+            -- Remove any stale chunks beyond the new chunk count
+            -- pk_col_type uses %s: value from format_type() is system-controlled
+            EXECUTE format('DELETE FROM %I WHERE source_id = $1::%s AND chunk_index > $2',
+                chunk_table, pk_col_type)
+                USING row_record.pk_val, COALESCE(array_length(chunks, 1), 0);
+
+            rows_processed := rows_processed + 1;
+        END LOOP;
+
+        RAISE NOTICE 'Processed % existing rows', rows_processed;
+    END;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION pgedge_vectorizer.enable_vectorization IS
+'Enable automatic chunking and vectorization for a table column';
+
+CREATE OR REPLACE FUNCTION pgedge_vectorizer.vectorization_trigger()
+RETURNS TRIGGER AS $$
+DECLARE
+    content_col TEXT;
+    chunk_table TEXT;
+    strategy TEXT;
+    chunk_sz INT;
+    overlap INT;
+    pk_col TEXT;
+    pk_type TEXT;
+    doc_content TEXT;
+    chunks TEXT[];
+    chunk_text TEXT;
+    i INT;
+    chunk_id BIGINT;
+    source_id_val TEXT;
+    deleted_chunks_count INT := 0;
+BEGIN
+    -- Extract trigger arguments
+    content_col := TG_ARGV[0];
+    chunk_table := TG_ARGV[1];
+    strategy := TG_ARGV[2];
+    chunk_sz := TG_ARGV[3]::INT;
+    overlap := TG_ARGV[4]::INT;
+    pk_col := COALESCE(TG_ARGV[5], 'id');
+    pk_type := COALESCE(TG_ARGV[6], 'bigint');
+
+    -- Get source document ID
+    EXECUTE format('SELECT ($1).%I', pk_col) USING NEW INTO source_id_val;
+
+    -- Get document content
+    EXECUTE format('SELECT $1.%I', content_col) USING NEW INTO doc_content;
+
+    -- Trim whitespace for empty check
+    IF doc_content IS NOT NULL THEN
+        doc_content := trim(doc_content);
+    END IF;
+
+    -- Skip if content unchanged (on UPDATE)
+    IF TG_OP = 'UPDATE' THEN
+        DECLARE
+            old_content TEXT;
+        BEGIN
+            EXECUTE format('SELECT $1.%I', content_col) USING OLD INTO old_content;
+            IF old_content IS NOT NULL THEN
+                old_content := trim(old_content);
+            END IF;
+            IF doc_content = old_content OR (doc_content IS NULL AND old_content IS NULL) THEN
+                RETURN NEW;
+            END IF;
+        END;
+    END IF;
+
+    -- On UPDATE, decrement IDF stats for the old document's terms before
+    -- deleting the old chunks.  This prevents doc_freq from drifting upward
+    -- when the worker later re-increments stats for the new chunks.
+    IF TG_OP = 'UPDATE' THEN
+        DECLARE
+            old_terms TEXT[];
+            old_content_for_idf TEXT;
+        BEGIN
+            EXECUTE format('SELECT $1.%I', content_col) USING OLD INTO old_content_for_idf;
+            IF old_content_for_idf IS NOT NULL THEN
+                old_content_for_idf := trim(old_content_for_idf);
+            END IF;
+            IF old_content_for_idf IS NOT NULL AND old_content_for_idf <> '' THEN
+                old_terms := pgedge_vectorizer.bm25_tokenize(old_content_for_idf);
+                EXECUTE format(
+                    'SELECT count(*)::int FROM %I WHERE source_id = $1::%s',
+                    chunk_table, pk_type
+                )
+                INTO deleted_chunks_count
+                USING source_id_val;
+
+                PERFORM pgedge_vectorizer.bm25_decrement_idf_stats(
+                    chunk_table, old_terms, deleted_chunks_count);
+            END IF;
+        END;
+    END IF;
+
+    -- Delete queue entries for this document's chunks before deleting the chunks.
+    -- Prevents orphaned queue entries that waste embedding API calls on deleted chunks.
+    -- Only targets 'pending'/'failed'; 'processing' items are left for the
+    -- worker to handle gracefully via its SPI_processed == 0 check.
+    EXECUTE format(
+        'DELETE FROM pgedge_vectorizer.queue
+         WHERE chunk_table = %L
+           AND chunk_id IN (SELECT id FROM %I WHERE source_id = $1::%s)
+           AND status IN (''pending'', ''failed'')',
+        chunk_table, chunk_table, pk_type)
+        USING source_id_val;
+
+    -- Delete existing chunks for this document
+    -- pk_type uses %s: value from format_type() is system-controlled (see enable_vectorization)
+    EXECUTE format('DELETE FROM %I WHERE source_id = $1::%s', chunk_table, pk_type)
+        USING source_id_val;
+
+    -- Skip if content is NULL or empty (after deleting old chunks)
+    IF doc_content IS NULL OR doc_content = '' THEN
+        RETURN NEW;
+    END IF;
+
+    -- Chunk the document
+    chunks := pgedge_vectorizer.chunk_text(doc_content, strategy, chunk_sz, overlap);
+
+    -- Insert chunks and queue for embedding
+    FOR i IN 1..array_length(chunks, 1) LOOP
+        chunk_text := chunks[i];
+
+        -- Insert chunk
+        EXECUTE format('
+            INSERT INTO %I (source_id, chunk_index, content, token_count)
+            VALUES ($1::%s, $2, $3, $4)
+            RETURNING id', chunk_table, pk_type)
+        USING source_id_val, i, chunk_text,
+              pgedge_vectorizer.count_tokens(chunk_text)
+        INTO chunk_id;
+
+        -- Queue for embedding
+        INSERT INTO pgedge_vectorizer.queue (chunk_id, chunk_table, content, max_attempts)
+        VALUES (chunk_id, chunk_table, chunk_text,
+                current_setting('pgedge_vectorizer.max_retries')::INT);
+    END LOOP;
+
+    -- Notify workers (they will pick up work via polling and SKIP LOCKED)
+    PERFORM pg_notify('pgedge_vectorizer_queue', source_id_val::TEXT);
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION pgedge_vectorizer.vectorization_trigger IS
+'Trigger function that chunks text and queues for vectorization';
+
+CREATE OR REPLACE FUNCTION pgedge_vectorizer.recreate_chunks(
+    source_table_name REGCLASS,
+    source_column_name NAME
+) RETURNS INT AS $$
+DECLARE
+    chunk_table_name TEXT;
+    rows_affected INT := 0;
+    trigger_name TEXT;
+    trigger_exists BOOLEAN;
+BEGIN
+    -- Prefer authoritative mapping from vectorizers registry.
+    SELECT v.chunk_table
+    INTO chunk_table_name
+    FROM pgedge_vectorizer.vectorizers v
+    WHERE v.source_table = source_table_name::TEXT
+      AND v.source_column = source_column_name;
+
+    -- Fallback to legacy default naming if no registry row exists.
+    IF chunk_table_name IS NULL THEN
+        chunk_table_name := source_table_name::TEXT || '_' || source_column_name || '_chunks';
+    END IF;
+
+    -- Verify chunk table exists
+    IF to_regclass(chunk_table_name) IS NULL THEN
+        RAISE EXCEPTION 'Chunk table % does not exist. Use enable_vectorization() first.', chunk_table_name;
+    END IF;
+
+    -- Verify trigger exists
+    trigger_name := source_table_name::TEXT || '_' || source_column_name || '_vectorization_trigger';
+    SELECT EXISTS (
+        SELECT 1 FROM pg_trigger t
+        JOIN pg_class c ON t.tgrelid = c.oid
+        WHERE c.oid = source_table_name
+        AND t.tgname = trigger_name
+    ) INTO trigger_exists;
+
+    IF NOT trigger_exists THEN
+        RAISE EXCEPTION 'Vectorization trigger % does not exist. Use enable_vectorization() first.', trigger_name;
+    END IF;
+
+    RAISE NOTICE 'Recreating chunks for %.% -> %', source_table_name, source_column_name, chunk_table_name;
+
+    -- Delete all existing chunks and reset IDF stats.
+    -- Truncating _idf_stats is safe here because recreate_chunks rebuilds
+    -- all chunks from scratch; the worker will repopulate IDF stats as it
+    -- processes the newly queued chunks.
+    EXECUTE format('DELETE FROM %I', chunk_table_name);
+    EXECUTE format('TRUNCATE TABLE %I', chunk_table_name || '_idf_stats');
+    GET DIAGNOSTICS rows_affected = ROW_COUNT;
+    RAISE NOTICE 'Deleted % existing chunks', rows_affected;
+
+    -- Delete all queue items for this chunk table (with retry logic)
+    BEGIN
+        -- Try to delete with a lock timeout
+        SET LOCAL lock_timeout = '5s';
+        DELETE FROM pgedge_vectorizer.queue WHERE chunk_table = chunk_table_name;
+        RAISE NOTICE 'Cleared queue for %', chunk_table_name;
+    EXCEPTION WHEN lock_not_available OR deadlock_detected THEN
+        -- If we can't get the lock, just mark them for cleanup
+        RAISE WARNING 'Could not clear queue due to concurrent access, continuing anyway';
+    END;
+
+    -- Manually process each row to bypass trigger's unchanged-content optimization
+    DECLARE
+        row_record RECORD;
+        doc_content TEXT;
+        chunks TEXT[];
+        chunk_text TEXT;
+        i INT;
+        chunk_id BIGINT;
+        rows_processed INT := 0;
+        actual_strategy TEXT;
+        actual_chunk_size INT;
+        actual_chunk_overlap INT;
+        pk_col TEXT;
+        pk_type TEXT;
+    BEGIN
+        -- Get chunking configuration from trigger arguments
+        -- In PostgreSQL 17+, tgargs is bytea and needs to be decoded
+        DECLARE
+            tgargs_array TEXT[];
+        BEGIN
+            SELECT string_to_array(encode(t.tgargs, 'escape'), E'\\000')
+            INTO tgargs_array
+            FROM pg_trigger t
+            JOIN pg_class c ON t.tgrelid = c.oid
+            WHERE c.oid = source_table_name
+            AND t.tgname = trigger_name;
+
+            -- Arguments: 1=content_col, 2=chunk_table, 3=strategy, 4=size, 5=overlap, 6=pk_col, 7=pk_type
+            actual_strategy := tgargs_array[3];
+            actual_chunk_size := tgargs_array[4]::INT;
+            actual_chunk_overlap := tgargs_array[5]::INT;
+            pk_col := COALESCE(tgargs_array[6], 'id');
+            pk_type := COALESCE(tgargs_array[7], 'bigint');
+        END;
+
+        RAISE NOTICE 'Re-chunking with strategy=%, size=%, overlap=%',
+            actual_strategy, actual_chunk_size, actual_chunk_overlap;
+
+        -- pk_val is cast to text so that row_record.pk_val is always the same
+        -- type across calls in a session, whatever the source table's actual
+        -- primary key type. See the identical comment in enable_vectorization()
+        -- for why: PL/pgSQL fixes a RECORD field's parameter type the first
+        -- time a dynamic EXECUTE ... USING statement evaluates it, and this
+        -- statement's own "$1::%s" cast below does not protect it, because
+        -- that cast is applied after PostgreSQL has already bound the record
+        -- field's raw runtime type (issue #39).
+        FOR row_record IN EXECUTE format(
+            'SELECT %I::text as pk_val, %I as content FROM %s WHERE %I IS NOT NULL AND %I != ''''',
+            pk_col, source_column_name, source_table_name, source_column_name, source_column_name
+        )
+        LOOP
+            doc_content := row_record.content;
+
+            -- Chunk the document
+            chunks := pgedge_vectorizer.chunk_text(doc_content, actual_strategy, actual_chunk_size, actual_chunk_overlap);
+
+            -- Insert chunks and queue for embedding
+            FOR i IN 1..array_length(chunks, 1) LOOP
+                chunk_text := chunks[i];
+
+                -- Insert chunk
+                -- pk_type uses %s: value from format_type() is system-controlled (see enable_vectorization)
+                EXECUTE format('
+                    INSERT INTO %I (source_id, chunk_index, content, token_count)
+                    VALUES ($1::%s, $2, $3, $4)
+                    RETURNING id', chunk_table_name, pk_type)
+                USING row_record.pk_val, i, chunk_text,
+                      pgedge_vectorizer.count_tokens(chunk_text)
+                INTO chunk_id;
+
+                -- Queue for embedding
+                INSERT INTO pgedge_vectorizer.queue (chunk_id, chunk_table, content, max_attempts)
+                VALUES (chunk_id, chunk_table_name, chunk_text,
+                        current_setting('pgedge_vectorizer.max_retries')::INT);
+            END LOOP;
+
+            rows_processed := rows_processed + 1;
+        END LOOP;
+
+        RAISE NOTICE 'Processed % rows', rows_processed;
+        RETURN rows_processed;
+    END;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION pgedge_vectorizer.recreate_chunks IS
+'Delete all chunks and recreate from source table (complete rebuild)';

--- a/sql/pgedge_vectorizer--1.1--1.2.sql
+++ b/sql/pgedge_vectorizer--1.1--1.2.sql
@@ -707,7 +707,17 @@ BEGIN
          * the whole result set: one inaccessible vectorizer should not make
          * the view useless for every other one.
          */
-        chunk_oid := to_regclass(v.chunk_table);
+        /*
+         * The chunk table's name is generated as source_table || column ||
+         * '_chunks' and created with %I, so for a schema-qualified source the
+         * dot ends up inside a single identifier rather than separating a
+         * schema from a relation. quote_ident() keeps to_regclass() from
+         * splitting it, matching how quote_identifier() is used for the same
+         * name in bm25.c. The source table's name, by contrast, comes from
+         * regclass output and is a genuine qualified reference, so it is
+         * looked up as it stands.
+         */
+        chunk_oid := to_regclass(quote_ident(v.chunk_table));
         IF chunk_oid IS NOT NULL
            AND has_table_privilege(chunk_oid, 'SELECT') THEN
             EXECUTE format(

--- a/sql/pgedge_vectorizer--1.2.sql
+++ b/sql/pgedge_vectorizer--1.2.sql
@@ -1093,7 +1093,17 @@ BEGIN
          * the whole result set: one inaccessible vectorizer should not make
          * the view useless for every other one.
          */
-        chunk_oid := to_regclass(v.chunk_table);
+        /*
+         * The chunk table's name is generated as source_table || column ||
+         * '_chunks' and created with %I, so for a schema-qualified source the
+         * dot ends up inside a single identifier rather than separating a
+         * schema from a relation. quote_ident() keeps to_regclass() from
+         * splitting it, matching how quote_identifier() is used for the same
+         * name in bm25.c. The source table's name, by contrast, comes from
+         * regclass output and is a genuine qualified reference, so it is
+         * looked up as it stands.
+         */
+        chunk_oid := to_regclass(quote_ident(v.chunk_table));
         IF chunk_oid IS NOT NULL
            AND has_table_privilege(chunk_oid, 'SELECT') THEN
             EXECUTE format(

--- a/sql/pgedge_vectorizer--1.2.sql
+++ b/sql/pgedge_vectorizer--1.2.sql
@@ -1,0 +1,1477 @@
+-- pgedge_vectorizer extension
+-- Version 1.2
+--
+-- Asynchronous text chunking and vectorization for PostgreSQL
+
+-- complain if script is sourced in psql, rather than via CREATE EXTENSION
+\echo Use "CREATE EXTENSION pgedge_vectorizer" to load this file. \quit
+
+---------------------------------------------------------------------------
+-- Create schema
+---------------------------------------------------------------------------
+
+CREATE SCHEMA IF NOT EXISTS pgedge_vectorizer;
+
+---------------------------------------------------------------------------
+-- Vectorizers registry
+-- Tracks which chunk tables have been created for source tables.
+-- Used by hybrid_search() to resolve chunk table names.
+---------------------------------------------------------------------------
+
+CREATE TABLE pgedge_vectorizer.vectorizers (
+    id            BIGSERIAL PRIMARY KEY,
+    source_table  TEXT NOT NULL,
+    source_column NAME NOT NULL,
+    chunk_table   TEXT NOT NULL,
+    source_pk     NAME,
+    pk_type       TEXT,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (source_table, source_column)
+);
+
+COMMENT ON TABLE pgedge_vectorizer.vectorizers IS
+'Registry of active vectorizer configurations (source table → chunk table)';
+
+---------------------------------------------------------------------------
+-- Queue table for async embedding generation
+---------------------------------------------------------------------------
+
+CREATE TABLE pgedge_vectorizer.queue (
+    id BIGSERIAL PRIMARY KEY,
+    chunk_id BIGINT NOT NULL,          -- ID of the chunk in the chunk table
+    chunk_table TEXT NOT NULL,          -- Name of the chunk table
+    content TEXT NOT NULL,              -- Text content to embed
+    status TEXT NOT NULL DEFAULT 'pending'
+        CHECK (status IN ('pending', 'processing', 'completed', 'failed')),
+    attempts INT NOT NULL DEFAULT 0,
+    max_attempts INT NOT NULL DEFAULT 3,
+    error_message TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    processing_started_at TIMESTAMPTZ,
+    processed_at TIMESTAMPTZ,
+    next_retry_at TIMESTAMPTZ,
+    -- Times the provider asked for a slower rate. Counted apart from
+    -- attempts, which max_attempts bounds, so throttling cannot spend an
+    -- item's retries.
+    rate_limit_deferrals INT NOT NULL DEFAULT 0,
+    metadata JSONB
+);
+
+-- Indexes for efficient queue processing
+CREATE INDEX idx_queue_status ON pgedge_vectorizer.queue(status, next_retry_at)
+    WHERE status IN ('pending', 'failed');
+
+CREATE INDEX idx_queue_chunk ON pgedge_vectorizer.queue(chunk_table, chunk_id);
+
+CREATE INDEX idx_queue_created_at ON pgedge_vectorizer.queue(created_at)
+    WHERE status = 'pending';
+
+---------------------------------------------------------------------------
+-- C function declarations
+---------------------------------------------------------------------------
+
+-- Chunking function
+CREATE FUNCTION pgedge_vectorizer.chunk_text(
+    content TEXT,
+    strategy TEXT DEFAULT NULL,
+    chunk_size INT DEFAULT NULL,
+    overlap INT DEFAULT NULL
+) RETURNS TEXT[]
+AS 'MODULE_PATHNAME', 'pgedge_vectorizer_chunk_text_sql'
+LANGUAGE C IMMUTABLE STRICT;
+
+COMMENT ON FUNCTION pgedge_vectorizer.chunk_text IS
+'Split text into chunks according to the specified strategy';
+
+-- Embedding generation function
+CREATE FUNCTION pgedge_vectorizer.generate_embedding(
+    query_text TEXT
+) RETURNS vector
+AS 'MODULE_PATHNAME', 'pgedge_vectorizer_generate_embedding'
+LANGUAGE C STABLE STRICT;
+
+COMMENT ON FUNCTION pgedge_vectorizer.generate_embedding IS
+'Generate an embedding vector from query text using the configured provider';
+
+-- Embedding dimension detection function
+CREATE FUNCTION pgedge_vectorizer.detect_embedding_dimension()
+RETURNS INT
+AS 'MODULE_PATHNAME', 'pgedge_vectorizer_detect_embedding_dimension'
+LANGUAGE C STRICT;
+
+COMMENT ON FUNCTION pgedge_vectorizer.detect_embedding_dimension IS
+'Detect the embedding dimension of the currently configured provider/model';
+
+-- BM25 query vector function
+-- Tokenizes the query and computes a sparse vector using current IDF stats.
+-- Used by hybrid_search() for the query-side sparse representation.
+CREATE FUNCTION pgedge_vectorizer.bm25_query_vector(
+    query TEXT,
+    chunk_table TEXT
+) RETURNS sparsevec
+AS 'MODULE_PATHNAME', 'pgedge_vectorizer_bm25_query_vector'
+LANGUAGE C STRICT;
+
+COMMENT ON FUNCTION pgedge_vectorizer.bm25_query_vector IS
+'Compute a BM25 sparse vector for a query text using IDF stats from the given chunk table';
+
+-- BM25 average document length helper
+CREATE FUNCTION pgedge_vectorizer.bm25_avg_doc_len(
+    chunk_table TEXT
+) RETURNS FLOAT8
+AS 'MODULE_PATHNAME', 'pgedge_vectorizer_bm25_avg_doc_len'
+LANGUAGE C STRICT;
+
+COMMENT ON FUNCTION pgedge_vectorizer.bm25_avg_doc_len IS
+'Return the average document length (in tokens) for the given chunk table';
+
+-- BM25 tokenizer (exposed for testing)
+CREATE FUNCTION pgedge_vectorizer.bm25_tokenize(
+    query TEXT
+) RETURNS TEXT[]
+AS 'MODULE_PATHNAME', 'pgedge_vectorizer_bm25_tokenize'
+LANGUAGE C STRICT;
+
+COMMENT ON FUNCTION pgedge_vectorizer.bm25_tokenize IS
+'Tokenize text and return the non-stopword terms (useful for testing)';
+
+-- Approximate token counter, shared with the C chunking code
+CREATE FUNCTION pgedge_vectorizer.count_tokens(
+    content TEXT
+) RETURNS INT
+AS 'MODULE_PATHNAME', 'pgedge_vectorizer_count_tokens'
+LANGUAGE C STABLE STRICT;
+
+COMMENT ON FUNCTION pgedge_vectorizer.count_tokens IS
+'Approximate the token count of the given text (UTF-8 characters divided by '
+'four, rounded up). This is the same estimate the chunking engine uses, and '
+'is what gets stored in the token_count column of a chunk table';
+
+---------------------------------------------------------------------------
+-- SQL Functions
+---------------------------------------------------------------------------
+
+-- Build a cleanup trigger name that stays unique within PostgreSQL's 63-byte
+-- identifier limit.
+--
+-- Two problems have to be solved at once.  The names differ only in their final
+-- word, so plain truncation would make the delete and truncate names identical
+-- for a long enough table and column, and the second CREATE OR REPLACE TRIGGER
+-- would silently replace the first.  Shortening the readable part instead is not
+-- sufficient either, because two columns on a long-named table would then
+-- shorten to the same string.
+--
+-- So the readable prefix is shortened to fit and a digest of the exact table and
+-- column is appended, which keeps the name unique per vectorized column however
+-- much of the readable part had to go.
+--
+-- Note that a shortened name no longer begins with the source table text, so
+-- teardown must not look these up by name pattern.  disable_vectorization()
+-- finds them by trigger function instead.
+CREATE FUNCTION pgedge_vectorizer.cleanup_trigger_name(
+    p_source_table  TEXT,
+    p_source_column TEXT,
+    p_suffix        TEXT
+) RETURNS TEXT AS $$
+DECLARE
+    digest TEXT;
+    prefix TEXT;
+    room   INT;
+BEGIN
+    digest := substr(md5(p_source_table || '.' || p_source_column), 1, 8);
+
+    -- Budget in bytes, not characters: the limit is 63 bytes, so a multibyte
+    -- name measured in characters would overflow and be truncated by the
+    -- server, cutting into the digest.  One byte for the separator.
+    room := GREATEST(63 - octet_length(p_suffix) - octet_length(digest) - 1, 0);
+
+    -- No more than `room` characters can fit in `room` bytes, so start there
+    -- and drop whole characters until the prefix is within the byte budget.
+    prefix := left(p_source_table || '_' || p_source_column, room);
+    WHILE octet_length(prefix) > room LOOP
+        prefix := left(prefix, -1);
+    END LOOP;
+
+    RETURN prefix || '_' || digest || p_suffix;
+END;
+$$ LANGUAGE plpgsql IMMUTABLE;
+
+COMMENT ON FUNCTION pgedge_vectorizer.cleanup_trigger_name IS
+'Build a cleanup trigger name that remains unique per vectorized column within the identifier length limit';
+
+-- Enable vectorization for a table/column
+CREATE FUNCTION pgedge_vectorizer.enable_vectorization(
+    source_table REGCLASS,
+    source_column NAME,
+    chunk_strategy TEXT DEFAULT NULL,
+    chunk_size INT DEFAULT NULL,
+    chunk_overlap INT DEFAULT NULL,
+    embedding_dimension INT DEFAULT NULL,
+    chunk_table_name TEXT DEFAULT NULL,
+    source_pk NAME DEFAULT NULL
+) RETURNS VOID AS $$
+DECLARE
+    chunk_table TEXT;
+    trigger_name TEXT;
+    actual_strategy TEXT;
+    actual_chunk_size INT;
+    actual_chunk_overlap INT;
+    pk_col_type TEXT;
+    pk_count INT;
+BEGIN
+    -- Use defaults from GUC if not provided
+    actual_strategy := COALESCE(chunk_strategy,
+        current_setting('pgedge_vectorizer.default_chunk_strategy'));
+    actual_chunk_size := COALESCE(chunk_size,
+        current_setting('pgedge_vectorizer.default_chunk_size')::INT);
+    actual_chunk_overlap := COALESCE(chunk_overlap,
+        current_setting('pgedge_vectorizer.default_chunk_overlap')::INT);
+
+    -- Auto-detect embedding dimension from configured model if not specified
+    IF embedding_dimension IS NULL THEN
+        embedding_dimension := pgedge_vectorizer.detect_embedding_dimension();
+        RAISE NOTICE 'Auto-detected embedding dimension: %', embedding_dimension;
+    END IF;
+
+    -- Detect PK column count to reject composite PKs
+    SELECT count(*)
+    INTO pk_count
+    FROM pg_index i
+    JOIN pg_attribute a ON a.attrelid = i.indrelid
+      AND a.attnum = ANY(i.indkey)
+    WHERE i.indrelid = source_table
+      AND i.indisprimary;
+
+    IF pk_count = 0 AND source_pk IS NULL THEN
+        RAISE EXCEPTION 'Table % has no primary key. Use the source_pk parameter to specify the column to use as document identifier.',
+            source_table;
+    END IF;
+
+    IF pk_count > 1 AND source_pk IS NULL THEN
+        RAISE EXCEPTION 'Table % has a composite primary key (% columns), which is not supported by auto-detection. Use the source_pk parameter to specify a single column.',
+            source_table, pk_count;
+    END IF;
+
+    -- Auto-detect PK column name and type if source_pk not specified
+    IF source_pk IS NULL THEN
+        SELECT a.attname, format_type(a.atttypid, a.atttypmod)
+        INTO source_pk, pk_col_type
+        FROM pg_index i
+        JOIN pg_attribute a ON a.attrelid = i.indrelid
+          AND a.attnum = ANY(i.indkey)
+        WHERE i.indrelid = source_table
+          AND i.indisprimary;
+    ELSE
+        -- User specified a column; look up its type
+        SELECT format_type(a.atttypid, a.atttypmod)
+        INTO pk_col_type
+        FROM pg_attribute a
+        WHERE a.attrelid = source_table
+          AND a.attname = source_pk
+          AND NOT a.attisdropped;
+
+        IF pk_col_type IS NULL THEN
+            RAISE EXCEPTION 'Column "%" does not exist on table %',
+                source_pk, source_table;
+        END IF;
+    END IF;
+
+    RAISE NOTICE 'Using primary key column: % (%)', source_pk, pk_col_type;
+
+    -- Determine chunk table name.
+    -- Include source schema in the generated identifier text to avoid
+    -- collisions when two schemas have the same relname.
+    chunk_table := COALESCE(chunk_table_name,
+                            source_table::TEXT || '_' || source_column || '_chunks');
+
+    -- Create chunks table
+    -- Note: pk_col_type uses %s (not %I) because format_type() returns
+    -- canonical SQL type names (e.g. "character varying(26)") that would
+    -- be incorrectly double-quoted by %I. This value is system-controlled.
+    EXECUTE format('
+        CREATE TABLE IF NOT EXISTS %I (
+            id BIGSERIAL PRIMARY KEY,
+            source_id %s NOT NULL,
+            chunk_index INT NOT NULL,
+            content TEXT NOT NULL,
+            token_count INT,
+            embedding vector(%s),
+            sparse_embedding sparsevec(65536),
+            created_at TIMESTAMPTZ DEFAULT NOW(),
+            updated_at TIMESTAMPTZ DEFAULT NOW(),
+            UNIQUE(source_id, chunk_index)
+        )', chunk_table, pk_col_type, embedding_dimension);
+
+    -- Add sparse columns to pre-existing chunk tables (upgrade path).
+    -- These are no-ops for freshly created tables (columns exist already).
+    EXECUTE format('
+        ALTER TABLE %I
+        ADD COLUMN IF NOT EXISTS sparse_embedding sparsevec(65536)',
+        chunk_table);
+
+    -- Create vector index for similarity search
+    EXECUTE format('
+        CREATE INDEX IF NOT EXISTS %I ON %I
+        USING hnsw (embedding vector_cosine_ops)',
+        chunk_table || '_embedding_idx', chunk_table);
+
+    -- Create index on source_id for joins
+    EXECUTE format('
+        CREATE INDEX IF NOT EXISTS %I ON %I (source_id)',
+        chunk_table || '_source_id_idx', chunk_table);
+
+    -- Create HNSW index on sparse_embedding for fast sparse search
+    EXECUTE format('
+        CREATE INDEX IF NOT EXISTS %I ON %I
+        USING hnsw (sparse_embedding sparsevec_ip_ops)
+        WHERE sparse_embedding IS NOT NULL',
+        chunk_table || '_sparse_idx', chunk_table);
+
+    -- Create BM25 IDF statistics table for this chunk table.
+    -- Only doc_freq is stored; the IDF weight is computed on read.
+    EXECUTE format('
+        CREATE TABLE IF NOT EXISTS %I (
+            term        TEXT    PRIMARY KEY,
+            doc_freq    INT     NOT NULL DEFAULT 1,
+            updated_at  TIMESTAMPTZ DEFAULT now()
+        )', chunk_table || '_idf_stats');
+
+    -- Register in vectorizers table for hybrid_search() lookups.
+    -- Use EXECUTE...USING to avoid PL/pgSQL variable/column ambiguity.
+    EXECUTE
+        'INSERT INTO pgedge_vectorizer.vectorizers
+             (source_table, source_column, chunk_table, source_pk, pk_type)
+         VALUES ($1, $2, $3, $4, $5)
+         ON CONFLICT (source_table, source_column)
+         DO UPDATE SET chunk_table = EXCLUDED.chunk_table,
+                       source_pk   = EXCLUDED.source_pk,
+                       pk_type     = EXCLUDED.pk_type'
+    USING source_table::TEXT, source_column, chunk_table, source_pk, pk_col_type;
+
+    -- Create trigger to chunk and queue on insert/update
+    trigger_name := source_table::TEXT || '_' || source_column || '_vectorization_trigger';
+
+    EXECUTE format('
+        CREATE OR REPLACE TRIGGER %I
+        AFTER INSERT OR UPDATE ON %s
+        FOR EACH ROW
+        EXECUTE FUNCTION pgedge_vectorizer.vectorization_trigger(%L, %L, %L, %L, %L, %L, %L)',
+        trigger_name, source_table,
+        source_column, chunk_table, actual_strategy,
+        actual_chunk_size, actual_chunk_overlap, source_pk, pk_col_type);
+
+    -- Clean up derived data when source rows are deleted.  Statement-level with
+    -- a transition table so that bulk deletes do not degenerate into per-row
+    -- work.
+    EXECUTE format('
+        CREATE OR REPLACE TRIGGER %I
+        AFTER DELETE ON %s
+        REFERENCING OLD TABLE AS old_rows
+        FOR EACH STATEMENT
+        EXECUTE FUNCTION pgedge_vectorizer.vectorization_delete_trigger(%L, %L, %L, %L)',
+        pgedge_vectorizer.cleanup_trigger_name(
+            source_table::TEXT, source_column, '_vectorization_delete_trigger'),
+        source_table,
+        source_column, chunk_table, source_pk, pk_col_type);
+
+    -- Clean up when the whole source table is truncated.
+    EXECUTE format('
+        CREATE OR REPLACE TRIGGER %I
+        AFTER TRUNCATE ON %s
+        FOR EACH STATEMENT
+        EXECUTE FUNCTION pgedge_vectorizer.vectorization_truncate_trigger(%L)',
+        pgedge_vectorizer.cleanup_trigger_name(
+            source_table::TEXT, source_column, '_vectorization_truncate_trigger'),
+        source_table, chunk_table);
+
+    RAISE NOTICE 'Vectorization enabled: % -> %', source_table, chunk_table;
+    RAISE NOTICE 'Strategy: %, chunk_size: %, overlap: %',
+        actual_strategy, actual_chunk_size, actual_chunk_overlap;
+
+    -- Process existing rows
+    DECLARE
+        row_record RECORD;
+        doc_content TEXT;
+        chunks TEXT[];
+        chunk_text TEXT;
+        i INT;
+        chunk_id BIGINT;
+        needs_embedding BOOLEAN;
+        needs_sparse BOOLEAN;
+        rows_processed INT := 0;
+    BEGIN
+        RAISE NOTICE 'Processing existing rows...';
+
+        -- pk_val is cast to text here so that row_record.pk_val is always the
+        -- same type across every call to this function within a session,
+        -- regardless of the source table's actual primary key type. PL/pgSQL
+        -- fixes the parameter type of a RECORD field the first time a dynamic
+        -- EXECUTE ... USING statement evaluates it, and reusing that same
+        -- statement later with a differently-typed record field fails with
+        -- "type of parameter N does not match that when preparing the plan"
+        -- (issue #39). Casting at the source, rather than at each USING site,
+        -- is required: PostgreSQL still binds the RECORD field's own runtime
+        -- type before any cast written into the later query text is applied.
+        FOR row_record IN EXECUTE format('SELECT %I::text as pk_val, %I as content FROM %s WHERE %I IS NOT NULL AND %I != ''''',
+            source_pk, source_column, source_table, source_column, source_column)
+        LOOP
+            doc_content := row_record.content;
+
+            -- Chunk the document
+            chunks := pgedge_vectorizer.chunk_text(doc_content, actual_strategy, actual_chunk_size, actual_chunk_overlap);
+
+            -- Insert chunks and queue for embedding
+            FOR i IN 1..array_length(chunks, 1) LOOP
+                chunk_text := chunks[i];
+
+                -- Insert or update chunk (only clear embedding if content changed).
+                -- pk_col_type uses %s: value from format_type() is system-controlled
+                -- (see the comment where the chunk table is created, above).
+                -- $1::%s casts pk_val, now always text, back to the source
+                -- table's actual primary key type.
+                EXECUTE format('
+                    INSERT INTO %I (source_id, chunk_index, content, token_count)
+                    VALUES ($1::%s, $2, $3, $4)
+                    ON CONFLICT (source_id, chunk_index)
+                    DO UPDATE SET content = EXCLUDED.content,
+                                  token_count = EXCLUDED.token_count,
+                                  embedding = CASE
+                                      WHEN %I.content = EXCLUDED.content THEN %I.embedding
+                                      ELSE NULL
+                                  END,
+                                  sparse_embedding = CASE
+                                      WHEN %I.content = EXCLUDED.content THEN %I.sparse_embedding
+                                      ELSE NULL
+                                  END,
+                                  updated_at = NOW()
+                    RETURNING id,
+                              (embedding IS NULL) AS needs_embedding,
+                              (sparse_embedding IS NULL) AS needs_sparse',
+                    chunk_table, pk_col_type, chunk_table, chunk_table, chunk_table, chunk_table)
+                USING row_record.pk_val, i, chunk_text,
+                      pgedge_vectorizer.count_tokens(chunk_text)
+                INTO chunk_id, needs_embedding, needs_sparse;
+
+                -- Queue if dense or sparse work is needed.
+                IF needs_embedding OR needs_sparse THEN
+                    INSERT INTO pgedge_vectorizer.queue (chunk_id, chunk_table, content, metadata, max_attempts)
+                    VALUES (
+                        chunk_id,
+                        chunk_table,
+                        chunk_text,
+                        CASE
+                            WHEN NOT needs_embedding AND needs_sparse
+                                THEN jsonb_build_object('sparse_only', true)
+                            ELSE NULL
+                        END,
+                        current_setting('pgedge_vectorizer.max_retries')::INT
+                    );
+                END IF;
+            END LOOP;
+
+            -- Remove queue entries for stale high-index chunks before deleting them.
+            -- Only targets 'pending'/'failed'; 'processing' items are left for the
+            -- worker to handle gracefully via its SPI_processed == 0 check.
+            -- pk_col_type uses %s: value from format_type() is system-controlled
+            EXECUTE format(
+                'DELETE FROM pgedge_vectorizer.queue
+                 WHERE chunk_table = %L
+                   AND chunk_id IN (
+                       SELECT id FROM %I WHERE source_id = $1::%s AND chunk_index > $2
+                   )
+                   AND status IN (''pending'', ''failed'')',
+                chunk_table, chunk_table, pk_col_type)
+                USING row_record.pk_val, COALESCE(array_length(chunks, 1), 0);
+
+            -- Remove any stale chunks beyond the new chunk count
+            -- pk_col_type uses %s: value from format_type() is system-controlled
+            EXECUTE format('DELETE FROM %I WHERE source_id = $1::%s AND chunk_index > $2',
+                chunk_table, pk_col_type)
+                USING row_record.pk_val, COALESCE(array_length(chunks, 1), 0);
+
+            rows_processed := rows_processed + 1;
+        END LOOP;
+
+        RAISE NOTICE 'Processed % existing rows', rows_processed;
+    END;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION pgedge_vectorizer.enable_vectorization IS
+'Enable automatic chunking and vectorization for a table column';
+
+-- Disable vectorization for a table column
+CREATE FUNCTION pgedge_vectorizer.disable_vectorization(
+    source_table REGCLASS,
+    source_column NAME DEFAULT NULL,
+    drop_chunk_table BOOLEAN DEFAULT FALSE
+) RETURNS VOID AS $$
+DECLARE
+    trigger_name TEXT;
+    chunk_table TEXT;
+    trigger_rec RECORD;
+    chunk_tables_to_drop TEXT[];
+    ct TEXT;
+BEGIN
+    -- If column specified, drop that specific trigger
+    IF source_column IS NOT NULL THEN
+        trigger_name := source_table::TEXT || '_' || source_column || '_vectorization_trigger';
+
+        -- Look up the authoritative chunk table name from the registry so that
+        -- custom chunk_table_name values (passed to enable_vectorization) are
+        -- honored; fall back to the default convention only when not registered.
+        -- Use EXECUTE...USING to avoid variable/column name ambiguity for
+        -- source_table and source_column (same pattern as the DELETE below).
+        EXECUTE
+            'SELECT v.chunk_table FROM pgedge_vectorizer.vectorizers v
+              WHERE v.source_table = $1 AND v.source_column = $2'
+        INTO chunk_table
+        USING source_table::TEXT, source_column;
+
+        IF chunk_table IS NULL THEN
+            chunk_table := source_table::TEXT || '_' || source_column || '_chunks';
+        END IF;
+
+        -- Drop triggers
+        EXECUTE format('DROP TRIGGER IF EXISTS %I ON %s', trigger_name, source_table);
+        EXECUTE format('DROP TRIGGER IF EXISTS %I ON %s',
+                       pgedge_vectorizer.cleanup_trigger_name(
+                           source_table::TEXT, source_column, '_vectorization_delete_trigger'),
+                       source_table);
+        EXECUTE format('DROP TRIGGER IF EXISTS %I ON %s',
+                       pgedge_vectorizer.cleanup_trigger_name(
+                           source_table::TEXT, source_column, '_vectorization_truncate_trigger'),
+                       source_table);
+
+        -- Remove orphaned queue items for this chunk table
+        EXECUTE format('DELETE FROM pgedge_vectorizer.queue WHERE chunk_table = %L AND status IN (''pending'', ''processing'')', chunk_table);
+
+        -- Remove from vectorizers registry.
+        -- Use EXECUTE...USING to avoid PL/pgSQL variable/column
+        -- name ambiguity for source_table and source_column.
+        EXECUTE
+            'DELETE FROM pgedge_vectorizer.vectorizers
+              WHERE source_table = $1 AND source_column = $2'
+        USING source_table::TEXT, source_column;
+
+        -- Optionally drop chunk table and IDF stats table
+        IF drop_chunk_table THEN
+            EXECUTE format('DROP TABLE IF EXISTS %I CASCADE',
+                           chunk_table || '_idf_stats');
+            EXECUTE format('DROP TABLE IF EXISTS %I CASCADE', chunk_table);
+            RAISE NOTICE 'Vectorization disabled and chunk table dropped: %', chunk_table;
+        ELSE
+            RAISE NOTICE 'Vectorization disabled (chunk table preserved): %', chunk_table;
+        END IF;
+    ELSE
+        -- Drop all vectorization triggers for this table
+        -- Find vectorization triggers by their trigger function rather than by
+        -- name pattern.  Cleanup trigger names are shortened when the table and
+        -- column are long, so a shortened name need not begin with the source
+        -- table text and a LIKE pattern anchored on it would miss them,
+        -- silently leaving cleanup triggers behind.
+        FOR trigger_rec IN
+            SELECT t.tgname
+            FROM pg_trigger t
+            WHERE t.tgrelid = source_table
+              AND NOT t.tgisinternal
+              AND t.tgfoid IN (
+                  SELECT p.oid
+                  FROM pg_proc p
+                  JOIN pg_namespace n ON n.oid = p.pronamespace
+                  WHERE n.nspname = 'pgedge_vectorizer'
+                    AND p.proname IN ('vectorization_trigger',
+                                      'vectorization_delete_trigger',
+                                      'vectorization_truncate_trigger'))
+        LOOP
+            EXECUTE format('DROP TRIGGER IF EXISTS %I ON %s', trigger_rec.tgname, source_table);
+            RAISE NOTICE 'Dropped trigger: %', trigger_rec.tgname;
+        END LOOP;
+
+        -- Collect chunk table names before deleting registry entries.
+        -- Use EXECUTE...USING to avoid PL/pgSQL variable/column
+        -- name ambiguity for source_table.
+        EXECUTE
+            'SELECT ARRAY(
+                SELECT v.chunk_table
+                FROM pgedge_vectorizer.vectorizers v
+                WHERE v.source_table = $1
+            )'
+        INTO chunk_tables_to_drop
+        USING source_table::TEXT;
+
+        -- Remove orphaned queue items for exact chunk tables from registry.
+        DELETE FROM pgedge_vectorizer.queue q
+        WHERE q.chunk_table = ANY(COALESCE(chunk_tables_to_drop, '{}'))
+        AND q.status IN ('pending', 'processing');
+
+        -- Remove all vectorizer registry entries for this source table
+        EXECUTE
+            'DELETE FROM pgedge_vectorizer.vectorizers WHERE source_table = $1'
+        USING source_table::TEXT;
+
+        -- Optionally drop all chunk tables and their IDF stats tables
+        IF drop_chunk_table THEN
+            FOREACH ct IN ARRAY COALESCE(chunk_tables_to_drop, '{}') LOOP
+                EXECUTE format('DROP TABLE IF EXISTS %I CASCADE', ct || '_idf_stats');
+                EXECUTE format('DROP TABLE IF EXISTS %I CASCADE', ct);
+                RAISE NOTICE 'Vectorization disabled and chunk table dropped: %', ct;
+            END LOOP;
+        END IF;
+    END IF;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION pgedge_vectorizer.disable_vectorization IS
+'Disable automatic vectorization for a table';
+
+-- Recreate the DELETE and TRUNCATE cleanup triggers for every registered
+-- vectorizer.
+--
+-- Upgrade scripts only run on a version change, so an installation of an
+-- unreleased build that already has vectorized tables would otherwise have no
+-- supported way to acquire the new triggers.  This is also the repair route if
+-- triggers are ever dropped by hand.
+--
+-- Returns the number of vectorizers whose triggers were recreated.  Entries
+-- whose primary key is not recorded are skipped with a warning rather than
+-- guessed at, because enable_vectorization() accepts an explicit source_pk that
+-- re-detection could get wrong.
+CREATE FUNCTION pgedge_vectorizer.refresh_triggers()
+RETURNS INT AS $$
+DECLARE
+    v         RECORD;
+    refreshed INT := 0;
+BEGIN
+    FOR v IN
+        SELECT source_table, source_column, chunk_table, source_pk, pk_type
+        FROM pgedge_vectorizer.vectorizers
+    LOOP
+        IF to_regclass(v.source_table) IS NULL THEN
+            RAISE WARNING 'Skipping %: source table no longer exists', v.source_table;
+            CONTINUE;
+        END IF;
+
+        IF v.source_pk IS NULL OR v.pk_type IS NULL THEN
+            RAISE WARNING 'Skipping %.%: primary key not recorded, re-run enable_vectorization() for this column',
+                v.source_table, v.source_column;
+            CONTINUE;
+        END IF;
+
+        EXECUTE format('
+            CREATE OR REPLACE TRIGGER %I
+            AFTER DELETE ON %s
+            REFERENCING OLD TABLE AS old_rows
+            FOR EACH STATEMENT
+            EXECUTE FUNCTION pgedge_vectorizer.vectorization_delete_trigger(%L, %L, %L, %L)',
+            pgedge_vectorizer.cleanup_trigger_name(
+                v.source_table, v.source_column, '_vectorization_delete_trigger'),
+            v.source_table,
+            v.source_column, v.chunk_table, v.source_pk, v.pk_type);
+
+        EXECUTE format('
+            CREATE OR REPLACE TRIGGER %I
+            AFTER TRUNCATE ON %s
+            FOR EACH STATEMENT
+            EXECUTE FUNCTION pgedge_vectorizer.vectorization_truncate_trigger(%L)',
+            pgedge_vectorizer.cleanup_trigger_name(
+                v.source_table, v.source_column, '_vectorization_truncate_trigger'),
+            v.source_table, v.chunk_table);
+
+        refreshed := refreshed + 1;
+    END LOOP;
+
+    RETURN refreshed;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION pgedge_vectorizer.refresh_triggers IS
+'Recreate the DELETE and TRUNCATE cleanup triggers for all registered vectorizers; returns the number refreshed';
+
+-- BM25 IDF stats decrement helper
+-- Called by vectorization_trigger before deleting old chunks on UPDATE so that
+-- the doc_freq counts for the old document's terms are removed before the
+-- worker re-increments them for the new chunks.  This prevents permanent
+-- overcount of IDF stats when documents are updated.
+CREATE OR REPLACE FUNCTION pgedge_vectorizer.bm25_decrement_idf_stats(
+    p_chunk_table TEXT,
+    p_terms       TEXT[],
+    p_deleted_chunks_count INT DEFAULT 1
+) RETURNS VOID AS $$
+BEGIN
+    IF p_terms IS NULL OR array_length(p_terms, 1) IS NULL THEN
+        RETURN;
+    END IF;
+
+    IF p_deleted_chunks_count IS NULL OR p_deleted_chunks_count <= 0 THEN
+        RETURN;
+    END IF;
+
+    EXECUTE format(
+        'UPDATE %I SET'
+        '    doc_freq   = GREATEST(doc_freq - $1, 0),'
+        '    updated_at = now()'
+        ' WHERE term = ANY($2)',
+        p_chunk_table || '_idf_stats')
+    USING p_deleted_chunks_count, p_terms;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION pgedge_vectorizer.bm25_decrement_idf_stats IS
+'Decrement doc_freq in the _idf_stats table for a set of terms before their source chunks are deleted';
+
+-- Statement-level trigger function cleaning up after DELETE on a source table.
+--
+-- Statement-level rather than row-level so that a bulk delete does not run three
+-- statements plus a tokenisation per row: with the old_rows transition table the
+-- queue and chunk deletions are one set-based statement each.  Only the BM25
+-- decrement needs a loop, because bm25_decrement_idf_stats() takes one
+-- document's terms at a time.
+CREATE FUNCTION pgedge_vectorizer.vectorization_delete_trigger()
+RETURNS TRIGGER AS $$
+DECLARE
+    content_col TEXT;
+    chunk_table TEXT;
+    pk_col      TEXT;
+    pk_type     TEXT;
+    old_row     RECORD;
+    old_terms   TEXT[];
+    chunk_count INT;
+BEGIN
+    content_col := TG_ARGV[0];
+    chunk_table := TG_ARGV[1];
+    pk_col      := COALESCE(TG_ARGV[2], 'id');
+    pk_type     := COALESCE(TG_ARGV[3], 'bigint');
+
+    -- Decrement BM25 document frequencies first: the loop counts each
+    -- document's chunks, which is only possible while they still exist.
+    FOR old_row IN EXECUTE
+        format('SELECT %I::text AS pk_value, %I::text AS content FROM old_rows',
+               pk_col, content_col)
+    LOOP
+        IF old_row.content IS NULL OR trim(old_row.content) = '' THEN
+            CONTINUE;
+        END IF;
+
+        EXECUTE format(
+            'SELECT count(*)::int FROM %I WHERE source_id = $1::%s',
+            chunk_table, pk_type)
+        INTO chunk_count
+        USING old_row.pk_value;
+
+        IF chunk_count > 0 THEN
+            old_terms := pgedge_vectorizer.bm25_tokenize(trim(old_row.content));
+            PERFORM pgedge_vectorizer.bm25_decrement_idf_stats(
+                chunk_table, old_terms, chunk_count);
+        END IF;
+    END LOOP;
+
+    -- Remove queue entries for the doomed chunks, so the worker does not spend
+    -- embedding API calls on them.  'processing' rows are left alone, matching
+    -- the INSERT/UPDATE path: the worker copes with the chunk having gone.
+    EXECUTE format(
+        'DELETE FROM pgedge_vectorizer.queue
+          WHERE chunk_table = %L
+            AND status IN (''pending'', ''failed'')
+            AND chunk_id IN (
+                SELECT c.id FROM %I c
+                 WHERE c.source_id IN (SELECT o.%I::%s FROM old_rows o))',
+        chunk_table, chunk_table, pk_col, pk_type);
+
+    -- Finally the chunks themselves, which takes the embeddings with them.
+    EXECUTE format(
+        'DELETE FROM %I WHERE source_id IN (SELECT o.%I::%s FROM old_rows o)',
+        chunk_table, pk_col, pk_type);
+
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION pgedge_vectorizer.vectorization_delete_trigger IS
+'Statement-level AFTER DELETE trigger removing chunks, queue entries and BM25 statistics for deleted source rows';
+
+-- Statement-level trigger function cleaning up after TRUNCATE on a source table.
+--
+-- Truncating the source orphans every chunk, so there is no per-row work and no
+-- transition table (which TRUNCATE triggers cannot have in any case).  Resetting
+-- _idf_stats wholesale is right because the corpus becomes empty, and mirrors
+-- what recreate_chunks() does when rebuilding from scratch.
+CREATE FUNCTION pgedge_vectorizer.vectorization_truncate_trigger()
+RETURNS TRIGGER AS $$
+DECLARE
+    chunk_table TEXT;
+BEGIN
+    chunk_table := TG_ARGV[0];
+
+    EXECUTE format(
+        'DELETE FROM pgedge_vectorizer.queue
+          WHERE chunk_table = %L AND status IN (''pending'', ''failed'')',
+        chunk_table);
+
+    EXECUTE format('TRUNCATE TABLE %I', chunk_table);
+
+    IF to_regclass(chunk_table || '_idf_stats') IS NOT NULL THEN
+        EXECUTE format('TRUNCATE TABLE %I', chunk_table || '_idf_stats');
+    END IF;
+
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION pgedge_vectorizer.vectorization_truncate_trigger IS
+'Statement-level AFTER TRUNCATE trigger emptying the chunk table, its queue entries and its BM25 statistics';
+
+-- Trigger function for vectorization
+CREATE FUNCTION pgedge_vectorizer.vectorization_trigger()
+RETURNS TRIGGER AS $$
+DECLARE
+    content_col TEXT;
+    chunk_table TEXT;
+    strategy TEXT;
+    chunk_sz INT;
+    overlap INT;
+    pk_col TEXT;
+    pk_type TEXT;
+    doc_content TEXT;
+    chunks TEXT[];
+    chunk_text TEXT;
+    i INT;
+    chunk_id BIGINT;
+    source_id_val TEXT;
+    deleted_chunks_count INT := 0;
+BEGIN
+    -- Extract trigger arguments
+    content_col := TG_ARGV[0];
+    chunk_table := TG_ARGV[1];
+    strategy := TG_ARGV[2];
+    chunk_sz := TG_ARGV[3]::INT;
+    overlap := TG_ARGV[4]::INT;
+    pk_col := COALESCE(TG_ARGV[5], 'id');
+    pk_type := COALESCE(TG_ARGV[6], 'bigint');
+
+    -- Get source document ID
+    EXECUTE format('SELECT ($1).%I', pk_col) USING NEW INTO source_id_val;
+
+    -- Get document content
+    EXECUTE format('SELECT $1.%I', content_col) USING NEW INTO doc_content;
+
+    -- Trim whitespace for empty check
+    IF doc_content IS NOT NULL THEN
+        doc_content := trim(doc_content);
+    END IF;
+
+    -- Skip if content unchanged (on UPDATE)
+    IF TG_OP = 'UPDATE' THEN
+        DECLARE
+            old_content TEXT;
+        BEGIN
+            EXECUTE format('SELECT $1.%I', content_col) USING OLD INTO old_content;
+            IF old_content IS NOT NULL THEN
+                old_content := trim(old_content);
+            END IF;
+            IF doc_content = old_content OR (doc_content IS NULL AND old_content IS NULL) THEN
+                RETURN NEW;
+            END IF;
+        END;
+    END IF;
+
+    -- On UPDATE, decrement IDF stats for the old document's terms before
+    -- deleting the old chunks.  This prevents doc_freq from drifting upward
+    -- when the worker later re-increments stats for the new chunks.
+    IF TG_OP = 'UPDATE' THEN
+        DECLARE
+            old_terms TEXT[];
+            old_content_for_idf TEXT;
+        BEGIN
+            EXECUTE format('SELECT $1.%I', content_col) USING OLD INTO old_content_for_idf;
+            IF old_content_for_idf IS NOT NULL THEN
+                old_content_for_idf := trim(old_content_for_idf);
+            END IF;
+            IF old_content_for_idf IS NOT NULL AND old_content_for_idf <> '' THEN
+                old_terms := pgedge_vectorizer.bm25_tokenize(old_content_for_idf);
+                EXECUTE format(
+                    'SELECT count(*)::int FROM %I WHERE source_id = $1::%s',
+                    chunk_table, pk_type
+                )
+                INTO deleted_chunks_count
+                USING source_id_val;
+
+                PERFORM pgedge_vectorizer.bm25_decrement_idf_stats(
+                    chunk_table, old_terms, deleted_chunks_count);
+            END IF;
+        END;
+    END IF;
+
+    -- Delete queue entries for this document's chunks before deleting the chunks.
+    -- Prevents orphaned queue entries that waste embedding API calls on deleted chunks.
+    -- Only targets 'pending'/'failed'; 'processing' items are left for the
+    -- worker to handle gracefully via its SPI_processed == 0 check.
+    EXECUTE format(
+        'DELETE FROM pgedge_vectorizer.queue
+         WHERE chunk_table = %L
+           AND chunk_id IN (SELECT id FROM %I WHERE source_id = $1::%s)
+           AND status IN (''pending'', ''failed'')',
+        chunk_table, chunk_table, pk_type)
+        USING source_id_val;
+
+    -- Delete existing chunks for this document
+    -- pk_type uses %s: value from format_type() is system-controlled (see enable_vectorization)
+    EXECUTE format('DELETE FROM %I WHERE source_id = $1::%s', chunk_table, pk_type)
+        USING source_id_val;
+
+    -- Skip if content is NULL or empty (after deleting old chunks)
+    IF doc_content IS NULL OR doc_content = '' THEN
+        RETURN NEW;
+    END IF;
+
+    -- Chunk the document
+    chunks := pgedge_vectorizer.chunk_text(doc_content, strategy, chunk_sz, overlap);
+
+    -- Insert chunks and queue for embedding
+    FOR i IN 1..array_length(chunks, 1) LOOP
+        chunk_text := chunks[i];
+
+        -- Insert chunk
+        EXECUTE format('
+            INSERT INTO %I (source_id, chunk_index, content, token_count)
+            VALUES ($1::%s, $2, $3, $4)
+            RETURNING id', chunk_table, pk_type)
+        USING source_id_val, i, chunk_text,
+              pgedge_vectorizer.count_tokens(chunk_text)
+        INTO chunk_id;
+
+        -- Queue for embedding
+        INSERT INTO pgedge_vectorizer.queue (chunk_id, chunk_table, content, max_attempts)
+        VALUES (chunk_id, chunk_table, chunk_text,
+                current_setting('pgedge_vectorizer.max_retries')::INT);
+    END LOOP;
+
+    -- Notify workers (they will pick up work via polling and SKIP LOCKED)
+    PERFORM pg_notify('pgedge_vectorizer_queue', source_id_val::TEXT);
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION pgedge_vectorizer.vectorization_trigger IS
+'Trigger function that chunks text and queues for vectorization';
+
+---------------------------------------------------------------------------
+-- Views for monitoring
+---------------------------------------------------------------------------
+
+-- Queue status summary
+CREATE VIEW pgedge_vectorizer.queue_status AS
+SELECT
+    chunk_table,
+    status,
+    COUNT(*) as count,
+    MIN(created_at) as oldest,
+    MAX(created_at) as newest,
+    AVG(EXTRACT(EPOCH FROM (COALESCE(processed_at, NOW()) - created_at))) as avg_processing_time_secs
+FROM pgedge_vectorizer.queue
+GROUP BY chunk_table, status
+ORDER BY chunk_table, status;
+
+COMMENT ON VIEW pgedge_vectorizer.queue_status IS
+'Summary of queue items by table and status';
+
+-- Failed items view
+CREATE VIEW pgedge_vectorizer.failed_items AS
+SELECT
+    id,
+    chunk_table,
+    chunk_id,
+    attempts,
+    max_attempts,
+    error_message,
+    created_at,
+    next_retry_at,
+    LEFT(content, 100) as content_preview,
+    rate_limit_deferrals
+FROM pgedge_vectorizer.queue
+WHERE status = 'failed'
+ORDER BY created_at DESC;
+
+COMMENT ON VIEW pgedge_vectorizer.failed_items IS
+'Failed queue items with error details';
+
+-- Pending items count
+CREATE VIEW pgedge_vectorizer.pending_count AS
+SELECT
+    COUNT(*) as pending_items,
+    COUNT(DISTINCT chunk_table) as affected_tables
+FROM pgedge_vectorizer.queue
+WHERE status = 'pending';
+
+COMMENT ON VIEW pgedge_vectorizer.pending_count IS
+'Count of pending items waiting for processing';
+
+---------------------------------------------------------------------------
+-- Utility functions
+---------------------------------------------------------------------------
+
+-- Retry failed items
+CREATE FUNCTION pgedge_vectorizer.retry_failed(
+    max_age_hours INT DEFAULT 24
+) RETURNS INT AS $$
+DECLARE
+    rows_affected INT;
+BEGIN
+    UPDATE pgedge_vectorizer.queue
+    SET status = 'pending',
+        attempts = 0,
+        error_message = NULL,
+        next_retry_at = NULL,
+        rate_limit_deferrals = 0
+    WHERE status = 'failed'
+      AND attempts < max_attempts
+      AND created_at > NOW() - (max_age_hours || ' hours')::INTERVAL;
+
+    GET DIAGNOSTICS rows_affected = ROW_COUNT;
+    RETURN rows_affected;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION pgedge_vectorizer.retry_failed IS
+'Reset failed items to pending for retry';
+
+-- Clear completed items
+CREATE FUNCTION pgedge_vectorizer.clear_completed(
+    older_than_hours INT DEFAULT 24
+) RETURNS INT AS $$
+DECLARE
+    rows_affected INT;
+BEGIN
+    DELETE FROM pgedge_vectorizer.queue
+    WHERE status = 'completed'
+      AND processed_at < NOW() - (older_than_hours || ' hours')::INTERVAL;
+
+    GET DIAGNOSTICS rows_affected = ROW_COUNT;
+    RETURN rows_affected;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION pgedge_vectorizer.clear_completed IS
+'Remove old completed items from the queue';
+
+-- Reprocess chunks that don't have embeddings
+CREATE FUNCTION pgedge_vectorizer.reprocess_chunks(
+    chunk_table_name TEXT
+) RETURNS INT AS $$
+DECLARE
+    rows_affected INT := 0;
+    chunk_record RECORD;
+    hybrid_enabled BOOLEAN;
+BEGIN
+    hybrid_enabled := COALESCE(
+        current_setting('pgedge_vectorizer.enable_hybrid', true),
+        'false'
+    )::BOOLEAN;
+
+    -- Queue chunks that need dense embeddings, and when hybrid is enabled,
+    -- also queue chunks missing sparse embeddings.
+    FOR chunk_record IN EXECUTE format(
+        'SELECT id, content, (embedding IS NULL) AS needs_embedding, '
+        '       (sparse_embedding IS NULL) AS needs_sparse '
+        'FROM %I '
+        'WHERE embedding IS NULL '
+        '   OR (sparse_embedding IS NULL AND %L::boolean)',
+        chunk_table_name,
+        hybrid_enabled
+    )
+    LOOP
+        -- Check if already queued
+        PERFORM 1 FROM pgedge_vectorizer.queue
+        WHERE chunk_id = chunk_record.id
+          AND chunk_table = chunk_table_name
+          AND status IN ('pending', 'processing');
+
+        -- Only queue if not already queued
+        IF NOT FOUND THEN
+            INSERT INTO pgedge_vectorizer.queue (chunk_id, chunk_table, content, metadata, max_attempts)
+            VALUES (
+                chunk_record.id,
+                chunk_table_name,
+                chunk_record.content,
+                CASE
+                    WHEN NOT chunk_record.needs_embedding AND chunk_record.needs_sparse
+                        THEN jsonb_build_object('sparse_only', true)
+                    ELSE NULL
+                END,
+                current_setting('pgedge_vectorizer.max_retries')::INT
+            );
+
+            rows_affected := rows_affected + 1;
+        END IF;
+    END LOOP;
+
+    RAISE NOTICE 'Queued % chunks from % for processing', rows_affected, chunk_table_name;
+    RETURN rows_affected;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION pgedge_vectorizer.reprocess_chunks IS
+'Queue existing chunks without embeddings for processing';
+
+-- Recreate all chunks from scratch
+CREATE FUNCTION pgedge_vectorizer.recreate_chunks(
+    source_table_name REGCLASS,
+    source_column_name NAME
+) RETURNS INT AS $$
+DECLARE
+    chunk_table_name TEXT;
+    rows_affected INT := 0;
+    trigger_name TEXT;
+    trigger_exists BOOLEAN;
+BEGIN
+    -- Prefer authoritative mapping from vectorizers registry.
+    SELECT v.chunk_table
+    INTO chunk_table_name
+    FROM pgedge_vectorizer.vectorizers v
+    WHERE v.source_table = source_table_name::TEXT
+      AND v.source_column = source_column_name;
+
+    -- Fallback to legacy default naming if no registry row exists.
+    IF chunk_table_name IS NULL THEN
+        chunk_table_name := source_table_name::TEXT || '_' || source_column_name || '_chunks';
+    END IF;
+
+    -- Verify chunk table exists
+    IF to_regclass(chunk_table_name) IS NULL THEN
+        RAISE EXCEPTION 'Chunk table % does not exist. Use enable_vectorization() first.', chunk_table_name;
+    END IF;
+
+    -- Verify trigger exists
+    trigger_name := source_table_name::TEXT || '_' || source_column_name || '_vectorization_trigger';
+    SELECT EXISTS (
+        SELECT 1 FROM pg_trigger t
+        JOIN pg_class c ON t.tgrelid = c.oid
+        WHERE c.oid = source_table_name
+        AND t.tgname = trigger_name
+    ) INTO trigger_exists;
+
+    IF NOT trigger_exists THEN
+        RAISE EXCEPTION 'Vectorization trigger % does not exist. Use enable_vectorization() first.', trigger_name;
+    END IF;
+
+    RAISE NOTICE 'Recreating chunks for %.% -> %', source_table_name, source_column_name, chunk_table_name;
+
+    -- Delete all existing chunks and reset IDF stats.
+    -- Truncating _idf_stats is safe here because recreate_chunks rebuilds
+    -- all chunks from scratch; the worker will repopulate IDF stats as it
+    -- processes the newly queued chunks.
+    EXECUTE format('DELETE FROM %I', chunk_table_name);
+    EXECUTE format('TRUNCATE TABLE %I', chunk_table_name || '_idf_stats');
+    GET DIAGNOSTICS rows_affected = ROW_COUNT;
+    RAISE NOTICE 'Deleted % existing chunks', rows_affected;
+
+    -- Delete all queue items for this chunk table (with retry logic)
+    BEGIN
+        -- Try to delete with a lock timeout
+        SET LOCAL lock_timeout = '5s';
+        DELETE FROM pgedge_vectorizer.queue WHERE chunk_table = chunk_table_name;
+        RAISE NOTICE 'Cleared queue for %', chunk_table_name;
+    EXCEPTION WHEN lock_not_available OR deadlock_detected THEN
+        -- If we can't get the lock, just mark them for cleanup
+        RAISE WARNING 'Could not clear queue due to concurrent access, continuing anyway';
+    END;
+
+    -- Manually process each row to bypass trigger's unchanged-content optimization
+    DECLARE
+        row_record RECORD;
+        doc_content TEXT;
+        chunks TEXT[];
+        chunk_text TEXT;
+        i INT;
+        chunk_id BIGINT;
+        rows_processed INT := 0;
+        actual_strategy TEXT;
+        actual_chunk_size INT;
+        actual_chunk_overlap INT;
+        pk_col TEXT;
+        pk_type TEXT;
+    BEGIN
+        -- Get chunking configuration from trigger arguments
+        -- In PostgreSQL 17+, tgargs is bytea and needs to be decoded
+        DECLARE
+            tgargs_array TEXT[];
+        BEGIN
+            SELECT string_to_array(encode(t.tgargs, 'escape'), E'\\000')
+            INTO tgargs_array
+            FROM pg_trigger t
+            JOIN pg_class c ON t.tgrelid = c.oid
+            WHERE c.oid = source_table_name
+            AND t.tgname = trigger_name;
+
+            -- Arguments: 1=content_col, 2=chunk_table, 3=strategy, 4=size, 5=overlap, 6=pk_col, 7=pk_type
+            actual_strategy := tgargs_array[3];
+            actual_chunk_size := tgargs_array[4]::INT;
+            actual_chunk_overlap := tgargs_array[5]::INT;
+            pk_col := COALESCE(tgargs_array[6], 'id');
+            pk_type := COALESCE(tgargs_array[7], 'bigint');
+        END;
+
+        RAISE NOTICE 'Re-chunking with strategy=%, size=%, overlap=%',
+            actual_strategy, actual_chunk_size, actual_chunk_overlap;
+
+        -- pk_val is cast to text so that row_record.pk_val is always the same
+        -- type across calls in a session, whatever the source table's actual
+        -- primary key type. See the identical comment in enable_vectorization()
+        -- for why: PL/pgSQL fixes a RECORD field's parameter type the first
+        -- time a dynamic EXECUTE ... USING statement evaluates it, and this
+        -- statement's own "$1::%s" cast below does not protect it, because
+        -- that cast is applied after PostgreSQL has already bound the record
+        -- field's raw runtime type (issue #39).
+        FOR row_record IN EXECUTE format(
+            'SELECT %I::text as pk_val, %I as content FROM %s WHERE %I IS NOT NULL AND %I != ''''',
+            pk_col, source_column_name, source_table_name, source_column_name, source_column_name
+        )
+        LOOP
+            doc_content := row_record.content;
+
+            -- Chunk the document
+            chunks := pgedge_vectorizer.chunk_text(doc_content, actual_strategy, actual_chunk_size, actual_chunk_overlap);
+
+            -- Insert chunks and queue for embedding
+            FOR i IN 1..array_length(chunks, 1) LOOP
+                chunk_text := chunks[i];
+
+                -- Insert chunk
+                -- pk_type uses %s: value from format_type() is system-controlled (see enable_vectorization)
+                EXECUTE format('
+                    INSERT INTO %I (source_id, chunk_index, content, token_count)
+                    VALUES ($1::%s, $2, $3, $4)
+                    RETURNING id', chunk_table_name, pk_type)
+                USING row_record.pk_val, i, chunk_text,
+                      pgedge_vectorizer.count_tokens(chunk_text)
+                INTO chunk_id;
+
+                -- Queue for embedding
+                INSERT INTO pgedge_vectorizer.queue (chunk_id, chunk_table, content, max_attempts)
+                VALUES (chunk_id, chunk_table_name, chunk_text,
+                        current_setting('pgedge_vectorizer.max_retries')::INT);
+            END LOOP;
+
+            rows_processed := rows_processed + 1;
+        END LOOP;
+
+        RAISE NOTICE 'Processed % rows', rows_processed;
+        RETURN rows_processed;
+    END;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION pgedge_vectorizer.recreate_chunks IS
+'Delete all chunks and recreate from source table (complete rebuild)';
+
+-- Get configuration summary
+CREATE FUNCTION pgedge_vectorizer.show_config()
+RETURNS TABLE (
+    setting TEXT,
+    value TEXT
+) AS $$
+BEGIN
+    RETURN QUERY
+    SELECT
+        name::TEXT as setting,
+        current_setting(name)::TEXT as value
+    FROM pg_settings
+    WHERE name LIKE 'pgedge_vectorizer.%'
+    ORDER BY name;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION pgedge_vectorizer.show_config IS
+'Show all pgedge_vectorizer configuration settings';
+
+---------------------------------------------------------------------------
+-- Grants (for non-superuser usage - optional)
+---------------------------------------------------------------------------
+
+-- Grant usage on schema to public (optional - comment out if not desired)
+-- GRANT USAGE ON SCHEMA pgedge_vectorizer TO PUBLIC;
+-- GRANT SELECT ON ALL TABLES IN SCHEMA pgedge_vectorizer TO PUBLIC;
+-- GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA pgedge_vectorizer TO PUBLIC;
+-- hybrid.sql
+-- Hybrid BM25 + dense vector search using Reciprocal Rank Fusion (RRF).
+--
+-- Requires: pgedge_vectorizer.enable_hybrid = true in postgresql.conf
+-- and pgvector >= 0.7.0 for sparsevec support.
+
+---------------------------------------------------------------------------
+-- hybrid_search() — main user-facing function
+---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION pgedge_vectorizer.hybrid_search(
+    p_source_table   REGCLASS,
+    p_query          TEXT,
+    p_limit          INT     DEFAULT 10,
+    p_alpha          FLOAT8  DEFAULT 0.7,
+    p_rrf_k          INT     DEFAULT 60,
+    p_source_column  NAME    DEFAULT NULL
+)
+RETURNS TABLE (
+    source_id   TEXT,
+    chunk       TEXT,
+    dense_rank  INT,
+    sparse_rank INT,
+    rrf_score   FLOAT8
+)
+LANGUAGE plpgsql AS $$
+DECLARE
+    v_chunk_table  TEXT;
+    v_query_dense  vector;
+    v_query_sparse sparsevec;
+BEGIN
+    IF COALESCE(current_setting('pgedge_vectorizer.enable_hybrid', true), 'false')::boolean IS NOT TRUE THEN
+        RAISE EXCEPTION
+            'Hybrid search is disabled. Set pgedge_vectorizer.enable_hybrid = true and allow workers to populate sparse_embedding.';
+    END IF;
+
+    -- Look up the chunk table from the vectorizers registry.
+    -- When p_source_column is provided, use the exact mapping.
+    -- When NULL, raise an exception if the table has more than one
+    -- vectorized column to avoid silently returning results from the
+    -- wrong chunk table.
+    IF p_source_column IS NOT NULL THEN
+        SELECT vz.chunk_table INTO v_chunk_table
+        FROM pgedge_vectorizer.vectorizers vz
+        WHERE vz.source_table = p_source_table::TEXT
+          AND vz.source_column = p_source_column;
+    ELSE
+        SELECT vz.chunk_table INTO v_chunk_table
+        FROM pgedge_vectorizer.vectorizers vz
+        WHERE vz.source_table = p_source_table::TEXT
+        LIMIT 1;
+
+        IF v_chunk_table IS NOT NULL AND
+           (SELECT count(*) FROM pgedge_vectorizer.vectorizers
+            WHERE source_table = p_source_table::TEXT) > 1
+        THEN
+            RAISE EXCEPTION
+                'Table % has multiple vectorized columns. '
+                'Pass p_source_column to disambiguate.',
+                p_source_table;
+        END IF;
+    END IF;
+
+    IF v_chunk_table IS NULL THEN
+        RAISE EXCEPTION
+            'No vectorizer found for table %. '
+            'Call pgedge_vectorizer.enable_vectorization() first.',
+            p_source_table;
+    END IF;
+
+    -- Generate dense query vector via the existing C function
+    v_query_dense := pgedge_vectorizer.generate_embedding(p_query);
+
+    -- Generate sparse BM25 query vector
+    v_query_sparse := pgedge_vectorizer.bm25_query_vector(
+                          p_query, v_chunk_table);
+
+    -- Run both ranked lists and merge with Reciprocal Rank Fusion.
+    -- Join on chunk id (not source_id) to avoid mixing unrelated chunks
+    -- from the same document.  source_id is cast to TEXT to support
+    -- arbitrary PK types (BIGINT, UUID, VARCHAR, etc.).
+    RETURN QUERY EXECUTE format($sql$
+        WITH dense_candidates AS (
+            SELECT
+                id,
+                source_id::text AS source_id,
+                content AS chunk,
+                embedding <=> %L::vector AS dist
+            FROM %I
+            WHERE embedding IS NOT NULL
+            ORDER BY dist
+            LIMIT %s * 3
+        ),
+        dense AS (
+            SELECT
+                id,
+                source_id,
+                chunk,
+                ROW_NUMBER() OVER (ORDER BY dist) AS rnk
+            FROM dense_candidates
+        ),
+        sparse_candidates AS (
+            SELECT
+                id,
+                source_id::text AS source_id,
+                content AS chunk,
+                sparse_embedding <#> %L::sparsevec AS dist
+            FROM %I
+            WHERE sparse_embedding IS NOT NULL
+            ORDER BY dist ASC
+            LIMIT %s * 3
+        ),
+        sparse AS (
+            SELECT
+                id,
+                source_id,
+                chunk,
+                ROW_NUMBER() OVER (ORDER BY dist ASC) AS rnk
+            FROM sparse_candidates
+        ),
+        merged AS (
+            SELECT
+                COALESCE(d.source_id, s.source_id)  AS source_id,
+                COALESCE(d.chunk,     s.chunk)       AS chunk,
+                COALESCE(d.rnk, 9999)::INT           AS dense_rank,
+                COALESCE(s.rnk, 9999)::INT           AS sparse_rank,
+                (
+                      %s::float8  / (%s + COALESCE(d.rnk, 9999))
+                    + (1.0 - %s::float8) / (%s + COALESCE(s.rnk, 9999))
+                )                                    AS rrf_score
+            FROM dense d
+            FULL OUTER JOIN sparse s USING (id)
+        )
+        SELECT
+            source_id,
+            chunk,
+            dense_rank,
+            sparse_rank,
+            rrf_score
+        FROM merged
+        ORDER BY rrf_score DESC
+        LIMIT %s
+    $sql$,
+        v_query_dense,   v_chunk_table, p_limit,
+        v_query_sparse,  v_chunk_table, p_limit,
+        p_alpha, p_rrf_k,
+        p_alpha, p_rrf_k,
+        p_limit
+    );
+END;
+$$;
+
+COMMENT ON FUNCTION pgedge_vectorizer.hybrid_search IS
+'Hybrid BM25 + dense vector search using Reciprocal Rank Fusion.
+ p_alpha controls the weight of dense results (0 = pure sparse, 1 = pure dense).
+ p_rrf_k is the RRF rank smoothing constant (default 60).
+ Requires pgedge_vectorizer.enable_hybrid = true in postgresql.conf.';
+
+---------------------------------------------------------------------------
+-- hybrid_search_simple() — convenience wrapper
+---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION pgedge_vectorizer.hybrid_search_simple(
+    p_source_table  REGCLASS,
+    p_query         TEXT,
+    p_limit         INT  DEFAULT 10,
+    p_source_column NAME DEFAULT NULL
+)
+RETURNS TABLE (
+    source_id  TEXT,
+    chunk      TEXT,
+    rrf_score  FLOAT8
+)
+LANGUAGE sql AS $$
+    SELECT source_id, chunk, rrf_score
+    FROM pgedge_vectorizer.hybrid_search(
+             p_source_table, p_query, p_limit,
+             p_source_column => p_source_column);
+$$;
+
+COMMENT ON FUNCTION pgedge_vectorizer.hybrid_search_simple IS
+'Convenience wrapper for hybrid_search() returning only source_id, chunk, and rrf_score';

--- a/sql/pgedge_vectorizer--1.2.sql
+++ b/sql/pgedge_vectorizer--1.2.sql
@@ -1008,6 +1008,142 @@ COMMENT ON VIEW pgedge_vectorizer.pending_count IS
 'Count of pending items waiting for processing';
 
 ---------------------------------------------------------------------------
+-- Vectorizer status: how far behind the embeddings are
+--
+-- Embeddings are derived data generated asynchronously, so there is always
+-- some lag between a source change and the embedding catching up. This
+-- reports, per vectorizer, how much of the source is embedded and how much
+-- work is outstanding, so that a user can tell whether a search result set
+-- reflects recent changes and an operator can spot a stalled worker.
+--
+-- The chunk tables are named in the registry rather than joined statically,
+-- so the counts have to be gathered with dynamic SQL rather than expressed
+-- as a plain view. Each row costs a scan of one chunk table and a count of
+-- one source table, which is considerably more than the queue views cost;
+-- it is a diagnostic to run when you want an answer, not something to put
+-- on a dashboard refreshing every second.
+---------------------------------------------------------------------------
+
+CREATE FUNCTION pgedge_vectorizer.vectorizer_status(
+    p_source_table  REGCLASS DEFAULT NULL,
+    p_source_column NAME DEFAULT NULL
+) RETURNS TABLE (
+    source_table        TEXT,
+    source_column       NAME,
+    chunk_table         TEXT,
+    source_rows         BIGINT,
+    source_rows_covered BIGINT,
+    source_coverage     NUMERIC,
+    chunks_total        BIGINT,
+    chunks_embedded     BIGINT,
+    chunk_coverage      NUMERIC,
+    queue_pending       BIGINT,
+    queue_processing    BIGINT,
+    queue_failed        BIGINT,
+    oldest_pending_age  INTERVAL,
+    last_processed_at   TIMESTAMPTZ
+) AS $$
+DECLARE
+    v            RECORD;
+    src_oid      OID;
+    chunk_oid    OID;
+BEGIN
+    FOR v IN
+        SELECT r.source_table, r.source_column, r.chunk_table
+          FROM pgedge_vectorizer.vectorizers r
+         WHERE (p_source_table IS NULL
+                OR to_regclass(r.source_table) = p_source_table)
+           AND (p_source_column IS NULL OR r.source_column = p_source_column)
+         ORDER BY r.source_table, r.source_column
+    LOOP
+        source_table  := v.source_table;
+        source_column := v.source_column;
+        chunk_table   := v.chunk_table;
+
+        source_rows         := NULL;
+        source_rows_covered := NULL;
+        source_coverage     := NULL;
+        chunks_total        := NULL;
+        chunks_embedded     := NULL;
+        chunk_coverage      := NULL;
+
+        /*
+         * Queue figures first: they come from a table the caller can always
+         * read, and they are the half that stays meaningful even when the
+         * chunk or source table has been dropped from under the registry.
+         *
+         * last_processed_at only reflects queue rows that still exist, so
+         * clear_completed() will move it backwards. That is a property of
+         * the queue, not of the embeddings, and is documented as such.
+         */
+        SELECT count(*) FILTER (WHERE q.status = 'pending'),
+               count(*) FILTER (WHERE q.status = 'processing'),
+               count(*) FILTER (WHERE q.status = 'failed'),
+               NOW() - min(q.created_at) FILTER (WHERE q.status = 'pending'),
+               max(q.processed_at)
+          INTO queue_pending, queue_processing, queue_failed,
+               oldest_pending_age, last_processed_at
+          FROM pgedge_vectorizer.queue q
+         WHERE q.chunk_table = v.chunk_table;
+
+        /*
+         * The counts below read user tables, and the function runs as the
+         * caller. A table that has been dropped, or that the caller cannot
+         * read, leaves the corresponding columns NULL rather than failing
+         * the whole result set: one inaccessible vectorizer should not make
+         * the view useless for every other one.
+         */
+        chunk_oid := to_regclass(v.chunk_table);
+        IF chunk_oid IS NOT NULL
+           AND has_table_privilege(chunk_oid, 'SELECT') THEN
+            EXECUTE format(
+                'SELECT count(*),
+                        count(*) FILTER (WHERE embedding IS NOT NULL),
+                        count(DISTINCT source_id)
+                            FILTER (WHERE embedding IS NOT NULL)
+                   FROM %s', chunk_oid::REGCLASS)
+              INTO chunks_total, chunks_embedded, source_rows_covered;
+
+            IF chunks_total > 0 THEN
+                chunk_coverage := round(chunks_embedded::NUMERIC
+                                        / chunks_total, 4);
+            END IF;
+        END IF;
+
+        src_oid := to_regclass(v.source_table);
+        IF src_oid IS NOT NULL
+           AND has_table_privilege(src_oid, 'SELECT') THEN
+            EXECUTE format('SELECT count(*) FROM %s', src_oid::REGCLASS)
+              INTO source_rows;
+
+            /*
+             * A coverage above 1 means the chunk table holds rows for source
+             * rows that are gone, which is worth seeing rather than hiding
+             * behind a clamp to 1.
+             */
+            IF source_rows > 0 AND source_rows_covered IS NOT NULL THEN
+                source_coverage := round(source_rows_covered::NUMERIC
+                                         / source_rows, 4);
+            END IF;
+        END IF;
+
+        RETURN NEXT;
+    END LOOP;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION pgedge_vectorizer.vectorizer_status IS
+'Embedding coverage and queue backlog for the registered vectorizers, '
+'optionally narrowed to one source table or one source column. Scans the '
+'chunk and source tables, so it costs considerably more than the queue views';
+
+CREATE VIEW pgedge_vectorizer.vectorizer_status AS
+SELECT * FROM pgedge_vectorizer.vectorizer_status(NULL, NULL);
+
+COMMENT ON VIEW pgedge_vectorizer.vectorizer_status IS
+'Embedding coverage and queue backlog for every registered vectorizer';
+
+---------------------------------------------------------------------------
 -- Utility functions
 ---------------------------------------------------------------------------
 

--- a/src/pgedge_vectorizer.h
+++ b/src/pgedge_vectorizer.h
@@ -181,6 +181,7 @@ extern EmbeddingProvider GeminiProvider;
 
 /* tokenizer.c */
 int count_tokens(const char *text, const char *model);
+Datum pgedge_vectorizer_count_tokens(PG_FUNCTION_ARGS);
 int *tokenize_text(const char *text, const char *model, int *token_count);
 char *detokenize_tokens(const int *tokens, int token_count, const char *model);
 int get_char_offset_for_tokens(const char *text, int target_tokens, const char *model);

--- a/src/tokenizer.c
+++ b/src/tokenizer.c
@@ -58,6 +58,24 @@ count_tokens(const char *text, const char *model)
 }
 
 /*
+ * SQL-callable wrapper around count_tokens()
+ *
+ * Exposed so that the plpgsql chunking paths compute token_count with exactly
+ * the same rule as the C chunker, rather than open-coding the approximation
+ * and disagreeing with it by a token.
+ */
+PG_FUNCTION_INFO_V1(pgedge_vectorizer_count_tokens);
+
+Datum
+pgedge_vectorizer_count_tokens(PG_FUNCTION_ARGS)
+{
+	text	   *input = PG_GETARG_TEXT_PP(0);
+	const char *text_str = TextDatumGetCString(PointerGetDatum(input));
+
+	PG_RETURN_INT32(count_tokens(text_str, pgedge_vectorizer_model));
+}
+
+/*
  * Tokenize text into token IDs
  *
  * This is a placeholder for tiktoken integration.

--- a/test/expected/count_tokens.out
+++ b/test/expected/count_tokens.out
@@ -1,0 +1,157 @@
+-- count_tokens test
+--
+-- count_tokens() exposes the estimate the C chunking code has always used, so
+-- that the plpgsql paths which write the token_count column can call it rather
+-- than open-coding the same rule and rounding it the other way. The point of
+-- the tests below is therefore as much the agreement between the two as the
+-- values themselves.
+---------------------------------------------------------------------------
+-- The estimate itself: UTF-8 characters divided by four, rounded up
+---------------------------------------------------------------------------
+-- 11 characters, so 3 tokens.
+SELECT pgedge_vectorizer.count_tokens('hello world') AS eleven_chars;
+ eleven_chars 
+--------------
+            3
+(1 row)
+
+-- Exactly 4 characters is exactly 1 token; anything shorter still rounds up
+-- to 1, which is the difference from the truncating arithmetic this replaces.
+SELECT pgedge_vectorizer.count_tokens('test') AS four_chars,
+       pgedge_vectorizer.count_tokens('abc')  AS three_chars,
+       pgedge_vectorizer.count_tokens('a')    AS one_char;
+ four_chars | three_chars | one_char 
+------------+-------------+----------
+          1 |           1 |        1
+(1 row)
+
+-- Empty text is the one case that is genuinely zero.
+SELECT pgedge_vectorizer.count_tokens('') AS empty;
+ empty 
+-------
+     0
+(1 row)
+
+-- STRICT, so NULL in, NULL out.
+SELECT pgedge_vectorizer.count_tokens(NULL) IS NULL AS null_is_null;
+ null_is_null 
+--------------
+ t
+(1 row)
+
+-- Characters, not bytes: four Han characters are twelve bytes but one token.
+SELECT pgedge_vectorizer.count_tokens('你好世界') AS four_han_chars,
+       octet_length('你好世界') AS bytes;
+ four_han_chars | bytes 
+----------------+-------
+              1 |    12
+(1 row)
+
+-- Declared STABLE rather than IMMUTABLE: the estimate is defined in terms of
+-- pgedge_vectorizer.model, which will matter once the counter is model-aware,
+-- and an index or cached plan built on an IMMUTABLE promise would then be
+-- wrong. Pin the volatility so that cannot be relaxed by accident.
+SELECT provolatile
+  FROM pg_proc
+ WHERE proname = 'count_tokens'
+   AND pronamespace = 'pgedge_vectorizer'::regnamespace;
+ provolatile 
+-------------
+ s
+(1 row)
+
+---------------------------------------------------------------------------
+-- Agreement with what the chunking paths store
+---------------------------------------------------------------------------
+CREATE TABLE count_tokens_docs (
+    id      BIGSERIAL PRIMARY KEY,
+    content TEXT
+);
+-- Chunks written by enable_vectorization() back-filling an existing table.
+INSERT INTO count_tokens_docs (content)
+VALUES ('abc'),
+       ('Short document.'),
+       (repeat('The quick brown fox jumps over the lazy dog. ', 20));
+SELECT pgedge_vectorizer.enable_vectorization(
+    'count_tokens_docs'::regclass,
+    'content',
+    'token_based',
+    100,
+    10,
+    1536
+);
+NOTICE:  Using primary key column: id (bigint)
+NOTICE:  column "sparse_embedding" of relation "count_tokens_docs_content_chunks" already exists, skipping
+NOTICE:  Vectorization enabled: count_tokens_docs -> count_tokens_docs_content_chunks
+NOTICE:  Strategy: token_based, chunk_size: 100, overlap: 10
+NOTICE:  Processing existing rows...
+NOTICE:  Processed 3 existing rows
+ enable_vectorization 
+----------------------
+ 
+(1 row)
+
+SELECT count(*) AS mismatched_on_backfill
+  FROM count_tokens_docs_content_chunks
+ WHERE token_count IS DISTINCT FROM pgedge_vectorizer.count_tokens(content);
+ mismatched_on_backfill 
+------------------------
+                      0
+(1 row)
+
+-- The three-character row is the regression: length('abc') / 4 stored 0, which
+-- the BM25 scoring path then had to clamp back up to 1.
+SELECT token_count AS short_row_token_count
+  FROM count_tokens_docs_content_chunks c
+  JOIN count_tokens_docs d ON d.id = c.source_id
+ WHERE d.content = 'abc';
+ short_row_token_count 
+-----------------------
+                     1
+(1 row)
+
+-- Chunks written by the insert trigger.
+INSERT INTO count_tokens_docs (content)
+VALUES ('xy'),
+       ('A document added after vectorization was enabled.');
+SELECT count(*) AS mismatched_on_insert
+  FROM count_tokens_docs_content_chunks
+ WHERE token_count IS DISTINCT FROM pgedge_vectorizer.count_tokens(content);
+ mismatched_on_insert 
+----------------------
+                    0
+(1 row)
+
+-- Chunks written by recreate_chunks().
+SELECT pgedge_vectorizer.recreate_chunks('count_tokens_docs'::regclass, 'content');
+NOTICE:  Recreating chunks for count_tokens_docs.content -> count_tokens_docs_content_chunks
+NOTICE:  Deleted 0 existing chunks
+NOTICE:  Cleared queue for count_tokens_docs_content_chunks
+NOTICE:  Re-chunking with strategy=token_based, size=100, overlap=10
+NOTICE:  Processed 5 rows
+ recreate_chunks 
+-----------------
+               5
+(1 row)
+
+SELECT count(*) AS mismatched_on_recreate
+  FROM count_tokens_docs_content_chunks
+ WHERE token_count IS DISTINCT FROM pgedge_vectorizer.count_tokens(content);
+ mismatched_on_recreate 
+------------------------
+                      0
+(1 row)
+
+---------------------------------------------------------------------------
+-- Cleanup
+---------------------------------------------------------------------------
+SELECT pgedge_vectorizer.disable_vectorization('count_tokens_docs'::regclass,
+                                               'content', TRUE);
+NOTICE:  Vectorization disabled and chunk table dropped: count_tokens_docs_content_chunks
+ disable_vectorization 
+-----------------------
+ 
+(1 row)
+
+DROP TABLE count_tokens_docs;
+DELETE FROM pgedge_vectorizer.queue;

--- a/test/expected/vectorizer_status.out
+++ b/test/expected/vectorizer_status.out
@@ -1,0 +1,224 @@
+-- vectorizer_status test
+--
+-- The view reports how far the embeddings are behind the source. Nothing in a
+-- regression run generates a real embedding, since that needs a provider, so
+-- the chunk rows are marked embedded by hand below to walk coverage from none
+-- through partial to complete. Timestamps and ages are deliberately not
+-- selected: they are wall-clock values and would differ on every run.
+CREATE TABLE vstatus_docs (
+    id      BIGSERIAL PRIMARY KEY,
+    body    TEXT
+);
+INSERT INTO vstatus_docs (body)
+VALUES ('The first document, which is long enough to be worth embedding.'),
+       ('The second document, on an unrelated subject entirely.'),
+       ('The third.');
+SELECT pgedge_vectorizer.enable_vectorization(
+    'vstatus_docs'::regclass,
+    'body',
+    'token_based',
+    100,
+    10,
+    1536
+);
+NOTICE:  Using primary key column: id (bigint)
+NOTICE:  column "sparse_embedding" of relation "vstatus_docs_body_chunks" already exists, skipping
+NOTICE:  Vectorization enabled: vstatus_docs -> vstatus_docs_body_chunks
+NOTICE:  Strategy: token_based, chunk_size: 100, overlap: 10
+NOTICE:  Processing existing rows...
+NOTICE:  Processed 3 existing rows
+ enable_vectorization 
+----------------------
+ 
+(1 row)
+
+---------------------------------------------------------------------------
+-- Nothing embedded yet: the whole chunk table is outstanding, and every
+-- chunk is sitting in the queue
+---------------------------------------------------------------------------
+SELECT source_table, source_column, chunk_table,
+       source_rows, source_rows_covered, source_coverage,
+       chunks_total, chunks_embedded, chunk_coverage,
+       queue_pending, queue_processing, queue_failed
+  FROM pgedge_vectorizer.vectorizer_status;
+ source_table | source_column |       chunk_table        | source_rows | source_rows_covered | source_coverage | chunks_total | chunks_embedded | chunk_coverage | queue_pending | queue_processing | queue_failed 
+--------------+---------------+--------------------------+-------------+---------------------+-----------------+--------------+-----------------+----------------+---------------+------------------+--------------
+ vstatus_docs | body          | vstatus_docs_body_chunks |           3 |                   0 |          0.0000 |            3 |               0 |         0.0000 |             3 |                0 |            0
+(1 row)
+
+-- An age is reported for the oldest pending item, and there is no processed
+-- timestamp yet. The values themselves are wall-clock, so only their
+-- presence is asserted.
+SELECT oldest_pending_age IS NOT NULL AS has_pending_age,
+       last_processed_at IS NULL      AS nothing_processed_yet
+  FROM pgedge_vectorizer.vectorizer_status;
+ has_pending_age | nothing_processed_yet 
+-----------------+-----------------------
+ t               | t
+(1 row)
+
+---------------------------------------------------------------------------
+-- Two chunks embedded: partial coverage, and the queue drains to match
+---------------------------------------------------------------------------
+UPDATE vstatus_docs_body_chunks
+   SET embedding = array_fill(0.1::real, ARRAY[1536])::vector
+ WHERE source_id IN (SELECT id FROM vstatus_docs ORDER BY id LIMIT 2);
+UPDATE pgedge_vectorizer.queue
+   SET status = 'completed', processed_at = NOW()
+ WHERE chunk_table = 'vstatus_docs_body_chunks'
+   AND chunk_id IN (SELECT id FROM vstatus_docs_body_chunks
+                     WHERE embedding IS NOT NULL);
+SELECT source_rows, source_rows_covered, source_coverage,
+       chunks_total, chunks_embedded, chunk_coverage,
+       queue_pending, queue_failed
+  FROM pgedge_vectorizer.vectorizer_status;
+ source_rows | source_rows_covered | source_coverage | chunks_total | chunks_embedded | chunk_coverage | queue_pending | queue_failed 
+-------------+---------------------+-----------------+--------------+-----------------+----------------+---------------+--------------
+           3 |                   2 |          0.6667 |            3 |               2 |         0.6667 |             1 |            0
+(1 row)
+
+SELECT last_processed_at IS NOT NULL AS has_processed_timestamp
+  FROM pgedge_vectorizer.vectorizer_status;
+ has_processed_timestamp 
+-------------------------
+ t
+(1 row)
+
+---------------------------------------------------------------------------
+-- A failed item is counted apart from the pending backlog
+---------------------------------------------------------------------------
+UPDATE pgedge_vectorizer.queue
+   SET status = 'failed', error_message = 'synthetic failure'
+ WHERE chunk_table = 'vstatus_docs_body_chunks'
+   AND status = 'pending';
+SELECT queue_pending, queue_processing, queue_failed,
+       oldest_pending_age IS NULL AS no_pending_age
+  FROM pgedge_vectorizer.vectorizer_status;
+ queue_pending | queue_processing | queue_failed | no_pending_age 
+---------------+------------------+--------------+----------------
+             0 |                0 |            1 | t
+(1 row)
+
+---------------------------------------------------------------------------
+-- Everything embedded: coverage reaches 1 on both measures
+---------------------------------------------------------------------------
+UPDATE vstatus_docs_body_chunks
+   SET embedding = array_fill(0.1::real, ARRAY[1536])::vector
+ WHERE embedding IS NULL;
+SELECT source_coverage, chunk_coverage
+  FROM pgedge_vectorizer.vectorizer_status;
+ source_coverage | chunk_coverage 
+-----------------+----------------
+          1.0000 |         1.0000
+(1 row)
+
+---------------------------------------------------------------------------
+-- Narrowing to one vectorizer
+---------------------------------------------------------------------------
+CREATE TABLE vstatus_other (
+    id   BIGSERIAL PRIMARY KEY,
+    body TEXT
+);
+INSERT INTO vstatus_other (body) VALUES ('An unrelated vectorized table.');
+SELECT pgedge_vectorizer.enable_vectorization(
+    'vstatus_other'::regclass,
+    'body',
+    'token_based',
+    100,
+    10,
+    1536
+);
+NOTICE:  Using primary key column: id (bigint)
+NOTICE:  column "sparse_embedding" of relation "vstatus_other_body_chunks" already exists, skipping
+NOTICE:  Vectorization enabled: vstatus_other -> vstatus_other_body_chunks
+NOTICE:  Strategy: token_based, chunk_size: 100, overlap: 10
+NOTICE:  Processing existing rows...
+NOTICE:  Processed 1 existing rows
+ enable_vectorization 
+----------------------
+ 
+(1 row)
+
+-- The view covers both.
+SELECT source_table, source_column FROM pgedge_vectorizer.vectorizer_status;
+ source_table  | source_column 
+---------------+---------------
+ vstatus_docs  | body
+ vstatus_other | body
+(2 rows)
+
+-- The function narrows to one source table, and to one column of it.
+SELECT source_table, chunks_total
+  FROM pgedge_vectorizer.vectorizer_status('vstatus_docs'::regclass);
+ source_table | chunks_total 
+--------------+--------------
+ vstatus_docs |            3
+(1 row)
+
+SELECT source_table, chunks_total
+  FROM pgedge_vectorizer.vectorizer_status('vstatus_docs'::regclass, 'body');
+ source_table | chunks_total 
+--------------+--------------
+ vstatus_docs |            3
+(1 row)
+
+-- A column that is not vectorized returns nothing rather than erroring.
+SELECT count(*) AS rows_for_unknown_column
+  FROM pgedge_vectorizer.vectorizer_status('vstatus_docs'::regclass, 'title');
+ rows_for_unknown_column 
+-------------------------
+                       0
+(1 row)
+
+---------------------------------------------------------------------------
+-- Coverage above 1 is left visible: it means the chunk table holds rows for
+-- source rows that have gone, which is worth seeing rather than clamping
+---------------------------------------------------------------------------
+ALTER TABLE vstatus_docs DISABLE TRIGGER USER;
+DELETE FROM vstatus_docs WHERE body = 'The third.';
+ALTER TABLE vstatus_docs ENABLE TRIGGER USER;
+SELECT source_rows, source_rows_covered, source_coverage > 1 AS over_covered
+  FROM pgedge_vectorizer.vectorizer_status('vstatus_docs'::regclass);
+ source_rows | source_rows_covered | over_covered 
+-------------+---------------------+--------------
+           2 |                   3 | t
+(1 row)
+
+---------------------------------------------------------------------------
+-- A chunk table dropped from under the registry leaves the counts NULL
+-- rather than failing the whole result set
+---------------------------------------------------------------------------
+DROP TABLE vstatus_docs_body_chunks;
+SELECT source_table,
+       chunks_total IS NULL     AS chunk_counts_null,
+       source_rows IS NOT NULL  AS source_count_still_reported,
+       queue_failed
+  FROM pgedge_vectorizer.vectorizer_status('vstatus_docs'::regclass);
+ source_table | chunk_counts_null | source_count_still_reported | queue_failed 
+--------------+-------------------+-----------------------------+--------------
+ vstatus_docs | t                 | t                           |            1
+(1 row)
+
+---------------------------------------------------------------------------
+-- Cleanup
+---------------------------------------------------------------------------
+SELECT pgedge_vectorizer.disable_vectorization('vstatus_docs'::regclass,
+                                               'body', TRUE);
+NOTICE:  table "vstatus_docs_body_chunks" does not exist, skipping
+NOTICE:  Vectorization disabled and chunk table dropped: vstatus_docs_body_chunks
+ disable_vectorization 
+-----------------------
+ 
+(1 row)
+
+SELECT pgedge_vectorizer.disable_vectorization('vstatus_other'::regclass,
+                                               'body', TRUE);
+NOTICE:  Vectorization disabled and chunk table dropped: vstatus_other_body_chunks
+ disable_vectorization 
+-----------------------
+ 
+(1 row)
+
+DROP TABLE vstatus_docs;
+DROP TABLE vstatus_other;
+DELETE FROM pgedge_vectorizer.queue;

--- a/test/expected/vectorizer_status.out
+++ b/test/expected/vectorizer_status.out
@@ -200,6 +200,49 @@ SELECT source_table,
 (1 row)
 
 ---------------------------------------------------------------------------
+-- A schema-qualified source table
+--
+-- The chunk table's name is generated as source_table || column || '_chunks'
+-- and created with %I, so here it is a single identifier with a dot in it,
+-- 'vstatus_schema.qualified_body_chunks', rather than a relation in a schema.
+-- Looking that up without quoting finds nothing, and the chunk counts come
+-- back NULL whilst the queue counts still work.
+---------------------------------------------------------------------------
+CREATE SCHEMA vstatus_schema;
+CREATE TABLE vstatus_schema.qualified (
+    id   BIGSERIAL PRIMARY KEY,
+    body TEXT
+);
+INSERT INTO vstatus_schema.qualified (body)
+VALUES ('A document in a table that is not on the search path.');
+SELECT pgedge_vectorizer.enable_vectorization(
+    'vstatus_schema.qualified'::regclass,
+    'body',
+    'token_based',
+    100,
+    10,
+    1536
+);
+NOTICE:  Using primary key column: id (bigint)
+NOTICE:  column "sparse_embedding" of relation "vstatus_schema.qualified_body_chunks" already exists, skipping
+NOTICE:  Vectorization enabled: vstatus_schema.qualified -> vstatus_schema.qualified_body_chunks
+NOTICE:  Strategy: token_based, chunk_size: 100, overlap: 10
+NOTICE:  Processing existing rows...
+NOTICE:  Processed 1 existing rows
+ enable_vectorization 
+----------------------
+ 
+(1 row)
+
+SELECT chunk_table, source_rows, chunks_total, queue_pending
+  FROM pgedge_vectorizer.vectorizer_status(
+           'vstatus_schema.qualified'::regclass);
+             chunk_table              | source_rows | chunks_total | queue_pending 
+--------------------------------------+-------------+--------------+---------------
+ vstatus_schema.qualified_body_chunks |           1 |            1 |             1
+(1 row)
+
+---------------------------------------------------------------------------
 -- Cleanup
 ---------------------------------------------------------------------------
 SELECT pgedge_vectorizer.disable_vectorization('vstatus_docs'::regclass,
@@ -219,6 +262,16 @@ NOTICE:  Vectorization disabled and chunk table dropped: vstatus_other_body_chun
  
 (1 row)
 
+SELECT pgedge_vectorizer.disable_vectorization(
+           'vstatus_schema.qualified'::regclass, 'body', TRUE);
+NOTICE:  Vectorization disabled and chunk table dropped: vstatus_schema.qualified_body_chunks
+ disable_vectorization 
+-----------------------
+ 
+(1 row)
+
 DROP TABLE vstatus_docs;
 DROP TABLE vstatus_other;
+DROP SCHEMA vstatus_schema CASCADE;
+NOTICE:  drop cascades to table vstatus_schema.qualified
 DELETE FROM pgedge_vectorizer.queue;

--- a/test/sql/count_tokens.sql
+++ b/test/sql/count_tokens.sql
@@ -1,0 +1,99 @@
+-- count_tokens test
+--
+-- count_tokens() exposes the estimate the C chunking code has always used, so
+-- that the plpgsql paths which write the token_count column can call it rather
+-- than open-coding the same rule and rounding it the other way. The point of
+-- the tests below is therefore as much the agreement between the two as the
+-- values themselves.
+
+---------------------------------------------------------------------------
+-- The estimate itself: UTF-8 characters divided by four, rounded up
+---------------------------------------------------------------------------
+
+-- 11 characters, so 3 tokens.
+SELECT pgedge_vectorizer.count_tokens('hello world') AS eleven_chars;
+
+-- Exactly 4 characters is exactly 1 token; anything shorter still rounds up
+-- to 1, which is the difference from the truncating arithmetic this replaces.
+SELECT pgedge_vectorizer.count_tokens('test') AS four_chars,
+       pgedge_vectorizer.count_tokens('abc')  AS three_chars,
+       pgedge_vectorizer.count_tokens('a')    AS one_char;
+
+-- Empty text is the one case that is genuinely zero.
+SELECT pgedge_vectorizer.count_tokens('') AS empty;
+
+-- STRICT, so NULL in, NULL out.
+SELECT pgedge_vectorizer.count_tokens(NULL) IS NULL AS null_is_null;
+
+-- Characters, not bytes: four Han characters are twelve bytes but one token.
+SELECT pgedge_vectorizer.count_tokens('你好世界') AS four_han_chars,
+       octet_length('你好世界') AS bytes;
+
+-- Declared STABLE rather than IMMUTABLE: the estimate is defined in terms of
+-- pgedge_vectorizer.model, which will matter once the counter is model-aware,
+-- and an index or cached plan built on an IMMUTABLE promise would then be
+-- wrong. Pin the volatility so that cannot be relaxed by accident.
+SELECT provolatile
+  FROM pg_proc
+ WHERE proname = 'count_tokens'
+   AND pronamespace = 'pgedge_vectorizer'::regnamespace;
+
+---------------------------------------------------------------------------
+-- Agreement with what the chunking paths store
+---------------------------------------------------------------------------
+
+CREATE TABLE count_tokens_docs (
+    id      BIGSERIAL PRIMARY KEY,
+    content TEXT
+);
+
+-- Chunks written by enable_vectorization() back-filling an existing table.
+INSERT INTO count_tokens_docs (content)
+VALUES ('abc'),
+       ('Short document.'),
+       (repeat('The quick brown fox jumps over the lazy dog. ', 20));
+
+SELECT pgedge_vectorizer.enable_vectorization(
+    'count_tokens_docs'::regclass,
+    'content',
+    'token_based',
+    100,
+    10,
+    1536
+);
+
+SELECT count(*) AS mismatched_on_backfill
+  FROM count_tokens_docs_content_chunks
+ WHERE token_count IS DISTINCT FROM pgedge_vectorizer.count_tokens(content);
+
+-- The three-character row is the regression: length('abc') / 4 stored 0, which
+-- the BM25 scoring path then had to clamp back up to 1.
+SELECT token_count AS short_row_token_count
+  FROM count_tokens_docs_content_chunks c
+  JOIN count_tokens_docs d ON d.id = c.source_id
+ WHERE d.content = 'abc';
+
+-- Chunks written by the insert trigger.
+INSERT INTO count_tokens_docs (content)
+VALUES ('xy'),
+       ('A document added after vectorization was enabled.');
+
+SELECT count(*) AS mismatched_on_insert
+  FROM count_tokens_docs_content_chunks
+ WHERE token_count IS DISTINCT FROM pgedge_vectorizer.count_tokens(content);
+
+-- Chunks written by recreate_chunks().
+SELECT pgedge_vectorizer.recreate_chunks('count_tokens_docs'::regclass, 'content');
+
+SELECT count(*) AS mismatched_on_recreate
+  FROM count_tokens_docs_content_chunks
+ WHERE token_count IS DISTINCT FROM pgedge_vectorizer.count_tokens(content);
+
+---------------------------------------------------------------------------
+-- Cleanup
+---------------------------------------------------------------------------
+
+SELECT pgedge_vectorizer.disable_vectorization('count_tokens_docs'::regclass,
+                                               'content', TRUE);
+DROP TABLE count_tokens_docs;
+DELETE FROM pgedge_vectorizer.queue;

--- a/test/sql/vectorizer_status.sql
+++ b/test/sql/vectorizer_status.sql
@@ -1,0 +1,161 @@
+-- vectorizer_status test
+--
+-- The view reports how far the embeddings are behind the source. Nothing in a
+-- regression run generates a real embedding, since that needs a provider, so
+-- the chunk rows are marked embedded by hand below to walk coverage from none
+-- through partial to complete. Timestamps and ages are deliberately not
+-- selected: they are wall-clock values and would differ on every run.
+
+CREATE TABLE vstatus_docs (
+    id      BIGSERIAL PRIMARY KEY,
+    body    TEXT
+);
+
+INSERT INTO vstatus_docs (body)
+VALUES ('The first document, which is long enough to be worth embedding.'),
+       ('The second document, on an unrelated subject entirely.'),
+       ('The third.');
+
+SELECT pgedge_vectorizer.enable_vectorization(
+    'vstatus_docs'::regclass,
+    'body',
+    'token_based',
+    100,
+    10,
+    1536
+);
+
+---------------------------------------------------------------------------
+-- Nothing embedded yet: the whole chunk table is outstanding, and every
+-- chunk is sitting in the queue
+---------------------------------------------------------------------------
+
+SELECT source_table, source_column, chunk_table,
+       source_rows, source_rows_covered, source_coverage,
+       chunks_total, chunks_embedded, chunk_coverage,
+       queue_pending, queue_processing, queue_failed
+  FROM pgedge_vectorizer.vectorizer_status;
+
+-- An age is reported for the oldest pending item, and there is no processed
+-- timestamp yet. The values themselves are wall-clock, so only their
+-- presence is asserted.
+SELECT oldest_pending_age IS NOT NULL AS has_pending_age,
+       last_processed_at IS NULL      AS nothing_processed_yet
+  FROM pgedge_vectorizer.vectorizer_status;
+
+---------------------------------------------------------------------------
+-- Two chunks embedded: partial coverage, and the queue drains to match
+---------------------------------------------------------------------------
+
+UPDATE vstatus_docs_body_chunks
+   SET embedding = array_fill(0.1::real, ARRAY[1536])::vector
+ WHERE source_id IN (SELECT id FROM vstatus_docs ORDER BY id LIMIT 2);
+
+UPDATE pgedge_vectorizer.queue
+   SET status = 'completed', processed_at = NOW()
+ WHERE chunk_table = 'vstatus_docs_body_chunks'
+   AND chunk_id IN (SELECT id FROM vstatus_docs_body_chunks
+                     WHERE embedding IS NOT NULL);
+
+SELECT source_rows, source_rows_covered, source_coverage,
+       chunks_total, chunks_embedded, chunk_coverage,
+       queue_pending, queue_failed
+  FROM pgedge_vectorizer.vectorizer_status;
+
+SELECT last_processed_at IS NOT NULL AS has_processed_timestamp
+  FROM pgedge_vectorizer.vectorizer_status;
+
+---------------------------------------------------------------------------
+-- A failed item is counted apart from the pending backlog
+---------------------------------------------------------------------------
+
+UPDATE pgedge_vectorizer.queue
+   SET status = 'failed', error_message = 'synthetic failure'
+ WHERE chunk_table = 'vstatus_docs_body_chunks'
+   AND status = 'pending';
+
+SELECT queue_pending, queue_processing, queue_failed,
+       oldest_pending_age IS NULL AS no_pending_age
+  FROM pgedge_vectorizer.vectorizer_status;
+
+---------------------------------------------------------------------------
+-- Everything embedded: coverage reaches 1 on both measures
+---------------------------------------------------------------------------
+
+UPDATE vstatus_docs_body_chunks
+   SET embedding = array_fill(0.1::real, ARRAY[1536])::vector
+ WHERE embedding IS NULL;
+
+SELECT source_coverage, chunk_coverage
+  FROM pgedge_vectorizer.vectorizer_status;
+
+---------------------------------------------------------------------------
+-- Narrowing to one vectorizer
+---------------------------------------------------------------------------
+
+CREATE TABLE vstatus_other (
+    id   BIGSERIAL PRIMARY KEY,
+    body TEXT
+);
+
+INSERT INTO vstatus_other (body) VALUES ('An unrelated vectorized table.');
+
+SELECT pgedge_vectorizer.enable_vectorization(
+    'vstatus_other'::regclass,
+    'body',
+    'token_based',
+    100,
+    10,
+    1536
+);
+
+-- The view covers both.
+SELECT source_table, source_column FROM pgedge_vectorizer.vectorizer_status;
+
+-- The function narrows to one source table, and to one column of it.
+SELECT source_table, chunks_total
+  FROM pgedge_vectorizer.vectorizer_status('vstatus_docs'::regclass);
+
+SELECT source_table, chunks_total
+  FROM pgedge_vectorizer.vectorizer_status('vstatus_docs'::regclass, 'body');
+
+-- A column that is not vectorized returns nothing rather than erroring.
+SELECT count(*) AS rows_for_unknown_column
+  FROM pgedge_vectorizer.vectorizer_status('vstatus_docs'::regclass, 'title');
+
+---------------------------------------------------------------------------
+-- Coverage above 1 is left visible: it means the chunk table holds rows for
+-- source rows that have gone, which is worth seeing rather than clamping
+---------------------------------------------------------------------------
+
+ALTER TABLE vstatus_docs DISABLE TRIGGER USER;
+DELETE FROM vstatus_docs WHERE body = 'The third.';
+ALTER TABLE vstatus_docs ENABLE TRIGGER USER;
+
+SELECT source_rows, source_rows_covered, source_coverage > 1 AS over_covered
+  FROM pgedge_vectorizer.vectorizer_status('vstatus_docs'::regclass);
+
+---------------------------------------------------------------------------
+-- A chunk table dropped from under the registry leaves the counts NULL
+-- rather than failing the whole result set
+---------------------------------------------------------------------------
+
+DROP TABLE vstatus_docs_body_chunks;
+
+SELECT source_table,
+       chunks_total IS NULL     AS chunk_counts_null,
+       source_rows IS NOT NULL  AS source_count_still_reported,
+       queue_failed
+  FROM pgedge_vectorizer.vectorizer_status('vstatus_docs'::regclass);
+
+---------------------------------------------------------------------------
+-- Cleanup
+---------------------------------------------------------------------------
+
+SELECT pgedge_vectorizer.disable_vectorization('vstatus_docs'::regclass,
+                                               'body', TRUE);
+SELECT pgedge_vectorizer.disable_vectorization('vstatus_other'::regclass,
+                                               'body', TRUE);
+DROP TABLE vstatus_docs;
+DROP TABLE vstatus_other;
+DELETE FROM pgedge_vectorizer.queue;

--- a/test/sql/vectorizer_status.sql
+++ b/test/sql/vectorizer_status.sql
@@ -149,6 +149,39 @@ SELECT source_table,
   FROM pgedge_vectorizer.vectorizer_status('vstatus_docs'::regclass);
 
 ---------------------------------------------------------------------------
+-- A schema-qualified source table
+--
+-- The chunk table's name is generated as source_table || column || '_chunks'
+-- and created with %I, so here it is a single identifier with a dot in it,
+-- 'vstatus_schema.qualified_body_chunks', rather than a relation in a schema.
+-- Looking that up without quoting finds nothing, and the chunk counts come
+-- back NULL whilst the queue counts still work.
+---------------------------------------------------------------------------
+
+CREATE SCHEMA vstatus_schema;
+
+CREATE TABLE vstatus_schema.qualified (
+    id   BIGSERIAL PRIMARY KEY,
+    body TEXT
+);
+
+INSERT INTO vstatus_schema.qualified (body)
+VALUES ('A document in a table that is not on the search path.');
+
+SELECT pgedge_vectorizer.enable_vectorization(
+    'vstatus_schema.qualified'::regclass,
+    'body',
+    'token_based',
+    100,
+    10,
+    1536
+);
+
+SELECT chunk_table, source_rows, chunks_total, queue_pending
+  FROM pgedge_vectorizer.vectorizer_status(
+           'vstatus_schema.qualified'::regclass);
+
+---------------------------------------------------------------------------
 -- Cleanup
 ---------------------------------------------------------------------------
 
@@ -156,6 +189,9 @@ SELECT pgedge_vectorizer.disable_vectorization('vstatus_docs'::regclass,
                                                'body', TRUE);
 SELECT pgedge_vectorizer.disable_vectorization('vstatus_other'::regclass,
                                                'body', TRUE);
+SELECT pgedge_vectorizer.disable_vectorization(
+           'vstatus_schema.qualified'::regclass, 'body', TRUE);
 DROP TABLE vstatus_docs;
 DROP TABLE vstatus_other;
+DROP SCHEMA vstatus_schema CASCADE;
 DELETE FROM pgedge_vectorizer.queue;


### PR DESCRIPTION
## Summary

Embeddings are generated asynchronously, so a search always runs against a picture of the source that is some way out of date, and there was no way to find out how far. `pgedge_vectorizer.vectorizer_status` reports, per registered vectorizer, how much of the source is embedded and how much work is still queued.

- Coverage is reported two ways, because they answer different questions. `source_coverage` (source rows with at least one embedded chunk) is the closer match to whether a search over the table can be trusted; `chunk_coverage` (individual chunks embedded) is the better measure of how much work remains. A large document part-way through embedding is covered on the first and only partly on the second.
- Alongside those: `queue_pending`, `queue_processing`, `queue_failed`, `oldest_pending_age` and `last_processed_at` for the vectorizer.
- Chunk tables are named in the registry rather than joined statically, so the counts come from dynamic SQL in a function that the view wraps. The function takes an optional source table and column, so one vectorizer can be inspected without paying for all of them.

Two choices worth calling out. The function runs as the caller and reports NULL counts for a chunk or source table that has been dropped or that the caller cannot read, rather than failing the whole result set. And a `source_coverage` above 1 is left visible rather than clamped, because it means the chunk table holds rows for source rows that have gone, which is a real problem worth seeing.

Each row costs a scan of one chunk table and a count of one source table, which is considerably more than the existing queue views cost. `docs/monitoring.md` says so plainly and frames it as a diagnostic to run deliberately rather than something to poll.

## Test plan

- [x] New `vectorizer_status` regression test walks coverage from none through partial to complete, checks failed items are counted apart from the pending backlog, checks narrowing by table and by column, and checks the two degraded cases (coverage above 1 after orphaning, NULL counts after the chunk table is dropped).
- [x] Full suite green against PostgreSQL 18.4: 22 pg_regress tests and 69 TAP tests.
- [x] Upgrade path exercised by hand: `CREATE EXTENSION ... VERSION '1.1'`, enable a vectorizer, `ALTER EXTENSION ... UPDATE TO '1.2'`, then query the view against a chunk table created under 1.1.

## Note on the base branch

This is stacked on #72, which creates the 1.2 scripts this change also lands in, so the branch is cut from `token-count-consistency` and the diff below carries that commit too. It targets `main` rather than the stack parent only because CI is configured to run on `main`, `master` and `develop` alone, so a PR aimed at the parent gets no checks at all. Once #72 merges, the diff here reduces to just this feature. Review the second commit; the first is #72.

Closes #25
